### PR TITLE
Fix  `.social-count` underline

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -251,7 +251,7 @@
   border-bottom-right-radius: 3px;
 
   &:hover,
-  &:active{
+  &:active {
     text-decoration: none;
   }
 

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -250,9 +250,13 @@
   border-top-right-radius: 3px;
   border-bottom-right-radius: 3px;
 
+  &:hover,
+  &:active{
+    text-decoration: none;
+  }
+
   &:hover {
     color: $brand-blue;
-    text-decoration: none;
     cursor: pointer;
   }
 }


### PR DESCRIPTION
 `.social-count` elements get an underline when pressing down (`:active`), then dragging out. I didn't see this behaviour in any of the other buttons or text-buttons, but feel free to close this PR if this was a design-choice, rather than something that was overlooked.

Also, I did not know how to "add tests", but maybe that isn't needed for such a small change.