### PR TITLE
Set different z-index for .details-overlay

### DIFF
--- a/modules/primer-utilities/lib/details.scss
+++ b/modules/primer-utilities/lib/details.scss
@@ -5,7 +5,7 @@
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: 99;
+  z-index: 80;
   display: block;
   cursor: default;
   content: " ";
@@ -13,5 +13,6 @@
 }
 
 .details-overlay-dark[open] > summary::before {
+  z-index: 99;
   background: $black-fade-50;
 }


### PR DESCRIPTION
The main difference here is that `.details-overlay` is usually used by menus for "click anywhere to close" but can sometimes be under sticky menus, while`.details-overlay-dark` is used for dialogs which should be the top most layer.

/cc @primer/ds-core @jonrohan 
