### PR TITLE
Gruntfile updates

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,6 +26,9 @@ module.exports = function(grunt) {
       dist: {
         src: 'css/*.css'
       },
+      docs: {
+        src: '_site/*.css'
+      }
     },
 
     // Runs CSS reporting
@@ -60,7 +63,7 @@ module.exports = function(grunt) {
 
     watch: {
       sass: {
-        files: 'scss/**/*.scss',
+        files: ['scss/**/*.scss', 'docs/docs.scss'],
         tasks: ['sass', 'autoprefixer', 'parker']
       }
     },
@@ -98,7 +101,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-sass');
 
   // Generate and format the CSS
-  grunt.registerTask('default', ['sass', 'autoprefixer', 'parker']);
+  grunt.registerTask('default', ['sass', 'jekyll', 'autoprefixer', 'parker']);
 
   // Publish to GitHub
   grunt.registerTask('publish', ['jekyll', 'buildcontrol:pages']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -104,5 +104,5 @@ module.exports = function(grunt) {
   grunt.registerTask('default', ['sass', 'jekyll', 'autoprefixer', 'parker']);
 
   // Publish to GitHub
-  grunt.registerTask('publish', ['jekyll', 'buildcontrol:pages']);
+  grunt.registerTask('publish', ['jekyll', 'autoprefixer:docs', 'buildcontrol:pages']);
 };


### PR DESCRIPTION
Fixes #23 by:

- Updating the Gruntfile to run Autoprefixer on our compiled `_site` directory. Normally this does nothing, but since we publish our Jekyll-based site with the build control plugin, this is a-okay.
- Updates the default and publish tasks to provide this functionality during normal dev and publishing.