### PR TITLE
Add `backface-visibility` to `.hover-grow`

### DIFF
--- a/modules/primer-utilities/lib/animations.scss
+++ b/modules/primer-utilities/lib/animations.scss
@@ -176,6 +176,7 @@
 /* Increase scale of an element on hover */
 .hover-grow {
   transition: transform 0.3s;
+  backface-visibility: hidden;
 
   &:hover {
     transform: scale(1.025);


### PR DESCRIPTION
Fixes https://github.com/github/education-web/issues/1672

This PR adds one line of CSS to the `.hover-grow` utility class: `backface-visibility: hidden;`

That line addresses a visual bug where any images contained within the element would flicker or distort briefly during the animation.

/cc @primer/ds-core
