### PR TITLE
Change #666 to #767676

### DIFF
--- a/scss/_counter.scss
+++ b/scss/_counter.scss
@@ -4,7 +4,7 @@
   font-size: 11px;
   font-weight: bold;
   line-height: 1;
-  color: $brand-gray;
+  color: #666;
   background-color: #eee;
   border-radius: 20px;
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -4,7 +4,7 @@ $grid-gutter:     10px !default;
 // Brand colors
 $brand-blue:       #4078c0 !default;
 $brand-gray-light: #999    !default;
-$brand-gray:       #666    !default;
+$brand-gray:       #767676 !default;
 $brand-gray-dark:  #333    !default;
 $brand-green:      #6cc644 !default;
 $brand-red:        #bd2c00 !default;


### PR DESCRIPTION
This achieves minimum AA compliancy against `#fff` with a change that's less stark than the current `#666`. For `color`s against `#eee` though, we'll need to manually adjust the values, but I think that's fair game. It's a slightly different approach, but one that maintains a bit more of the site's feel.