### PR TITLE
Add Apple Emoji to default font stack

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -12,7 +12,7 @@ $brand-orange:     #c9510c !default;
 $brand-purple:     #6e5494 !default;
 
 // Font stack
-$body-font: Helvetica, arial, nimbussansl, liberationsans, freesans, clean, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol" !default;
+$body-font: Helvetica, arial, nimbussansl, liberationsans, freesans, clean, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
 
 // The base body size
 $body-font-size: 13px !default;


### PR DESCRIPTION
Improves emoji color rendering in Chrome.

-
To: @jonrohan 
CC: @mdo @aroben @mislav