### PR TITLE
Run script/check-versions after testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
 
 script:
   - npm test
+  - script/check-versions
 
 after_success:
   # this will short-circuit the publish step if it fails to interpolate $NPM_API_KEY


### PR DESCRIPTION
This should catch dependency version mismatches, @emplums. Let's see what happens with this PR on Travis. 🤞 

I'm trying to think of an instance of when you'd need CI to pass with version mismatches. If anyone can think of one, we should have this short-circuit with something like:

```sh
script/check-versions || exit 0
```