### PR TITLE
Add `background-color: #fff` to `.avatar-child`

### DIFF
--- a/scss/_avatars.scss
+++ b/scss/_avatars.scss
@@ -31,6 +31,7 @@
   position: absolute;
   right: -15%;
   bottom: -9%;
+  background-color: #fff; // For transparent backgrounds
   border-radius: 2px;
   box-shadow: -2px -2px 0 rgba(255, 255, 255, 0.8);
 }


### PR DESCRIPTION
Recommendation from a support request; should ensure any child avatar in the pairing is visible even with a transparent background.