### PR TITLE
Add colorizeTooltip deprecation warning

### DIFF
--- a/modules/primer-tooltips/lib/tooltips.scss
+++ b/modules/primer-tooltips/lib/tooltips.scss
@@ -311,3 +311,4 @@
     border-left-color: $background-color;
   }
 }
+@warn "the colorizeTooltip mixin will be deprecated in version 11.";


### PR DESCRIPTION
This adds a warning message to `primer-tooltips` that deprecates the `colorizeTooltip` mixin https://github.com/primer/primer/issues/403.

The mixin won't be fully deprecated until version 11.

https://github.com/primer/primer/issues/451