### PR TITLE
Add !important to details visibility override

### DIFF
--- a/modules/primer-base/lib/base.scss
+++ b/modules/primer-base/lib/base.scss
@@ -73,6 +73,6 @@ details {
 
   &:not([open]) {
     // Set details content hidden by default for browsers that don't do this
-    > *:not(summary) { display: none; }
+    > *:not(summary) { display: none !important; }
   }
 }


### PR DESCRIPTION
Fixes this case:

```html
<details>
  <summary>summary</summary>
  <div class="d-flex">this shows up regardless</div>
</details>
```

`d-flex` has `!important` so it overrides the details default.

/cc @primer/ds-core
