### PR TITLE
Button Edge States

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -32,10 +32,11 @@
     border-color: #51a7e8;
     outline: none;
     box-shadow: 0 0 5px rgba(81, 167, 232, 0.5);
+  }
 
-    &:hover {
-      border-color: #51a7e8;
-    }
+  &:focus:hover,
+  &.selected:focus {
+    border-color: #51a7e8;
   }
 
   &:hover,

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -50,12 +50,15 @@
 
   &:active,
   &.selected,
-  &.selected:hover,
   &.zeroclipboard-is-active {
     background-color: #dcdcdc;
     background-image: none;
     border-color: #b5b5b5;
     box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15);
+  }
+
+  &.selected:hover {
+    background-color: darken(#dcdcdc, 5%);
   }
 
   &:disabled,

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -316,10 +316,13 @@
 
     // Bring any button into forefront for proper borders given negative margin below
     &:hover,
-    &:focus,
     &:active,
     &.selected {
       z-index: 2;
+    }
+
+    &:focus {
+      z-index: 3;
     }
   }
 

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -98,6 +98,10 @@
     border-color: darken(#4a993e, 5%);
   }
 
+  &.selected:hover {
+    background-color: darken(#60b044, 10%);
+  }
+
   &:disabled,
   &.disabled {
     &,
@@ -129,6 +133,10 @@
     border-color: darken(#cd504a, 15%);
   }
 
+  &.selected:hover {
+    background-color: darken(#b33630, 5%);
+  }
+
   &:disabled,
   &.disabled {
     &,
@@ -154,13 +162,16 @@
   &:hover,
   &:active,
   &.selected,
-  &.selected:hover,
   &.zeroclipboard-is-hover,
   &.zeroclipboard-is-active {
     color: #fff;
     background-color: $brand-blue;
     background-image: none;
     border-color: $brand-blue;
+  }
+
+  &.selected:hover {
+    background-color: darken($brand-blue, 5%);
   }
 
   &:disabled,

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -32,6 +32,10 @@
     border-color: #51a7e8;
     outline: none;
     box-shadow: 0 0 5px rgba(81, 167, 232, 0.5);
+
+    &:hover {
+      border-color: #51a7e8;
+    }
   }
 
   &:hover,


### PR DESCRIPTION
This is a new pull request split from #84, now without the brand-color exploration commits.

A number of button changes here, mostly focused on little edge-case polish.

### Changes

Left: Old
Right: New

1. Focused states are important. I think we should maintain the focused border regardless of hover states.
![focus](https://cloud.githubusercontent.com/assets/1369864/6906073/0609ab68-d6f2-11e4-9a83-8ca8fad9f441.png)

2. Selected buttons should still have a hover state since you can still interact with them.
![selected-hover](https://cloud.githubusercontent.com/assets/1369864/6906000/7410124c-d6f1-11e4-9c38-a470adcc8cdb.png)

3. Focused buttons within the button groups are now the highest in the z-order as opposed to being overlapped by the button to the right.
![focus-z](https://cloud.githubusercontent.com/assets/1369864/6925202/86b7b8e8-d7a3-11e4-93e1-0532a6ca1077.png)

### Issues

These issues are beyond the scope of Primer, but they should be noted.

1. By showing the focused state, we're exposing some inconsistent button implementation throughout github.com. Some buttons receive focus when pressed, others not.
2. By having a hover state on .selected buttons, the dropdown select menus don't receive a hover event because mouse events are inhibited by a blocking overlay div.