### PR TITLE
Fix white border on last avatar in AvatarStack (take two)

### DIFF
--- a/modules/primer-avatars/lib/avatar-stack.scss
+++ b/modules/primer-avatars/lib/avatar-stack.scss
@@ -88,6 +88,7 @@
     }
 
     &:last-child {
+      border-right: 0;
       z-index: 1;
     }
 

--- a/modules/primer-avatars/stories.js
+++ b/modules/primer-avatars/stories.js
@@ -60,7 +60,23 @@ storiesOf('Avatars', module)
         <img className='avatar' alt='Uncle Cat' width='20' height='20' src='https://user-images.githubusercontent.com/334891/29999089-2837c968-9009-11e7-92c1-6a7540a594d5.png'/>
       </div>
     </div>
-
+  </div>
+))
+.add('AvatarStack on blue background', () => (
+  <div className='border bg-blue-light p-4'>
+    <div className="AvatarStack flex-self-start ">
+      <div className="AvatarStack-body" aria-label="chesterbr">
+        <a className="avatar" aria-describedby="hovercard-aria-description">
+          <img height="20" width="20" alt="@github" src="https://avatars0.githubusercontent.com/github?s=60&amp;v=4" />
+        </a>
+      </div>
+    </div>
+    <div className='AvatarStack AvatarStack-two mt-2'>
+      <div className='AvatarStack-body tooltipped tooltipped-sw tooltipped-align-right-1' aria-label='two avatars'>
+        <img className='avatar' alt='Uncle Cat' width='20' height='20' src='https://user-images.githubusercontent.com/334891/29999089-2837c968-9009-11e7-92c1-6a7540a594d5.png'/>
+        <img className='avatar' alt='Uncle Cat' width='20' height='20' src='https://user-images.githubusercontent.com/334891/29999089-2837c968-9009-11e7-92c1-6a7540a594d5.png'/>
+      </div>
+    </div>
   </div>
 ))
 .add('CircleBadge--small', () => (


### PR DESCRIPTION
This is a fix for the white border on the last (and first, if _only_) avatar being visible on other backgrounds, as in our repo commit header:

![](https://user-images.githubusercontent.com/6009211/41414748-7b63240c-7019-11e8-9dcd-915e2d022e9e.png)

![](https://user-images.githubusercontent.com/6009211/41414757-7ef4f0be-7019-11e8-89fa-073d7874689b.png)

I've added a story for this to Storybook to test it out:

| Before | After |
| :--- | :--- |
| ![image](https://user-images.githubusercontent.com/113896/41626267-8b19ae24-73d0-11e8-9fc1-c55baff429f1.png) | ![image](https://user-images.githubusercontent.com/113896/41626296-a186b620-73d0-11e8-8d75-c5b72935360a.png) |

