### PR TITLE
Including primer-markdown in primer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# HEAD
+
+- Added [primer-markdown](https://github.com/primer/markdown) to the build
+
+# 4.0.2
+
+- Added npm build scripts to add `build/build.css` to the npm package
+
+# 4.0.1
+
+- Fixed: missing primer-layout from build
+
+# 4.0.0
+
+- Whole new npm build system, pulling in the code from separate component repos

--- a/index.scss
+++ b/index.scss
@@ -24,6 +24,7 @@
 @import "primer-navigation/index.scss";
 @import "primer-states/index.scss";
 @import "primer-tooltips/index.scss";
+@import "primer-markdown/index.scss";
 
 @import "primer-flex-table/index.scss";
 @import "primer-truncate/index.scss";

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "primer-flex-table": "*",
     "primer-forms": "*",
     "primer-layout": "*",
+    "primer-markdown": "*",
     "primer-navigation": "*",
     "primer-states": "*",
     "primer-support": "*",


### PR DESCRIPTION
Previously we didn't include [primer-markdown](https://github.com/primer/markdown) in the main `primer-css` package. 

With the new distributed build style introduced in 4.0.0 #189, it makes more sense to me that markdown would be included. This PR adds what we need to have primer-markdown included in primer-css. 

-
@primer/design-systems what does everyone else think about including it?