### PR TITLE
Increase input font-size to 16px on mobile

### DIFF
--- a/modules/primer-forms/lib/form-control.scss
+++ b/modules/primer-forms/lib/form-control.scss
@@ -19,7 +19,7 @@ label {
 .form-select {
   min-height: 34px;
   padding: 6px $spacer-2;
-  font-size: $body-font-size;
+  font-size: $h4-size;
   line-height: 20px;
   color: $text-gray-dark;
   vertical-align: middle;
@@ -36,6 +36,11 @@ label {
     border-color: $blue-400;
     outline: none;
     box-shadow: $form-control-shadow, $btn-input-focus-shadow;
+  }
+
+  // Ensures inputs don't zoom on mobile but are body-font size on desktop
+  @include breakpoint(md) {
+    font-size: $body-font-size;
   }
 }
 


### PR DESCRIPTION
This pr fixes https://github.com/github/design-systems/issues/405 

It gives the input field a font-size of 16px on mobile from the `md` breakpoint and up it will have 14px, this means inputs won't zoom in on mobile on responsive pages.

To do:
- [x] test in github/github
  - [x] mobile
  - [x] tablet
  - [x] desktop

cc @primer/design-systems @kevinsawicki