### PR TITLE
Point style field to built css

### DIFF
--- a/modules/primer-alerts/package.json
+++ b/modules/primer-alerts/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://primercss.io/",
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "main": "build/index.js",
   "primer": {
     "category": "product",

--- a/modules/primer-avatars/package.json
+++ b/modules/primer-avatars/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://primercss.io/",
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "main": "build/index.js",
   "primer": {
     "category": "product",

--- a/modules/primer-base/package.json
+++ b/modules/primer-base/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://primercss.io/",
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-blankslate/package.json
+++ b/modules/primer-blankslate/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://primercss.io/",
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "main": "build/index.js",
   "primer": {
     "category": "product",

--- a/modules/primer-box/package.json
+++ b/modules/primer-box/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://primercss.io/",
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-buttons/package.json
+++ b/modules/primer-buttons/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://primercss.io/",
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-forms/package.json
+++ b/modules/primer-forms/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://primercss.io/",
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-labels/package.json
+++ b/modules/primer-labels/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://primercss.io/",
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "main": "build/index.js",
   "primer": {
     "category": "product",

--- a/modules/primer-layout/package.json
+++ b/modules/primer-layout/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://primercss.io/",
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-markdown/package.json
+++ b/modules/primer-markdown/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/primer/primer-markdown",
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "main": "build/index.js",
   "primer": {
     "category": "product",

--- a/modules/primer-marketing-support/package.json
+++ b/modules/primer-marketing-support/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://primercss.io/",
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "primer": {
     "category": "marketing",
     "module_type": "support"

--- a/modules/primer-marketing-utilities/package.json
+++ b/modules/primer-marketing-utilities/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://primercss.io/",
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "main": "build/index.js",
   "primer": {
     "category": "marketing",

--- a/modules/primer-navigation/package.json
+++ b/modules/primer-navigation/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://primercss.io/",
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-support/package.json
+++ b/modules/primer-support/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://primercss.io/",
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "primer": {
     "category": "core",
     "module_type": "support"

--- a/modules/primer-table-object/package.json
+++ b/modules/primer-table-object/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://primercss.io/",
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-tooltips/package.json
+++ b/modules/primer-tooltips/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://primercss.io/",
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-truncate/package.json
+++ b/modules/primer-truncate/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://primercss.io/",
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-utilities/package.json
+++ b/modules/primer-utilities/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://primercss.io/",
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "main": "build/index.js",
   "primer": {
     "category": "core",


### PR DESCRIPTION
Hey! 👋

I want to be able to import primer packages like this in my project:

```js
import 'primer-alerts'
```

and have it setup to import the file set in the `style` field in my project for primer packages but in a lot of packages it points to the SASS file and I much rather have it point to the built CSS so I don't have to compile it myself.

/cc @primer/ds-core
