### PR TITLE
Fix dependencies as devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "autoprefixer-core": "~5.2.1",
     "grunt": "^0.4.5",
     "grunt-autoprefixer": "^2.2.0",
-    "grunt-build-control": "^0.2.2"
+    "grunt-build-control": "^0.2.2",
     "grunt-jekyll": "^0.4.2",
     "grunt-parker": "^0.1.3",
     "grunt-sass": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -11,13 +11,14 @@
   },
   "devDependencies": {
     "autoprefixer-core": "~5.2.1",
-    "grunt": "~0.4.5",
-    "grunt-build-control": "~0.2.0",
-    "grunt-jekyll": "~0.4.2",
-    "grunt-parker": "~0.1.0",
-    "grunt-sass": "~1.0.0",
-    "grunt-contrib-watch": "~0.6.1",
-    "grunt-postcss": "~0.5.1"
+    "grunt": "^0.4.5",
+    "grunt-autoprefixer": "^2.2.0",
+    "grunt-build-control": "^0.2.2"
+    "grunt-jekyll": "^0.4.2",
+    "grunt-parker": "^0.1.3",
+    "grunt-sass": "^1.0.0",
+    "grunt-contrib-watch": "^0.6.1",
+    "grunt-postcss": "^0.5.1"
   },
   "description": "Primer is the CSS toolkit that powers GitHub's front-end design. It's purposefully limited to common components to provide our developers with the most flexibility, and to keep GitHub uniquely *GitHubby*. It's built with SCSS and available via Bower, so it's easy to include all or part of it within your own project.",
   "bugs": {
@@ -26,15 +27,6 @@
   "main": "css/primer.css",
   "directories": {
     "doc": "docs"
-  },
-  "dependencies": {
-    "grunt-jekyll": "^0.4.2",
-    "grunt-autoprefixer": "^2.2.0",
-    "grunt-contrib-watch": "^0.6.1",
-    "grunt-sass": "^1.0.0",
-    "grunt-parker": "^0.1.3",
-    "grunt": "^0.4.5",
-    "grunt-build-control": "^0.2.2"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
The "dependencies" should be marked as "devDependencies", as they're used only from the root, and not when depending on `primer-css` as an npm package.