### PR TITLE
Change avatars to be retina friendly

### DIFF
--- a/docs/avatars.md
+++ b/docs/avatars.md
@@ -17,7 +17,7 @@ Add `.avatar` to any `<img>` element to make it an avatar. This resets some key 
 Be sure to set `width` and `height` attributes for maximum browser performance.
 
 {% example html %}
-<img class="avatar" src="https://avatars3.githubusercontent.com/u/9919?v=3&s=72" width="72" height="72">
+<img class="avatar" src="https://avatars3.githubusercontent.com/u/9919?v=3&s=144" width="72" height="72">
 {% endexample %}
 
 ## Small avatars
@@ -25,7 +25,7 @@ Be sure to set `width` and `height` attributes for maximum browser performance.
 We occasionally use smaller avatars. Anything less than `48px` wide should include the `.avatar-small` modifier class to reset the `border-radius` to a more appropriate level.
 
 {% example html %}
-<img class="avatar avatar-small" src="https://avatars3.githubusercontent.com/u/9919?v=3&s=32" width="32" height="32">
+<img class="avatar avatar-small" src="https://avatars3.githubusercontent.com/u/9919?v=3&s=64" width="32" height="32">
 {% endexample %}
 
 ## Parent-child avatars
@@ -34,7 +34,7 @@ When you need a larger parent avatar, and a smaller child one, overlaid slightly
 
 {% example html %}
 <div class="avatar-parent-child left">
-  <img class="avatar" src="https://avatars3.githubusercontent.com/u/9919?v=3&s=48" width="48" height="48">
-  <img class="avatar avatar-child" src="https://avatars3.githubusercontent.com/u/9919?v=3&s=20" width="20" height="20">
+  <img class="avatar" src="https://avatars3.githubusercontent.com/u/9919?v=3&s=96" width="48" height="48">
+  <img class="avatar avatar-child" src="https://avatars3.githubusercontent.com/u/9919?v=3&s=40" width="20" height="20">
 </div>
 {% endexample %}


### PR DESCRIPTION
I was reading through the docs and noticed that the avatars looked rather fuzzy on the retina display, so I updated the size requested.

If leaving the avatars same size was intentional feel free to ignore this.

Thanks!