### PR TITLE
.text-muted to $brand-gray 

### DIFF
--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -40,7 +40,7 @@ blockquote {
 }
 
 // Text utilities
-.text-muted { color: #999; }
+.text-muted { color: $brand-gray; }
 .text-danger { color: $brand-red; }
 
 .text-emphasized {


### PR DESCRIPTION
Our brand light gray fails colour contrast.

![image](https://cloud.githubusercontent.com/assets/2235325/7373637/a0dd9912-edc5-11e4-90e3-2e3d3dae704f.png)

![screen shot 2015-04-28 at 16 43 45](https://cloud.githubusercontent.com/assets/2235325/7373669/cef95e94-edc5-11e4-8c7a-d230e67a2d45.png)

I've replaced this with our brand grey to be AA compliment.

![screen shot 2015-04-28 at 16 52 44](https://cloud.githubusercontent.com/assets/2235325/7373889/0beb02a2-edc7-11e4-992f-051ea4beb051.png)