### PR TITLE
Change issue tracker URL from twbs/bootstrap to primer/primer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Before you do, would you mind reading [this license agreement](CLA.md)? If you o
 
 ## Using the issue tracker
 
-The [issue tracker](https://github.com/twbs/bootstrap/issues) is the preferred channel for [bug reports](#bug-reports), [features requests](#feature-requests) and [submitting pull requests](#pull-requests), but please respect the following restrictions:
+The [issue tracker](https://github.com/primer/primer/issues) is the preferred channel for [bug reports](#bug-reports), [features requests](#feature-requests) and [submitting pull requests](#pull-requests), but please respect the following restrictions:
 
 * Please **do not** use the issue tracker for personal support requests.
 * Please **do not** derail or troll issues. Keep the discussion on topic and respect the opinions of others.


### PR DESCRIPTION
The `CONTRIBUTING.md` file still had a reference to Bootstrap's issue tracker instead of Primer's.