### PR TITLE
Button color contrast improvements

### DIFF
--- a/modules/primer-buttons/lib/button.scss
+++ b/modules/primer-buttons/lib/button.scss
@@ -22,7 +22,7 @@
   i {
     font-style: normal;
     font-weight: $font-weight-semibold;
-    opacity: 0.6;
+    opacity: 0.75;
   }
 
   .octicon {

--- a/modules/primer-support/lib/mixins/buttons.scss
+++ b/modules/primer-support/lib/mixins/buttons.scss
@@ -43,7 +43,7 @@
   } @else {
     &:focus,
     &.focus {
-      box-shadow: 0 0 0 0.2em rgba($bg, 0.3);
+      box-shadow: 0 0 0 0.2em rgba($bg, 0.4);
     }
 
     &:hover,
@@ -86,7 +86,7 @@
   background-image: linear-gradient(-180deg, $bg 0%, $bg2 90%);
 
   &:focus {
-    box-shadow: 0 0 0 0.2em rgba($color, 0.3);
+    box-shadow: 0 0 0 0.2em rgba($color, 0.4);
   }
 
   &:hover {
@@ -147,7 +147,7 @@
 
   &:focus {
     border-color: $text-color;
-    box-shadow: 0 0 0 0.2em rgba($text-color, 0.3);
+    box-shadow: 0 0 0 0.2em rgba($text-color, 0.4);
   }
 
   &:disabled,

--- a/script/release-pr
+++ b/script/release-pr
@@ -8,6 +8,8 @@ echo "🐦  Publishing PR (canary) release..."
 
 $(npm bin)/lerna publish --npm-tag=pr --canary --exact $@
 
+git status
+
 $(dirname $0)/notify success
 
 echo ""

--- a/script/release-pr
+++ b/script/release-pr
@@ -8,11 +8,8 @@ echo "🐦  Publishing PR (canary) release..."
 
 $(npm bin)/lerna publish --npm-tag=pr --canary --exact $@
 
-git status
-
-$(dirname $0)/notify success
-
-echo ""
 echo "📓  Updated CHANGELOG..."
 
 $(npm bin)/lerna-changelog
+
+$(dirname $0)/notify success

--- a/script/release-pr
+++ b/script/release-pr
@@ -8,8 +8,9 @@ echo "🐦  Publishing PR (canary) release..."
 
 $(npm bin)/lerna publish --npm-tag=pr --canary --exact $@
 
+$(dirname $0)/notify success
+
+echo ""
 echo "📓  Updated CHANGELOG..."
 
 $(npm bin)/lerna-changelog
-
-$(dirname $0)/notify success


### PR DESCRIPTION

Some quick fixes to address color accessibility issues reported in https://github.com/github/github/issues/82929

- Reduced opacity for italics in buttons which are used for things like "branch" or "base" in the code tab or pull requests. I'm not a fan of using the `<i>` tag in this way but unsure of how much work it would be to update in github/github so may need to follow up on this. Aside from targetting a type selector in an unusual way, we also can't guarantee that the resulting color will pass contrast in other color combinations.
- Reduced alpha transparency for button focus from `0.3` to `0.4` - this isn't really a fix, just a slight improvement. Default focus outlines don't pass color contrast so it's not something I've considered before, however the default is noticeably darker and people still need to see it (for example if you used a keyboard rather than a mouse due to motor control issues). Having the same alpha transparency for every color isn't necessarily the best approach either because some hues have more range than other which will affect their perceived lightness. Coupled by the fact that our green is too light at the moment, the focus is still very light. I'll follow up with another pass that will either address the green color or de-couple the mixin for focus from the hue.



/cc @primer/ds-core
