### PR TITLE
Call this section SCSS guidelines

### DIFF
--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -94,7 +94,7 @@ Make use of `<thead>`, `<tfoot>`, `<tbody>`, and `<th>` tags (and `scope` attrib
 
 
 
-## CSS
+## SCSS
 
 ### Spacing
 


### PR DESCRIPTION
fixes https://github.com/primer/primer/issues/88

We're actually writing the guidelines with `scss` files in mind. I think we should call this section **SCSS** to avoid misleading information or incorrect information.

@mdo 