### PR TITLE
Add Rouge as a gem dependency in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ Primer's documentation is built with Jekyll and published to `http://primercss.i
 
 You'll need the following installed:
 
-- Latest Jekyll (minimum v2.2.0): `$ gem install jekyll`
+- Latest Jekyll (minimum v2.2.0), Rouge and Sass: `$ gem install jekyll`
+- Latest Rouge: `$ gem install rouge`
 - Latest Sass: `$ gem install sass`
 - Latest Grunt CLI: `$ npm install -g grunt-cli`
 - [Node.js and npm](http://nodejs.org/download/)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Primer's documentation is built with Jekyll and published to `http://primercss.i
 
 You'll need the following installed:
 
-- Latest Jekyll (minimum v2.2.0), Rouge and Sass: `$ gem install jekyll`
+- Latest Jekyll (minimum v2.2.0): `$ gem install jekyll`
 - Latest Rouge: `$ gem install rouge`
 - Latest Sass: `$ gem install sass`
 - Latest Grunt CLI: `$ npm install -g grunt-cli`


### PR DESCRIPTION
If the Rouge gem is not installed, Jekyll will throw an error when the
`jekyll serve` command is run. (`Liquid Exception: cannot load such
file -- rouge in alerts.md`)