### PR TITLE
subhead: set style property to compiled CSS

### DIFF
--- a/modules/primer-subhead/package.json
+++ b/modules/primer-subhead/package.json
@@ -9,7 +9,7 @@
   },
   "author": "GitHub, Inc.",
   "license": "MIT",
-  "style": "index.scss",
+  "style": "build/build.css",
   "sass": "index.scss",
   "main": "build/index.js",
   "repository": "https://github.com/primer/primer/tree/master/modules/primer-subhead",


### PR DESCRIPTION
I think this might have been a slight oversight when I did #394.

This patch changes the `style` property in the `package.json` to point to the compiled CSS rather then the SASS sources that can be accessed using the `sass` property.

<3

/cc @primer/ds-core
