### PR TITLE
Styling changes for button.ellipsis-expander

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -251,7 +251,7 @@
 .ellipsis-expander {
   display: inline-block;
   height: 12px;
-  padding: 0 5px;
+  padding: 0 5px 5px;
   font-size: 12px;
   font-weight: bold;
   line-height: 6px;
@@ -260,6 +260,7 @@
   vertical-align: middle;
   background: #ddd;
   border-radius: 1px;
+  border: 0;
 
   &:hover {
     text-decoration: none;


### PR DESCRIPTION
I _think_ this belongs here. :grimacing:

Before

![ugly buttons](https://cloud.githubusercontent.com/assets/1153134/13118768/ccb3e2f4-d5e0-11e5-8627-9463dcceec84.png)

After

![not buttons](https://cloud.githubusercontent.com/assets/1153134/13118778/ddd9e51a-d5e0-11e5-8721-7d76df8dfa0c.png)

The bottom padding is more of a hack for [buttons and its oddness with `line-height`](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height), but it doesn't change how `a.ellipsis-expander` looks. :v: