### PR TITLE
add .user-select-none utility class

### DIFF
--- a/modules/primer-utilities/lib/typography.scss
+++ b/modules/primer-utilities/lib/typography.scss
@@ -219,3 +219,8 @@
 .text-mono {
   font-family: $mono-font;
 }
+
+/* Disallow user from selecting text */
+.user-select-none {
+  user-select: none !important;
+}


### PR DESCRIPTION
This adds a utility class for `.user-select-none`

Fixes #546 

A very close second for the class name was `.no-user-select` based on the file contents, however I feel like this was ultimately the better option purely for explicit declaration.

/cc @primer/ds-core
