### PR TITLE
Nuke the margins and floats on the right arrow in buttons

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -176,23 +176,6 @@
 }
 
 
-// Octicon buttons
-//
-// Improve alignment of Octicons within buttons and minibuttons. Also auto tweak
-// the right arrow to float right for ease of use.
-.btn {
-  > .octicon-arrow-right {
-    float: right;
-    margin-left: 5px;
-  }
-}
-
-// Required because we nuke the padding on minibuttons
-.btn-sm > .octicon-arrow-right {
-  margin-top: 4px;
-}
-
-
 // Minibutton overrides
 //
 // Tweak `line-height` to make them smaller.


### PR DESCRIPTION
Fixes a bug we've been seeing on GitHub in Chrome and Firefox. All this is unnecessary—the icon looks as expected without it.