### PR TITLE
Add build.css to "main" entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lib",
     "build"
   ],
+  "main": "build/build.css",
   "repository": "https://github.com/primer/primer.git",
   "bugs": {
     "url": "https://github.com/primer/primer/issues"


### PR DESCRIPTION
This allows using...

``` css
@import "primer-css";
```

For systems that support importing Node.js packages that define CSS in their `"main"` entry, like [postcss-import](https://github.com/postcss/postcss-import).