### PR TITLE
Add utility classes for <details>

### DIFF
--- a/modules/primer-utilities/docs/details.md
+++ b/modules/primer-utilities/docs/details.md
@@ -9,10 +9,10 @@ Details classes are created to enhance the native behaviors of `<details>`.
 
 ## Fullscreen click area
 
-Use `.details-expanded` to expand the click area of `<summary>` to cover the full screen, so user can click anywhere on a page to close `<details>`.
+Use `.details-overlay` to expand the click area of `<summary>` to cover the full screen, so user can click anywhere on a page to close `<details>`.
 
 ```html
-<details class="details-expanded">
+<details class="details-overlay">
   <summary class="btn">More</summary>
   <div class="position-relative bg-white p-3 border" style="z-index: 100">Hidden text</div>
 </details>
@@ -20,10 +20,10 @@ Use `.details-expanded` to expand the click area of `<summary>` to cover the ful
 
 ## Darkened fullscreen click area
 
-Use `.details-expanded-dark` darken the click area overlay. Useful for modals.
+Use `.details-overlay-dark` darken the click area overlay. Useful for modals.
 
 ```html
-<details class="details-expanded details-expanded-dark">
+<details class="details-overlay details-overlay-dark">
   <summary class="btn">More</summary>
   <div class="position-relative bg-white p-3 border" style="z-index: 100">Hidden text</div>
 </details>

--- a/modules/primer-utilities/docs/details.md
+++ b/modules/primer-utilities/docs/details.md
@@ -1,0 +1,30 @@
+---
+title: Details
+status: New release
+---
+
+Details classes are created to enhance the native behaviors of `<details>`.
+
+{:toc}
+
+## Fullscreen click area
+
+Use `.details-expanded` to expand the click area of `<summary>` to cover the full screen, so user can click anywhere on a page to close `<details>`.
+
+```html
+<details class="details-expanded">
+  <summary class="btn">More</summary>
+  <div class="position-relative bg-white p-3 border" style="z-index: 100">Hidden text</div>
+</details>
+```
+
+## Darkened fullscreen click area
+
+Use `.details-expanded-dark` darken the click area overlay. Useful for modals.
+
+```html
+<details class="details-expanded details-expanded-dark">
+  <summary class="btn">More</summary>
+  <div class="position-relative bg-white p-3 border" style="z-index: 100">Hidden text</div>
+</details>
+```

--- a/modules/primer-utilities/index.scss
+++ b/modules/primer-utilities/index.scss
@@ -4,6 +4,7 @@
 @import "./lib/borders.scss";
 @import "./lib/box-shadow.scss";
 @import "./lib/colors.scss";
+@import "./lib/details.scss";
 @import "./lib/flexbox.scss";
 @import "./lib/layout.scss";
 @import "./lib/margin.scss";

--- a/modules/primer-utilities/lib/details.scss
+++ b/modules/primer-utilities/lib/details.scss
@@ -1,0 +1,17 @@
+// stylelint-disable selector-max-type
+.details-expanded[open] > summary::before {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 99;
+  display: block;
+  cursor: default;
+  content: " ";
+  background: transparent;
+}
+
+.details-expanded-dark[open] > summary::before {
+  background: $black-fade-50;
+}

--- a/modules/primer-utilities/lib/details.scss
+++ b/modules/primer-utilities/lib/details.scss
@@ -1,5 +1,5 @@
 // stylelint-disable selector-max-type
-.details-expanded[open] > summary::before {
+.details-overlay[open] > summary::before {
   position: fixed;
   top: 0;
   right: 0;
@@ -12,6 +12,6 @@
   background: transparent;
 }
 
-.details-expanded-dark[open] > summary::before {
+.details-overlay-dark[open] > summary::before {
   background: $black-fade-50;
 }

--- a/modules/primer-utilities/stories/Details.js
+++ b/modules/primer-utilities/stories/Details.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+storiesOf('Details utilities', module)
+.add('details-expanded', () => (
+  <details className='details-expanded'>
+    <summary className='btn'>More</summary>
+    <div className='position-relative bg-white p-3 border' style={{zIndex: 100}}>Hidden text</div>
+  </details>
+))
+.add('details-expanded-dark', () => (
+  <details className='details-expanded details-expanded-dark'>
+    <summary className='btn'>More</summary>
+    <div className='position-relative bg-white p-3 border' style={{zIndex: 100}}>Hidden text</div>
+  </details>
+))

--- a/modules/primer-utilities/stories/Details.js
+++ b/modules/primer-utilities/stories/Details.js
@@ -2,14 +2,14 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 
 storiesOf('Details utilities', module)
-.add('details-expanded', () => (
-  <details className='details-expanded'>
+.add('details-overlay', () => (
+  <details className='details-overlay'>
     <summary className='btn'>More</summary>
     <div className='position-relative bg-white p-3 border' style={{zIndex: 100}}>Hidden text</div>
   </details>
 ))
-.add('details-expanded-dark', () => (
-  <details className='details-expanded details-expanded-dark'>
+.add('details-overlay-dark', () => (
+  <details className='details-overlay details-overlay-dark'>
     <summary className='btn'>More</summary>
     <div className='position-relative bg-white p-3 border' style={{zIndex: 100}}>Hidden text</div>
   </details>


### PR DESCRIPTION
This moves `<details>` utility classes we use on dotcom to Primer. Added docs & stories. Hopefully I did them correctly!

![](https://cl.ly/0I122J2D3n3e/Screen%20Recording%202018-05-23%20at%2004.52%20PM.gif)

/cc @primer/ds-core
