### PR TITLE
Remove padding override

### DIFF
--- a/docs/docs.scss
+++ b/docs/docs.scss
@@ -276,7 +276,6 @@ body {
 
   // Override markdown styles
   ul {
-    padding: 0;
     margin-top: 0;
     margin-bottom: 0;
   }


### PR DESCRIPTION
This addresses #4 and removes the padding override while maintaining the margin resets.