### PR TITLE
Get rid of underline in tab :focus state

### DIFF
--- a/scss/_tabnav.scss
+++ b/scss/_tabnav.scss
@@ -30,7 +30,10 @@
     border-radius: 3px 3px 0 0;
   }
 
-  &:hover { text-decoration: none; }
+  &:hover,
+  &:focus {
+    text-decoration: none;
+  }
 }
 
 // Tabnav extras


### PR DESCRIPTION
This is useful when a tab is styled with `.btn-link` (for example `button`), where underline is set on `:focus`. Also part of the effort in getting rid of fake `a` tags. :v: