### PR TITLE
Documenting the text-inheritance color utility

### DIFF
--- a/modules/primer-utilities/docs/colors.md
+++ b/modules/primer-utilities/docs/colors.md
@@ -131,6 +131,16 @@ Use text color utilities to set text or [octicons](/styleguide/css/styles/core/c
 
 These are our most common text with background color combinations. They don't all pass accessibility standards currently, but will be updated in the future. **Any of the combinations with a warning icon must be used with caution**.
 
+### Text color inheritance
+
+You can set the color inheritance on an element by using the `text-inherit` class.
+
+```html
+<div class="text-purple">
+  This text is purple, <a href="#" class="text-inherit">including the link</a>
+</div>
+```
+
 ### Text on white background
 
 ```html


### PR DESCRIPTION
Fixes https://github.com/github/design-systems/issues/399

This documents the `text-inherit` utility we have in primer-utilities/color.scss 

I broke it off into it's own section, and used a link to demonstrate the inheritance.

/cc @primer/ds-core
