### PR TITLE
Adding deprecation warning about .avatar-stack

### DIFF
--- a/modules/primer-avatars/lib/avatar-stack.scss
+++ b/modules/primer-avatars/lib/avatar-stack.scss
@@ -2,6 +2,8 @@
 // there is limited space available.
 //
 // No styleguide references
+@warn ".avatar-stack will be deprecated in version 11. Use .AvatarStack instead.";
+
 .avatar-stack {
   display: inline-block;
   white-space: nowrap;


### PR DESCRIPTION
This pull adds a deprecation warning about `.avatar-stack` when primer-avatars is built the warning reads

> ".avatar-stack will be deprecated in version 11. Use .AvatarStack instead."

/cc @primer/ds-core
