### PR TITLE
Updating 'style' to point to build.css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # HEAD
 
-- Added [primer-markdown](https://github.com/primer/markdown) to the build
+- Added: [primer-markdown](https://github.com/primer/markdown) to the build
+- Fixes: Pointing "style" package.json to `build/build.css` file.
 
 # 4.0.2
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://primercss.io/",
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "files": [
     "index.scss",
     "lib",


### PR DESCRIPTION
This closes #194 

The "style" was meant to accomplish what @RobLoach added in #194 but wasn't pointing at the correct place. This fixes that, pointing style to `build/build.css`

