### PR TITLE
Update GitHubbers section of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ bower install primer-css --save
 
 ### Things to know
 
-**Hey, GitHubbers!** For GitHub.com, you'll need to  `cd` into `vendor/assets` and run `bower install` there. Be sure to commit and push all the changes, including the `bower.json` and everything under `bower_components`.
+**Hey, GitHubbers!** For GitHub.com, run `bower install` at root. Be sure to commit and push all the changes, including the `bower.json` and everything under `bower_components`.
 
 ## Usage
 


### PR DESCRIPTION
Pretty sure we haven't had to `cd vendor/assets` for quite a while since @josh made the `.bowerrc` change. :star2:
