### PR TITLE
Add !important to [hidden]

### DIFF
--- a/modules/primer-base/lib/normalize.scss
+++ b/modules/primer-base/lib/normalize.scss
@@ -82,7 +82,7 @@ progress {
 
 template, /* 1 */
 [hidden] {
-  display: none;
+  display: none !important;
 }
 
 /* Links


### PR DESCRIPTION
Reference #467.

While the issue with `.d-*` styles need to be sorted out, having this `!important` now would help us with the many cases that we have already encountered with `.btn[hidden]`, where [`display: inline-block`](https://github.com/primer/primer/blob/efddb570a8623458b2ca10da6c7bbfd965712c2b/modules/primer-buttons/lib/button.scss#L6) takes precedence over `[hidden]`. 

---

Related but I don't want this to be a blocker – what do y'all think about just duplicating `[hidden] {display: none !important;}` at the end of `visibility-display.scss`? Considering these packages can be used separately and this is just one line of code 🤷🏻 IMO it's not horrible. 😬 

https://github.com/primer/primer/blob/efddb570a8623458b2ca10da6c7bbfd965712c2b/modules/primer-utilities/lib/visibility-display.scss#L30