### PR TITLE
Add note on SCSS' overloaded rgba() function

### DIFF
--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -108,7 +108,7 @@ Make use of `<thead>`, `<tfoot>`, `<tbody>`, and `<th>` tags (and `scope` attrib
 
 ### Formatting
 
-* Use hex color codes `#000` unless using `rgba()`.
+* Use hex color codes `#000` unless using `rgba()` in raw CSS (SCSS' `rgba()` function is overloaded to accept hex colors as a param, e.g., `rgba(#000, .5)`).
 * Use `//` for comment blocks (instead of `/* */`).
 * Avoid specifying units for zero values, e.g., `margin: 0;` instead of `margin: 0px;`.
 * Strive to limit use of shorthand declarations to instances where you must explicitly set all the available values.


### PR DESCRIPTION
Sass + SCSS overrides and overloads the [rgba() function](http://sass-lang.com/documentation/Sass/Script/Functions.html#rgba-instance_method) so it can also take parameters in the format `rgba($color, $alpha)`, e.g. `rgba(#000, .5)`.

It'd be pragmatic to leverage that overload and use hex colors that much more consistently in SCSS. If GitHub folks aren't writing much raw CSS this line can be trimmed further, ```* Use hex color codes `#000` (SCSS' `rgba()` function is overloaded to accept hex colors as a param, e.g., `rgba(#000, .5)`).``` (since Sass' overriding of `rgba()` isn't obvious perhaps good to spell it out explicitly here).