### PR TITLE
Configure Hound to use in-repo SCSS lint config

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,6 +1,6 @@
 scss:
-  enabled: false
-  config_file: scss/.scss-style.yml
+  enabled: true
+  config_file: scss/.scss-lint.yml
 
 ruby:
   enabled: false


### PR DESCRIPTION
* The `enabled` flag is now turned on.
* The file name is `scss/.scss-lint.yml`.

https://twitter.com/mdo/status/581544087146254338