### PR TITLE
Docs and source comments on broken ul/ol elements

### DIFF
--- a/docs/docs.scss
+++ b/docs/docs.scss
@@ -281,7 +281,7 @@ body {
     border: 1px solid lighten($brand-green, 30%);
   }
 
-  // Override markdown styles
+  // Override Markdown styles to restore values from `_type.scss`
   ul {
     padding: 0;
     margin-top: 0;

--- a/docs/type.md
+++ b/docs/type.md
@@ -68,7 +68,7 @@ Wrap `<blockquote>` around any <abbr title="HyperText Markup Language">HTML</abb
 
 ### Unordered
 
-A list of items in which the order does *not* explicitly matter.
+A list of items in which the order does *not* explicitly matter. **The broken display is intended** as Primer resets `<ul>`s and `<ol>`s for the time being. This will eventually be undone in the next major version.
 
 {% example html %}
 <ul>


### PR DESCRIPTION
Address #4.

There's no fix for the current version of Primer—these broken styles are indeed intended. Not elegant nor nice to look at, but it's how things are for the time being. We'll clean that up in v3 when versioning allows us to address it.