### PR TITLE
.btn and .button_to spacing in .btn-group

### DIFF
--- a/docs/buttons.md
+++ b/docs/buttons.md
@@ -154,6 +154,20 @@ Have a hankering for a series of buttons that are attached to one another? Wrap 
 </div>
 {% endexample %}
 
+Add `.button_to` to `<form>`s within `.btn-group`s for proper spacing and rounded corners.
+
+**Heads up!** This class name is inconsistent and will change in the next major version.
+
+{% example html %}
+<div class="btn-group">
+  <form class="button_to">
+    <button class="btn" type="button">Button in a form</button>
+  </form>
+  <button class="btn" type="button">Button</button>
+  <button class="btn" type="button">Button</button>
+</div>
+{% endexample %}
+
 ## Hidden text button
 
 Use `.hidden-text-expander` to indicate and toggle hidden text.

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -343,6 +343,8 @@
     }
   }
 
+  .btn + .button_to,
+  .button_to + .btn,
   .button_to + .button_to {
     margin-left: -1px;
   }


### PR DESCRIPTION
Accounts for a potential pattern where a button group can contain a button and form as immediate children, and thus needs some spacing help.