### PR TITLE
update grunt-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "grunt-build-control": "~0.2.0",
     "grunt-jekyll": "~0.4.2",
     "grunt-parker": "~0.1.0",
-    "grunt-sass": "~0.18.0",
+    "grunt-sass": "~1.0.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-postcss": "~0.5.1"
   },
@@ -31,7 +31,7 @@
     "grunt-jekyll": "^0.4.2",
     "grunt-autoprefixer": "^2.2.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-sass": "^0.18.1",
+    "grunt-sass": "^1.0.0",
     "grunt-parker": "^0.1.3",
     "grunt": "^0.4.5",
     "grunt-build-control": "^0.2.2"


### PR DESCRIPTION
node-sass v2.x doesn't work with Node.js v4.

When I try to run `npm install primer-css` in Node.js v4, the following error occured.

```
> node-sass@2.1.1 install /Users/outsider/projects/yak/primer/node_modules/grunt-sass/node_modules/node-sass
> node scripts/install.js

Can not download file from https://raw.githubusercontent.com/sass/node-sass-binaries/v2.1.1/darwin-x64-node-4.1/binding.node

> node-sass@2.1.1 postinstall /Users/outsider/projects/yak/primer/node_modules/grunt-sass/node_modules/node-sass
> node scripts/build.js

  CXX(target) Release/obj.target/binding/src/binding.o
In file included from ../src/binding.cpp:1:
../node_modules/nan/nan.h:324:27: error: redefinition of 'NanEnsureHandleOrPersistent'
  NAN_INLINE v8::Local<T> NanEnsureHandleOrPersistent(const v8::Local<T> &val) {
                          ^
../node_modules/nan/nan.h:319:17: note: previous definition is here
  v8::Handle<T> NanEnsureHandleOrPersistent(const v8::Handle<T> &val) {
                ^
../node_modules/nan/nan.h:344:27: error: redefinition of 'NanEnsureLocal'
  NAN_INLINE v8::Local<T> NanEnsureLocal(const v8::Handle<T> &val) {
                          ^
../node_modules/nan/nan.h:334:27: note: previous definition is here
  NAN_INLINE v8::Local<T> NanEnsureLocal(const v8::Local<T> &val) {
                          ^
../node_modules/nan/nan.h:757:13: error: no member named 'smalloc' in namespace 'node'
    , node::smalloc::FreeCallback callback
      ~~~~~~^
../node_modules/nan/nan.h:768:12: error: no matching function for call to 'New'
    return node::Buffer::New(v8::Isolate::GetCurrent(), data, size);
           ^~~~~~~~~~~~~~~~~
/Users/outsider/.node-gyp/4.1.2/src/node_buffer.h:31:40: note: candidate function not viable: no known conversion from 'uint32_t'
      (aka 'unsigned int') to 'enum encoding' for 3rd argument
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                       ^
/Users/outsider/.node-gyp/4.1.2/src/node_buffer.h:43:40: note: candidate function not viable: 2nd argument ('const char *') would lose
      const qualifier
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                       ^
/Users/outsider/.node-gyp/4.1.2/src/node_buffer.h:28:40: note: candidate function not viable: requires 2 arguments, but 3 were provided
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate, size_t length);
                                       ^
/Users/outsider/.node-gyp/4.1.2/src/node_buffer.h:36:40: note: candidate function not viable: requires 5 arguments, but 3 were provided
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                       ^
In file included from ../src/binding.cpp:1:
../node_modules/nan/nan.h:772:12: error: no viable conversion from 'v8::MaybeLocal<v8::Object>' to 'v8::Local<v8::Object>'
    return node::Buffer::New(v8::Isolate::GetCurrent(), size);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/outsider/.node-gyp/4.1.2/deps/v8/include/v8.h:210:7: note: candidate constructor (the implicit copy constructor) not viable: no
      known conversion from 'v8::MaybeLocal<v8::Object>' to 'const v8::Local<v8::Object> &' for 1st argument
class Local {
      ^
/Users/outsider/.node-gyp/4.1.2/deps/v8/include/v8.h:210:7: note: candidate constructor (the implicit move constructor) not viable: no
      known conversion from 'v8::MaybeLocal<v8::Object>' to 'v8::Local<v8::Object> &&' for 1st argument
class Local {
      ^
/Users/outsider/.node-gyp/4.1.2/deps/v8/include/v8.h:214:13: note: candidate template ignored: could not match 'Local' against
      'MaybeLocal'
  V8_INLINE Local(Local<S> that)
            ^
/Users/outsider/.node-gyp/4.1.2/deps/v8/include/v8.h:326:13: note: candidate template ignored: could not match 'S *' against
      'v8::MaybeLocal<v8::Object>'
  V8_INLINE Local(S* that)
            ^
In file included from ../src/binding.cpp:1:
../node_modules/nan/nan.h:779:26: error: no member named 'Use' in namespace 'node::Buffer'
    return node::Buffer::Use(v8::Isolate::GetCurrent(), data, size);
           ~~~~~~~~~~~~~~^
../src/binding.cpp:70:11: warning: 'FatalException' is deprecated: Use FatalException(isolate, ...) [-Wdeprecated-declarations]
    node::FatalException(try_catch);
          ^
/Users/outsider/.node-gyp/4.1.2/src/node.h:283:29: note: 'FatalException' has been explicitly marked deprecated here
                inline void FatalException(const v8::TryCatch& try_catch) {
                            ^
/Users/outsider/.node-gyp/4.1.2/src/node.h:66:42: note: expanded from macro 'NODE_DEPRECATED'
    __attribute__((deprecated(message))) declarator
                                         ^
../src/binding.cpp:245:11: warning: 'FatalException' is deprecated: Use FatalException(isolate, ...) [-Wdeprecated-declarations]
    node::FatalException(try_catch);
          ^
/Users/outsider/.node-gyp/4.1.2/src/node.h:283:29: note: 'FatalException' has been explicitly marked deprecated here
                inline void FatalException(const v8::TryCatch& try_catch) {
                            ^
/Users/outsider/.node-gyp/4.1.2/src/node.h:66:42: note: expanded from macro 'NODE_DEPRECATED'
    __attribute__((deprecated(message))) declarator
                                         ^
../src/binding.cpp:365:11: warning: 'FatalException' is deprecated: Use FatalException(isolate, ...) [-Wdeprecated-declarations]
    node::FatalException(try_catch);
          ^
/Users/outsider/.node-gyp/4.1.2/src/node.h:283:29: note: 'FatalException' has been explicitly marked deprecated here
                inline void FatalException(const v8::TryCatch& try_catch) {
                            ^
/Users/outsider/.node-gyp/4.1.2/src/node.h:66:42: note: expanded from macro 'NODE_DEPRECATED'
    __attribute__((deprecated(message))) declarator
                                         ^
In file included from ../src/binding.cpp:1:
In file included from ../node_modules/nan/nan.h:24:
In file included from /Users/outsider/.node-gyp/4.1.2/src/node.h:42:
/Users/outsider/.node-gyp/4.1.2/deps/v8/include/v8.h:221:5: error: assigning to 'v8::Primitive *volatile' from incompatible type
      'v8::Value *'
    TYPE_CHECK(T, S);
    ^~~~~~~~~~~~~~~~
/Users/outsider/.node-gyp/4.1.2/deps/v8/include/v8.h:180:37: note: expanded from macro 'TYPE_CHECK'
    *(static_cast<T* volatile*>(0)) = static_cast<S*>(0);      \
                                    ^ ~~~~~~~~~~~~~~~~~~
../node_modules/nan/nan.h:501:12: note: in instantiation of function template specialization
      'v8::Local<v8::Primitive>::Local<v8::Value>' requested here
    return NanEscapeScope(NanNew(v8::Undefined(v8::Isolate::GetCurrent())));
           ^
../node_modules/nan/nan.h:483:30: note: expanded from macro 'NanEscapeScope'
# define NanEscapeScope(val) scope.Escape(Nan::imp::NanEnsureLocal(val))
                             ^
In file included from ../src/binding.cpp:1:
In file included from ../node_modules/nan/nan.h:24:
In file included from /Users/outsider/.node-gyp/4.1.2/src/node.h:42:
/Users/outsider/.node-gyp/4.1.2/deps/v8/include/v8.h:221:5: error: assigning to 'v8::Boolean *volatile' from incompatible type
      'v8::Value *'
    TYPE_CHECK(T, S);
    ^~~~~~~~~~~~~~~~
/Users/outsider/.node-gyp/4.1.2/deps/v8/include/v8.h:180:37: note: expanded from macro 'TYPE_CHECK'
    *(static_cast<T* volatile*>(0)) = static_cast<S*>(0);      \
                                    ^ ~~~~~~~~~~~~~~~~~~
../node_modules/nan/nan.h:511:12: note: in instantiation of function template specialization 'v8::Local<v8::Boolean>::Local<v8::Value>'
      requested here
    return NanEscapeScope(NanNew(v8::True(v8::Isolate::GetCurrent())));
           ^
../node_modules/nan/nan.h:483:30: note: expanded from macro 'NanEscapeScope'
# define NanEscapeScope(val) scope.Escape(Nan::imp::NanEnsureLocal(val))
                             ^
In file included from ../src/binding.cpp:1:
In file included from ../node_modules/nan/nan.h:24:
In file included from /Users/outsider/.node-gyp/4.1.2/src/node.h:42:
/Users/outsider/.node-gyp/4.1.2/deps/v8/include/v8.h:221:5: error: assigning to 'v8::Function *volatile' from incompatible type
      'v8::Value *'
    TYPE_CHECK(T, S);
    ^~~~~~~~~~~~~~~~
/Users/outsider/.node-gyp/4.1.2/deps/v8/include/v8.h:180:37: note: expanded from macro 'TYPE_CHECK'
    *(static_cast<T* volatile*>(0)) = static_cast<S*>(0);      \
                                    ^ ~~~~~~~~~~~~~~~~~~
../node_modules/nan/nan.h:1645:12: note: in instantiation of function template specialization
      'v8::Local<v8::Function>::Local<v8::Value>' requested here
    return NanEscapeScope(NanNew(handle)->Get(kCallbackIndex)
           ^
../node_modules/nan/nan.h:483:30: note: expanded from macro 'NanEscapeScope'
# define NanEscapeScope(val) scope.Escape(Nan::imp::NanEnsureLocal(val))
                             ^
In file included from ../src/binding.cpp:1:
In file included from ../node_modules/nan/nan.h:24:
In file included from /Users/outsider/.node-gyp/4.1.2/src/node.h:42:
/Users/outsider/.node-gyp/4.1.2/deps/v8/include/v8.h:221:5: error: assigning to 'v8::Object *volatile' from incompatible type
      'v8::Value *'
    TYPE_CHECK(T, S);
    ^~~~~~~~~~~~~~~~
/Users/outsider/.node-gyp/4.1.2/deps/v8/include/v8.h:180:37: note: expanded from macro 'TYPE_CHECK'
    *(static_cast<T* volatile*>(0)) = static_cast<S*>(0);      \
                                    ^ ~~~~~~~~~~~~~~~~~~
../node_modules/nan/nan.h:1776:12: note: in instantiation of function template specialization 'v8::Local<v8::Object>::Local<v8::Value>'
      requested here
    return NanEscapeScope(
           ^
../node_modules/nan/nan.h:483:30: note: expanded from macro 'NanEscapeScope'
# define NanEscapeScope(val) scope.Escape(Nan::imp::NanEnsureLocal(val))
                             ^
3 warnings and 10 errors generated.
make: *** [Release/obj.target/binding/src/binding.o] Error 1
```

To use `node-sass v3.x`, I updated [grunt-sass to v1.0.0](https://github.com/sindresorhus/grunt-sass/releases/tag/v1.0.0).
Afterf updating `grunt-sass`, I can't find any problem in my local(OS X with Node v4.1.2).