### PR TITLE
Make private repo label accessible

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -46,7 +46,7 @@ $status-renamed:    #fffa5d !default;
 $status-pending:    #cea61b !default;
 
 // Repository type colors
-$repo-private-text: #a1882b !default;
+$repo-private-text: #4c4a42 !default;
 $repo-private-bg:   #fff9ea !default;
 $repo-private-icon: #e9dba5 !default;
 


### PR DESCRIPTION
It's important that all users are able to read a website with ease be it when being viewed by someone having colour deficits or when viewed on a black and white screen.

We should be aiming for all colours to be at least [AA compliant](https://www.w3.org/TR/AERT#color-contrast). 

**Private repo label**
![screen shot 2016-03-29 at 14 40 35](https://cloud.githubusercontent.com/assets/2235325/14109921/43c87774-f5bc-11e5-9cbf-9b638a67cfe5.png)


**The private repo label doesn't pass colour contrast** 😢 
![screen shot 2016-03-29 at 14 38 50](https://cloud.githubusercontent.com/assets/2235325/14109871/0093000a-f5bc-11e5-8963-5d6beb993dfc.png)

**After - uses flash warn text colour http://primercss.io/alerts/#variations** 
![screen shot 2016-03-29 at 14 42 25](https://cloud.githubusercontent.com/assets/2235325/14109965/81874b4e-f5bc-11e5-8484-4f87ea439579.png)

@sophshep as you bought this up ❤️ 

@mdo @jonrohan 