### PR TITLE
add $spacer-0 alias

### DIFF
--- a/modules/primer-support/lib/variables/layout.scss
+++ b/modules/primer-support/lib/variables/layout.scss
@@ -22,6 +22,7 @@ $spacers: (
 ) !default;
 
 // Aliases for easy use
+$spacer-0: nth($spacers, 1) !default; // 0
 $spacer-1: nth($spacers, 2) !default; // 4px
 $spacer-2: nth($spacers, 3) !default; // 8px
 $spacer-3: nth($spacers, 4) !default; // 16px


### PR DESCRIPTION
The `$spacer-0` alias is listed in the [styleguide](https://styleguide.github.com/primer/support/spacing/#spacing-scale) but didn't actually exist in master.

Fixes: #524

A [quick search](https://github.com/primer/primer/search?q=%22%24spacer-0%22&unscoped_q=%22%24spacer-0%22) confirmed that it was only used in the documentation and didn't live somewhere else in the codebase - such as another module or what have you.

/cc @primer/ds-core
