### PR TITLE
Add .BtnGroup-parent, deprecate .BtnGroup-form

### DIFF
--- a/modules/primer-buttons/README.md
+++ b/modules/primer-buttons/README.md
@@ -223,12 +223,12 @@ Have a hankering for a series of buttons that are attached to one another? Wrap 
 </div>
 ```
 
-Add `.BtnGroup-form` to `<form>`s within `.BtnGroup`s for proper spacing and rounded corners.
+Add `.BtnGroup-parent` to parent elements, like `<form>`s or `<details>`s, within `.BtnGroup`s for proper spacing and rounded corners.
 
 ```html
 <div class="BtnGroup">
   <button class="btn BtnGroup-item" type="button">Button</button>
-  <form class="BtnGroup-form">
+  <form class="BtnGroup-parent">
     <button class="btn BtnGroup-item" type="button">Button in a form</button>
   </form>
   <button class="btn BtnGroup-item" type="button">Button</button>

--- a/modules/primer-buttons/lib/button-group.scss
+++ b/modules/primer-buttons/lib/button-group.scss
@@ -38,12 +38,14 @@
     border-right-width: 1px;
 
     + .BtnGroup-item,
+    + .BtnGroup-parent .BtnGroup-item,
     + .BtnGroup-form .BtnGroup-item {
       border-left-width: 0;
     }
   }
 }
 
+.BtnGroup-parent,
 .BtnGroup-form {
   float: left;
 
@@ -72,6 +74,7 @@
     }
 
     + .BtnGroup-item,
+    + .BtnGroup-parent .BtnGroup-item,
     + .BtnGroup-form .BtnGroup-item {
       border-left-width: 0;
     }

--- a/modules/primer-buttons/lib/button-group.scss
+++ b/modules/primer-buttons/lib/button-group.scss
@@ -2,6 +2,8 @@
 //
 // A button group is a series of buttons laid out next to each other, all part
 // of one visual button, but separated by rules to be separate.
+@warn ".BtnGroup-form will be deprecated in version 11. Use .BtnGroup-parent instead.";
+
 .BtnGroup {
   display: inline-block;
   vertical-align: middle;


### PR DESCRIPTION
- There doesn't seem to be a `dev` branch for me to compare against
- For some reasons I can't push to primer repo directly anymore but I definitely still have admin access 🤔

Anyways this PR adds `.BtnGroup-parent` and keeps `.BtnGroup-form` for backwards compatibility. `parent` is a more generic name since this class can be used on more than just `<form>`. I had to use it on `<details>` a few times already.

Is this OK? is there more we need to do for class name deprecation?

🌹 

