### PR TITLE
Remove tab background color (for buttons)

### DIFF
--- a/scss/_tabnav.scss
+++ b/scss/_tabnav.scss
@@ -20,6 +20,7 @@
   line-height: 20px;
   color: #666;
   text-decoration: none;
+  background-color: transparent;
   border: 1px solid transparent;
   border-bottom: 0;
 


### PR DESCRIPTION
We need only one of this or #171.
When tabs are buttons (instead of `a[href=#]`) there leaves button's default background color: 

![image](https://cloud.githubusercontent.com/assets/1153134/12979207/a010557c-d110-11e5-9f1a-4f9c86f9a9d0.png)

#171 is a solution for `button.btn-link`, but if we just make it so that there isn't a background then we can do away with adding `.btn-link`. Thoughts?