### PR TITLE
Update Releasing Docs 

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,7 +14,7 @@
 
 5. Once the release PR is approved and you've done necessary testing, merge to `master`. This will trigger a publish to npm.
 
-6. 1. Create a new release branch for the next release from `master` and name it `release-<version>`.
+6. Create a new release branch for the next release from `master` and name it `release-<version>`.
 
  (CI will publish a release candidate version to npm for branches prefixed with `release`. These version numbers have a `rc.<number>` suffix on them)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@
 
 1. Go through the tracking PR and make sure everything that should be merged in is merged in.
 
-2. Once your builds finish, click on the details links for the continuous-integration/travis-ci/push build.  Expand the `Deploying application` output and you should be able to find an outputted change log here. Copy this and update the [CHANGELOG.md](https://github.com/primer/primer/blob/master/CHANGELOG.md) file.
+2. To update the change log for your release, click on the details links for the continuous-integration/travis-ci/push build.  Expand the `Deploying application` output and copy the change log content. Update the [CHANGELOG.md](https://github.com/primer/primer/blob/master/CHANGELOG.md) file with the change log content from the build.
 
 3. Run the version bump in your terminal: `npm run bump`.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,19 +3,20 @@
 
 ### In `primer/primer`:
 
-1. Create a new release branch from `dev` and name it `release-<version>`.
+
+1. Go through the tracking PR and make sure everything that should be merged in is merged in.
+
+2. Once your builds finish, click on the details links for the continuous-integration/travis-ci/push build.  Expand the `Deploying application` output and you should be able to find an outputted change log here. Copy this and update the [CHANGELOG.md](https://github.com/primer/primer/blob/master/CHANGELOG.md) file.
+
+3. Run the version bump in your terminal: `npm run bump`.
+
+4. Test your changes with the latest release candidate version in the appropriate places (styleguide, storybook, github/github).
+
+5. Once the release PR is approved and you've done necessary testing, merge to `master`. This will trigger a publish to npm.
+
+6. 1. Create a new release branch for the next release from `master` and name it `release-<version>`.
 
  (CI will publish a release candidate version to npm for branches prefixed with `release`. These version numbers have a `rc.<number>` suffix on them)
-
-2. Go through the tracking issue and make sure everything that should be merged in is merged in.
-
-3. Once your builds finish, click on the details links for the continuous-integration/travis-ci/push build.  Expand the `Deploying application` output and you should be able to find an outputted change log here. Copy this and update the [CHANGELOG.md](https://github.com/primer/primer/blob/master/CHANGELOG.md) file.
-
-4. Run the version bump in your terminal: `npm run bump`.
-
-5. Test your changes with the latest release candidate version in the appropriate places (styleguide, storybook, github/github).
-
-6. Once the release PR is approved and you've done necessary testing, merge to `master`. This will trigger a publish to npm.
 
 
 ### In `github/github`:
@@ -53,11 +54,6 @@
 
 1. Edit  [index.html](https://github.com/primer/primer.github.io/blob/master/index.html) to include the latest version.
 
-#### Update Storybook
-
-1. Pull the latest from master on primer/primer (after merging in release branch).
-
-2. Run `npm run publish-storybook`.
 
 #### Publish release tag
 


### PR DESCRIPTION
Updates the RELEASING.md docs to provide instructions for creating a release branch immediately _after_ finishing the last release, instead of right before deploying a new one.

Also removed the instructions for deploying Storybook since that's now automated 🎉 

/cc @primer/ds-core
