### PR TITLE
removed obsolete -webkit-validation-bubble styles

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -56,25 +56,6 @@ input.input-contrast,
   color: #aaa;
 }
 
-::-webkit-validation-bubble-message {
-  font-size: 12px;
-  color: #fff;
-  background: #9c2400;
-  border: 0;
-  border-radius: 3px;
-  -webkit-box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.1);
-}
-
-input::-webkit-validation-bubble-icon {
-  display: none;
-}
-
-::-webkit-validation-bubble-arrow {
-  background-color: #9c2400;
-  border: solid 1px #9c2400;
-  -webkit-box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.1);
-}
-
 // Mini inputs, to match .minibutton
 input.input-mini {
   min-height: 26px;


### PR DESCRIPTION
The -webkit-validation-bubble pseudo-element selector was [removed in Chrome 28](https://code.google.com/p/chromium/issues/detail?id=259050#c3).