### PR TITLE
Makes the focus indicator more visible

### DIFF
--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -23,6 +23,11 @@ a {
   &:active {
     text-decoration: underline;
   }
+  
+  &:focus {
+    background: #f5d143;
+    outline: none;
+  }
 }
 
 // Horizontal lines


### PR DESCRIPTION
We don’t currently have a focus style for keyboard/ screenreader users. This PR makes the focus indicator more visible for these users.

### Before
![screen shot 2015-08-11 at 12 40 08](https://cloud.githubusercontent.com/assets/2235325/9196936/0e125d92-4028-11e5-9522-ba1fc51d140e.png)

![screen shot 2015-08-11 at 12 42 47](https://cloud.githubusercontent.com/assets/2235325/9196927/f4ac110e-4027-11e5-85ec-9be52085d5ad.png)
The above screenshot is when the user has scrolled - leaving the point on the page but with focus still on the link.

### After
![screen shot 2015-08-11 at 12 39 55](https://cloud.githubusercontent.com/assets/2235325/9197007/b86b5fb4-4028-11e5-991d-26106ce43e96.png)

![screen shot 2015-08-11 at 12 42 01](https://cloud.githubusercontent.com/assets/2235325/9197016/c48bda62-4028-11e5-83d1-52ace49f20b1.png)