### PR TITLE
Add missing .editorconfig file with Primer's code style settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
This fixes an issue highlighted by https://github.com/primer/primer/issues/42: there's a link in the README to the `.editorconfig` file, but that file doesn't exist in this project yet. The broken links are fixed in PR https://github.com/primer/primer/pull/25. Obviously, if you don't want to implement editorconfig, feel free to ignore this PR but then the link will have to be changed in the README too.