### PR TITLE
Removed note about `aria-label` requiring a <button> or <a> element

### DIFF
--- a/tooltips/index.html
+++ b/tooltips/index.html
@@ -116,7 +116,7 @@
   <li><code>.tooltipped-nw</code></li>
 </ul>
 
-<p>Remember, <code>aria-label</code> and tooltip classes must go directly on <code>&lt;button&gt;</code> and <code>&lt;a&gt;</code> elements. Tooltip classes also conflict with Octicon classes, and as such, must go on a parent element instead of the icon.</p>
+<p>Tooltip classes will conflict with Octicon classes, and as such, must go on a parent element instead of the icon.</p>
 
 <div class="docs-example clearfix"><span class="tooltipped tooltipped-n" aria-label="This is the tooltip.">
   Text with a tooltip


### PR DESCRIPTION
`aria-label` can be used on any element, and is even used on the `<span>`
example right below this paragraph.

I verified with ChromeVox+Chrome and VoiceOver+Safari that the tooltip's contents (via `aria-label`) are read off even on a `<span>`.