### PR TITLE
Add IE9 hacks for custom select

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -518,6 +518,10 @@ input::-webkit-inner-spin-button {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  
+  // IE9 hacks to hide the background-image and reduce padding
+  padding-right: 8px \9;
+  background-image: none \9;
 
   &:focus {
     outline: none;


### PR DESCRIPTION
We still support IE9 on GitHub.com, though I don't know for how long. This adds the necessary overrides with some easy CSS-only hacks to prevent the custom `background-image` from showing up in IE9 in addition to the default select control's arrow button.

/cc @aaronshekey 