### PR TITLE
Fix broken pointer from packages to modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Then, you would import the module with:
 @import "primer-navigation/index.scss";
 ```
 
-Or, while you're figuring out which modules you need, you can import them directly from the `primer` [`packages` directory](./packages) like so:
+Or, while you're figuring out which modules you need, you can import them directly from the `primer` [`modules` directory](./modules) like so:
 
 ```scss
 @import "primer/modules/primer-navigation/index.css";


### PR DESCRIPTION
The directory that houses all of the design system components was changed from `packages` to `modules` in https://github.com/primer/primer/commit/c9ea37316fbb73c4d9931c52b42bc197260c0bf6

/cc @primer/ds-core
