### PR TITLE
Make brand-green AA compliant

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -6,7 +6,7 @@ $brand-blue:       #4078c0 !default;
 $brand-gray-light: #999    !default;
 $brand-gray:       #666    !default;
 $brand-gray-dark:  #333    !default;
-$brand-green:      #6cc644 !default;
+$brand-green:      #278904 !default;
 $brand-red:        #bd2c00 !default;
 $brand-orange:     #f93    !default;
 $brand-purple:     #6e5494 !default;


### PR DESCRIPTION
Brand green was failing colour contrast checks. As referenced in github/github#40219.

![green](https://cloud.githubusercontent.com/assets/2235325/7414525/4b1cefdc-ef4b-11e4-98fc-2992e4788598.png)

The new green is now AA complaint and AAA complaint over 18pt.

![screen shot 2015-04-30 at 14 49 07](https://cloud.githubusercontent.com/assets/2235325/7414541/66f82dfc-ef4b-11e4-9af2-ac27b5fea7f6.png)


@aaronshekey what do you think with your buttons? https://github.com/primer/primer/pull/92