### PR TITLE
Removed note about `aria-label` requiring a <button> or <a> element

### DIFF
--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -16,7 +16,7 @@ In addition, you'll want to specify a direction:
 - `.tooltipped-w`
 - `.tooltipped-nw`
 
-Remember, `aria-label` and tooltip classes must go directly on `<button>` and `<a>` elements. Tooltip classes also conflict with Octicon classes, and as such, must go on a parent element instead of the icon.
+Tooltip classes will conflict with Octicon classes, and as such, must go on a parent element instead of the icon.
 
 {% example html %}
 <span class="tooltipped tooltipped-n" aria-label="This is the tooltip.">


### PR DESCRIPTION
`aria-label` can be used on any element, and is even used on the `<span>` example right below this paragraph.

I verified with ChromeVox+Chrome and VoiceOver+Safari that the tooltip's contents (via `aria-label`) are read off even on a `<span>`.