### PR TITLE
Make brand-blue AA compliant

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -2,7 +2,7 @@ $container-width: 980px !default;
 $grid-gutter:     10px !default;
 
 // Brand colors
-$brand-blue:       #4183c4 !default;
+$brand-blue:       #4078C0 !default;
 $brand-gray-light: #999    !default;
 $brand-gray:       #666    !default;
 $brand-gray-dark:  #333    !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -2,7 +2,7 @@ $container-width: 980px !default;
 $grid-gutter:     10px !default;
 
 // Brand colors
-$brand-blue:       #4078C0 !default;
+$brand-blue:       #4078c0 !default;
 $brand-gray-light: #999    !default;
 $brand-gray:       #666    !default;
 $brand-gray-dark:  #333    !default;


### PR DESCRIPTION
Brand blue was failing colour contrast checks. As referenced in https://github.com/github/github/issues/40219.

![colours](https://cloud.githubusercontent.com/assets/2235325/7220154/a754c23c-e6b5-11e4-9b03-0031ce7a8938.png)

The new blue is now AA complaint and AAA complaint over 18pt.

![screen shot 2015-04-19 at 16 39 37](https://cloud.githubusercontent.com/assets/2235325/7220071/00c58b88-e6b3-11e4-8c0e-2287904bf7b4.png)