### PR TITLE
Fix code style issues in SCSS source files

### DIFF
--- a/scss/_alerts.scss
+++ b/scss/_alerts.scss
@@ -61,7 +61,9 @@
   padding: 15px;
   border-radius: 3px;
 
-  + .flash { margin-top: 5px; }
+  + .flash {
+    margin-top: 5px;
+  }
 }
 
 // Add an icon

--- a/scss/_avatars.scss
+++ b/scss/_avatars.scss
@@ -6,7 +6,9 @@
   border-radius: 3px;
 }
 
-.avatar-small { border-radius: 2px; }
+.avatar-small {
+  border-radius: 2px;
+}
 
 .avatar-link {
   float: left;

--- a/scss/_blankslate.scss
+++ b/scss/_blankslate.scss
@@ -63,13 +63,21 @@
     border-radius: 3px;
   }
 
-  > .mega-octicon { color: #aaa; }
+  > .mega-octicon {
+    color: #aaa;
+  }
 
-  .mega-octicon + .mega-octicon { margin-left: 10px; }
+  .mega-octicon + .mega-octicon {
+    margin-left: 10px;
+  }
 
-  .tabnav + & { margin-top: 20px; }
+  .tabnav + & {
+    margin-top: 20px;
+  }
 
-  .context-loader.large-format-loader { padding-top: 50px; }
+  .context-loader.large-format-loader {
+    padding-top: 50px;
+  }
 }
 
 // Forking blank slate

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -69,7 +69,7 @@
 // Green primary button
 .btn-primary {
   color: #fff;
-  text-shadow: 0 -1px 0 rgba(0,0,0,0.15);
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.15);
   @include gradient(#8add6d, #60b044);
   border-color: darken(#60b044, 2%);
 
@@ -81,7 +81,7 @@
 
   &:active,
   &.selected {
-    text-shadow: 0 1px 0 rgba(0,0,0,0.15);
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
     background-color: darken(#60b044, 5%);
     background-image: none;
     border-color: darken(#4a993e, 5%);

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -47,7 +47,9 @@ input.input-contrast,
 .input-contrast {
   background-color: #fafafa;
 
-  &:focus { background-color: #fff; }
+  &:focus {
+    background-color: #fff;
+  }
 }
 
 // Custom styling for HTML5 validation bubbles (WebKit only)
@@ -155,11 +157,17 @@ dl.form {
     }
 
     input {
-      &.shorter { width: 130px; }
+      &.shorter {
+        width: 130px;
+      }
 
-      &.short { width: 250px; }
+      &.short {
+        width: 250px;
+      }
 
-      &.long { width: 100%; }
+      &.long {
+        width: 100%;
+      }
     }
 
     // Textarea
@@ -177,9 +185,13 @@ dl.form {
     h4 {
       margin: 4px 0 0;
 
-      &.is-error { color: $brand-red; }
+      &.is-error {
+        color: $brand-red;
+      }
 
-      &.is-success { color: $brand-green; }
+      &.is-success {
+        color: $brand-green;
+      }
     }
 
     h4 + p.note {
@@ -375,7 +387,9 @@ dl.form {
     margin: 28px 25px 0 -20px;
   }
 
-  select { margin-top: 5px; }
+  select {
+    margin-top: 5px;
+  }
 }
 
 // IE 9
@@ -513,9 +527,13 @@ html.no-dnd-uploads {
     border: 1px solid #cacaca;
   }
 
-  .comment-header .comment-header-actions { display: none; }
+  .comment-header .comment-header-actions {
+    display: none;
+  }
 
-  .comment-form-error { margin-bottom: 10px; }
+  .comment-form-error {
+    margin-bottom: 10px;
+  }
 
   .write-content,
   .preview-content {
@@ -566,7 +584,9 @@ div.composer {
   border-bottom: 1px solid #eee;
 }
 
-.composer .tabnav { margin: 0 0 10px; }
+.composer .tabnav {
+  margin: 0 0 10px;
+}
 
 .infobar-widget {
 
@@ -574,7 +594,9 @@ div.composer {
     position: relative; // requires so that the `right: 0;` below works
     float: right;
 
-    .select-menu-modal-holder { right: 0; }
+    .select-menu-modal-holder {
+      right: 0;
+    }
   }
 
   &.assignee {
@@ -731,9 +753,13 @@ p.explain {
     line-height: 1.5;
   }
 
-  strong { color: #000; }
+  strong {
+    color: #000;
+  }
 
-  a { font-weight: bold; }
+  a {
+    font-weight: bold;
+  }
 }
 
 

--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -22,7 +22,9 @@
     border-top-right-radius: 2px;
     border-top-left-radius: 2px;
 
-    &:before { border-top-left-radius: 2px; }
+    &:before {
+      border-top-left-radius: 2px;
+    }
   }
 
   &:last-child {
@@ -30,7 +32,9 @@
     border-bottom-right-radius: 2px;
     border-bottom-left-radius: 2px;
 
-    &:before { border-bottom-left-radius: 2px; }
+    &:before {
+      border-bottom-left-radius: 2px;
+    }
   }
 
   &:hover {
@@ -60,7 +64,7 @@
     width: 16px;
     color: $brand-gray-dark;
     text-align: center;
- }
+  }
 
   .counter {
     float: right;

--- a/scss/_states.scss
+++ b/scss/_states.scss
@@ -25,8 +25,14 @@
   background-color: $status-open;
 }
 
-.state-merged { background-color: $status-merged; }
+.state-merged {
+  background-color: $status-merged;
+}
 
-.state-closed { background-color: $status-closed; }
+.state-closed {
+  background-color: $status-closed;
+}
 
-.state-renamed { background-color: $status-renamed; }
+.state-renamed {
+  background-color: $status-renamed;
+}

--- a/scss/_tabnav.scss
+++ b/scss/_tabnav.scss
@@ -30,7 +30,9 @@
     border-radius: 3px 3px 0 0;
   }
 
-  &:hover { text-decoration: none; }
+  &:hover {
+    text-decoration: none;
+  }
 }
 
 // Tabnav extras

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -12,13 +12,29 @@ h6 {
   line-height: 1.1;
 }
 
-h1 { font-size: 30px; }
-h2 { font-size: 21px; }
-h3 { font-size: 16px; }
-h4 { font-size: 14px; }
-h5 { font-size: 12px; }
-h6 { font-size: 11px; }
+h1 {
+  font-size: 30px;
+}
 
+h2 {
+  font-size: 21px;
+}
+
+h3 {
+  font-size: 16px;
+}
+
+h4 {
+  font-size: 14px;
+}
+
+h5 {
+  font-size: 12px;
+}
+
+h6 {
+  font-size: 11px;
+}
 
 // Body text
 // --------------------------------------------------
@@ -40,8 +56,13 @@ blockquote {
 }
 
 // Text utilities
-.text-muted { color: #999; }
-.text-danger { color: $brand-red; }
+.text-muted {
+  color: #999;
+}
+
+.text-danger {
+  color: $brand-red;
+}
 
 .text-emphasized {
   font-weight: bold;

--- a/scss/_utility.scss
+++ b/scss/_utility.scss
@@ -4,42 +4,69 @@
 }
 
 // Floats
-.right { float: right; }
+.right {
+  float: right;
+}
 
-.left { float: left; }
-
+.left {
+  float: left;
+}
 
 // Text alignment
-.text-right { text-align: right; }
+.text-right {
+  text-align: right;
+}
 
-.text-left { text-align: left; }
-
+.text-left {
+  text-align: left;
+}
 
 // Text states
-.danger { color: #c00; }
+.danger {
+  color: #c00;
+}
 
-.mute { color: #000; }
+.mute {
+  color: #000;
+}
 
-.text-diff-added { color: darken($brand-green, 10%); }
+.text-diff-added {
+  color: darken($brand-green, 10%);
+}
 
-.text-diff-deleted { color: $brand-red; }
+.text-diff-deleted {
+  color: $brand-red;
+}
 
 .text-open,
-.text-success { color: $status-open; }
+.text-success {
+  color: $status-open;
+}
 
-.text-closed { color: $status-closed; }
+.text-closed {
+  color: $status-closed;
+}
 
-.text-reverted { color: $status-reverted; }
+.text-reverted {
+  color: $status-reverted;
+}
 
-.text-merged { color: $status-merged; }
+.text-merged {
+  color: $status-merged;
+}
 
-.text-renamed { color: $status-renamed; }
+.text-renamed {
+  color: $status-renamed;
+}
 
-.text-pending { color: $status-pending; }
+.text-pending {
+  color: $status-pending;
+}
 
 .text-error,
-.text-failure { color: $brand-red; }
-
+.text-failure {
+  color: $brand-red;
+}
 
 // Muted link
 //


### PR DESCRIPTION
Respects code style as noted on http://primercss.io/guidelines/#css. The bulk of this commit includes moving single property declarations to a new line instead of having them on the same line as the opening and closing brace.

One additional change is to fix a faulty indentation in `scss/_menu.scss`.