### PR TITLE
Change 777 to brand-gray

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -208,7 +208,7 @@
   &.disabled {
     &,
     &:hover {
-      color: #777;
+      color: $brand-gray;
       background-color: #fff;
       background-image: none;
       border-color: #e5e5e5;

--- a/scss/_counter.scss
+++ b/scss/_counter.scss
@@ -4,7 +4,7 @@
   font-size: 11px;
   font-weight: bold;
   line-height: 1;
-  color: #777;
+  color: $brand-gray;
   background-color: #eee;
   border-radius: 20px;
 }

--- a/scss/_filter-list.scss
+++ b/scss/_filter-list.scss
@@ -11,7 +11,7 @@
   }
 
   &.pjax-active .filter-item {
-    color: #777;
+    color: $brand-gray;
     background-color: transparent;
 
     &.pjax-active {
@@ -28,7 +28,7 @@
   margin-bottom: 5px;
   overflow: hidden;
   font-size: 14px;
-  color: #777;
+  color: $brand-gray;
   text-decoration: none;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -65,4 +65,3 @@
     background-color: #f1f1f1;
   }
 }
-

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -205,7 +205,7 @@ dl.form {
   min-height: 17px;
   margin: 4px 0 2px;
   font-size: 12px;
-  color: #777;
+  color: $brand-gray;
 
   .spinner {
     margin-right: 3px;

--- a/scss/_utility.scss
+++ b/scss/_utility.scss
@@ -56,7 +56,7 @@
 //
 // Have a link you need to be gray to start, and blue on hover? Use this.
 .muted-link {
-  color: #777;
+  color: $brand-gray;
 
   &:hover {
     color: $brand-blue;


### PR DESCRIPTION
We were using a few similar shades of grey.

I've replaced all # 777 with $brand-gray for consistency.

![image](https://cloud.githubusercontent.com/assets/2235325/7881417/ace65fc6-05fa-11e5-9272-53b09ced01da.png)