### PR TITLE
Addresses inconsistent spacing within lists.

### DIFF
--- a/modules/primer-markdown/lib/lists.scss
+++ b/modules/primer-markdown/lib/lists.scss
@@ -53,6 +53,8 @@
     margin-top: $spacer-3;
   }
 
+  ol > li:first-child,
+  ul > li:first-child,
   li + li {
     margin-top: $em-spacer-3;
   }


### PR DESCRIPTION
There seems to be inconsistent spacing within lists whereby, given

* Foo
  * Bar
  * Baz
* Qux
* Quux

the vertical spacing between Bar and Baz, Baz and Qux, and Qux and Quux is all the same (`$em-spacer-3`), but the spacing between Foo and Bar is less (`0`). That appears to be the result of 

```
  li + li {
    margin-top: $em-spacer-3;
  }
```

which adds spacing between `li` siblings but not between the first `li` child and its parent `ol` or `ul`. This PR proposes to add an identical margin between the latter as well.

/cc @primer/ds-core
