### PR TITLE
Add Sass key to package.json

### DIFF
--- a/modules/primer-alerts/package.json
+++ b/modules/primer-alerts/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "product",

--- a/modules/primer-avatars/package.json
+++ b/modules/primer-avatars/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "product",

--- a/modules/primer-base/package.json
+++ b/modules/primer-base/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-blankslate/package.json
+++ b/modules/primer-blankslate/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "product",

--- a/modules/primer-box/package.json
+++ b/modules/primer-box/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-branch-name/package.json
+++ b/modules/primer-branch-name/package.json
@@ -7,6 +7,11 @@
     "category": "product",
     "module_type": "components"
   },
+  "files": [
+    "index.scss",
+    "lib",
+    "build"
+  ],
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "index.scss",
@@ -28,6 +33,7 @@
   },
   "keywords": [
     "github",
-    "primer"
+    "primer",
+    "design-system"
   ]
 }

--- a/modules/primer-branch-name/package.json
+++ b/modules/primer-branch-name/package.json
@@ -10,6 +10,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "index.scss",
+  "sass": "index.scss",
   "main": "build/index.js",
   "repository": "https://github.com/primer/primer/tree/master/modules/primer-branch-name",
   "bugs": {

--- a/modules/primer-breadcrumb/package.json
+++ b/modules/primer-breadcrumb/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-buttons/package.json
+++ b/modules/primer-buttons/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-core/package.json
+++ b/modules/primer-core/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-forms/package.json
+++ b/modules/primer-forms/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-labels/package.json
+++ b/modules/primer-labels/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "product",

--- a/modules/primer-layout/package.json
+++ b/modules/primer-layout/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-markdown/package.json
+++ b/modules/primer-markdown/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "product",

--- a/modules/primer-marketing-buttons/package.json
+++ b/modules/primer-marketing-buttons/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "marketing",

--- a/modules/primer-marketing-support/package.json
+++ b/modules/primer-marketing-support/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "primer": {
     "category": "marketing",
     "module_type": "support"

--- a/modules/primer-marketing-type/package.json
+++ b/modules/primer-marketing-type/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "style": "build/build.css",
   "main": "build/index.js",
+  "sass": "index.scss",
   "primer": {
     "category": "marketing",
     "module_type": "utilities"

--- a/modules/primer-marketing-utilities/package.json
+++ b/modules/primer-marketing-utilities/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "marketing",

--- a/modules/primer-marketing/package.json
+++ b/modules/primer-marketing/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "marketing",

--- a/modules/primer-navigation/package.json
+++ b/modules/primer-navigation/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-page-headers/package.json
+++ b/modules/primer-page-headers/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "marketing",

--- a/modules/primer-page-sections/package.json
+++ b/modules/primer-page-sections/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "marketing",

--- a/modules/primer-popover/package.json
+++ b/modules/primer-popover/package.json
@@ -10,6 +10,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "index.scss",
+  "sass": "index.scss",
   "main": "build/index.js",
   "repository": "https://github.com/primer/primer/tree/master/modules/primer-popover",
   "bugs": {

--- a/modules/primer-product/package.json
+++ b/modules/primer-product/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "product",

--- a/modules/primer-subhead/package.json
+++ b/modules/primer-subhead/package.json
@@ -10,6 +10,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "index.scss",
+  "sass": "index.scss",
   "main": "build/index.js",
   "repository": "https://github.com/primer/primer/tree/master/modules/primer-subhead",
   "bugs": {

--- a/modules/primer-support/package.json
+++ b/modules/primer-support/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "primer": {
     "category": "core",
     "module_type": "support"

--- a/modules/primer-table-object/package.json
+++ b/modules/primer-table-object/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-tables/package.json
+++ b/modules/primer-tables/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "marketing",

--- a/modules/primer-tooltips/package.json
+++ b/modules/primer-tooltips/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-truncate/package.json
+++ b/modules/primer-truncate/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer-utilities/package.json
+++ b/modules/primer-utilities/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "main": "build/index.js",
   "primer": {
     "category": "core",

--- a/modules/primer/package.json
+++ b/modules/primer/package.json
@@ -6,6 +6,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "sass": "index.scss",
   "primer": {
     "module_type": "meta"
   },

--- a/tools/generator-primer-module/app/templates/package.json
+++ b/tools/generator-primer-module/app/templates/package.json
@@ -7,6 +7,11 @@
     "category": "<%= category %>",
     "module_type": "<%= module_type %>"
   },
+  "files": [
+    "index.scss",
+    "lib",
+    "build"
+  ],
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "index.scss",


### PR DESCRIPTION
This pr follows up https://github.com/primer/primer/pull/394 and adds a Sass key to point to `index.scss` in each module.

Also added missing file info and updated the keywords for the `branch-name` module.

cc @koddsson @josh 