### PR TITLE
[DO NOT MERGE] Primer for testing with react components

### DIFF
--- a/modules/primer/package.json
+++ b/modules/primer/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "primer-alerts": "1.5.5",
     "primer-avatars": "1.5.2",
-    "primer-base": "1.6.3",
     "primer-blankslate": "1.4.5",
     "primer-box": "2.5.5",
     "primer-branch-name": "1.0.3",


### PR DESCRIPTION
This is for testing primer with react components, we need to remove some global styles and probably edit some utility classnames. This pr should not be merged. We'll use the alpha releases for now, and if we end up needing this setup for production with react then we'll likely create a new package.

So far this pr:
- removes `primer-base`