### PR TITLE
Add autoprefixer-core to package.json

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,7 +22,7 @@ module.exports = function(grunt) {
     postcss: {
       options: {
         processors: [
-          require('autoprefixer-core')({ browsers: ['last 2 versions', 'ie 8', 'ie 9'] }),
+          require('autoprefixer-core')({ browsers: ['last 2 versions', 'ie 8', 'ie 9'] })
         ]
       },
       dist: {
@@ -58,7 +58,7 @@ module.exports = function(grunt) {
       },
       src: [
         'css/*.css'
-      ],
+      ]
     },
 
     // Build tooling

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/primer/primer.git"
   },
   "devDependencies": {
+    "autoprefixer-core": "~5.2.1",
     "grunt": "~0.4.5",
     "grunt-build-control": "~0.2.0",
     "grunt-jekyll": "~0.4.2",


### PR DESCRIPTION
Reproduce issue:
```sh
rm -rf ./node_modules
npm install
grunt
```