### PR TITLE
Button group focus

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -353,16 +353,6 @@
   // Tuck buttons into one another to prevent double border
   .btn + .btn {
     margin-left: -1px;
-    box-shadow: inset 1px 0 0 rgba(255, 255, 255, 0.2);
-
-    &:hover {
-      box-shadow: none;
-    }
-
-    &:active,
-    &.selected {
-      box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.15);
-    }
   }
 
   .btn + .button_to,


### PR DESCRIPTION
Fixes #53.

Remove all overrides to `.btn`'s `box-shadow` when in button groups to avoid a broken `:focus` state on subsequent buttons.