### PR TITLE
Upgrade to lerna@2.11, rebuild package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,165 +69,6 @@
 				"slide": "^1.1.5"
 			}
 		},
-		"@babel/code-frame": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz",
-			"integrity": "sha512-7BKRkmYaPZm3Yff5HGZJKCz7RqZ5jUjknsXT6Gz5YKG23J3uq9hAj0epncCB0rlqmnZ8Q+UUpQB2tCR5mT37vw==",
-			"dev": true,
-			"requires": {
-				"@babel/highlight": "7.0.0-beta.46"
-			}
-		},
-		"@babel/core": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.46.tgz",
-			"integrity": "sha512-lCDbBSAhNAt+nL98xbgWmuhgrIxKvbvFHf73zlNCuXCHJkdlo7qzTofYK0ZWb+OVce8fQ17fC7DwTIhAwowzMw==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "7.0.0-beta.46",
-				"@babel/generator": "7.0.0-beta.46",
-				"@babel/helpers": "7.0.0-beta.46",
-				"@babel/template": "7.0.0-beta.46",
-				"@babel/traverse": "7.0.0-beta.46",
-				"@babel/types": "7.0.0-beta.46",
-				"babylon": "7.0.0-beta.46",
-				"convert-source-map": "^1.1.0",
-				"debug": "^3.1.0",
-				"json5": "^0.5.0",
-				"lodash": "^4.2.0",
-				"micromatch": "^2.3.11",
-				"resolve": "^1.3.2",
-				"semver": "^5.4.1",
-				"source-map": "^0.5.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
-				}
-			}
-		},
-		"@babel/generator": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.46.tgz",
-			"integrity": "sha512-5VfaEVkPG0gpNSTcf70jvV+MjbMoNn4g2iluwM7MhciedkolEtmG7PcdoUj5W1EmMfngz5cF65V7UMZXJO6y8Q==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "7.0.0-beta.46",
-				"jsesc": "^2.5.1",
-				"lodash": "^4.2.0",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "2.5.1",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
-				}
-			}
-		},
-		"@babel/helper-function-name": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.46.tgz",
-			"integrity": "sha512-zm4Kc5XB2njGs8PkmjV1zE/g1hBuphbh+VcDyFLaQsxkxSFSUtCbKwFL8AQpL/qPIcGbvX1MBt50a/3ZZH2CQA==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-get-function-arity": "7.0.0-beta.46",
-				"@babel/template": "7.0.0-beta.46",
-				"@babel/types": "7.0.0-beta.46"
-			}
-		},
-		"@babel/helper-get-function-arity": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.46.tgz",
-			"integrity": "sha512-dPrTb7QHVx44xJLjUl3LGAc13iS7hdXdO0fiOxdRN1suIS91yGGgeuwiQBlrw5SxbFchYtwenhlKbqHdVfGyVA==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "7.0.0-beta.46"
-			}
-		},
-		"@babel/helper-split-export-declaration": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.46.tgz",
-			"integrity": "sha512-UT7acgV7wsnBPwnqslqcnUFvsPBP4TtVaYM82xPGA7+evAa8q8HXOmFk08qsMK/pX/yy4+51gJJwyw2zofnacA==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "7.0.0-beta.46"
-			}
-		},
-		"@babel/helpers": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.46.tgz",
-			"integrity": "sha512-mbpH9pM3pJzo/tBr75U+zva3pqpyivogt1aofgEoD7bWFAYSuqOudRuz+m4XP6VPxxLoxcA4SFPGkuLRt9+7nQ==",
-			"dev": true,
-			"requires": {
-				"@babel/template": "7.0.0-beta.46",
-				"@babel/traverse": "7.0.0-beta.46",
-				"@babel/types": "7.0.0-beta.46"
-			}
-		},
-		"@babel/highlight": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.46.tgz",
-			"integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.0"
-			}
-		},
-		"@babel/template": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.46.tgz",
-			"integrity": "sha512-3/qi4m0l6G/vZbEwtqfzJk73mYtuE7nvAO1zT3/ZrTAHy4sHf2vaF9Eh1w+Tau263Yrkh0bjVQPb9zw6G+GeMQ==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "7.0.0-beta.46",
-				"@babel/types": "7.0.0-beta.46",
-				"babylon": "7.0.0-beta.46",
-				"lodash": "^4.2.0"
-			}
-		},
-		"@babel/traverse": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.46.tgz",
-			"integrity": "sha512-IU7MTGbcjpfhf5tyCu3sDB7sWYainZQcT+CqOBdVZXZfq5MMr130R7aiZBI2g5dJYUaW1PS81DVNpd0/Sq/Gzg==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "7.0.0-beta.46",
-				"@babel/generator": "7.0.0-beta.46",
-				"@babel/helper-function-name": "7.0.0-beta.46",
-				"@babel/helper-split-export-declaration": "7.0.0-beta.46",
-				"@babel/types": "7.0.0-beta.46",
-				"babylon": "7.0.0-beta.46",
-				"debug": "^3.1.0",
-				"globals": "^11.1.0",
-				"invariant": "^2.2.0",
-				"lodash": "^4.2.0"
-			}
-		},
-		"@babel/types": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.46.tgz",
-			"integrity": "sha512-uA5aruF2KKsJxToWdDpftsrPOIQtoGrGno2hiaeO9JRvfT9xZdK11nPoC+/RF9emNzmNbWn4HCRdCY+McT5Nbw==",
-			"dev": true,
-			"requires": {
-				"esutils": "^2.0.2",
-				"lodash": "^4.2.0",
-				"to-fast-properties": "^2.0.0"
-			}
-		},
 		"@concordance/react": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@concordance/react/-/react-1.0.0.tgz",
@@ -377,7 +218,7 @@
 			"dependencies": {
 				"autoprefixer": {
 					"version": "7.2.6",
-					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
+					"resolved": "http://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
 					"integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
 					"dev": true,
 					"requires": {
@@ -456,7 +297,7 @@
 		},
 		"@storybook/podda": {
 			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@storybook/podda/-/podda-1.2.3.tgz",
+			"resolved": "http://registry.npmjs.org/@storybook/podda/-/podda-1.2.3.tgz",
 			"integrity": "sha512-g7dsdsn50AhlGZ8iIDKdF8bi7Am++iFOq+QN+hNKz3FvgLuf8Dz+mpC/BFl90eE9bEYxXqXKeMf87399Ec5Qhw==",
 			"dev": true,
 			"requires": {
@@ -546,7 +387,7 @@
 		},
 		"@storybook/react-komposer": {
 			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@storybook/react-komposer/-/react-komposer-2.0.4.tgz",
+			"resolved": "http://registry.npmjs.org/@storybook/react-komposer/-/react-komposer-2.0.4.tgz",
 			"integrity": "sha1-wsDUp12bSpwMa0bxSrBQ9FitS7A=",
 			"dev": true,
 			"requires": {
@@ -616,9 +457,9 @@
 			}
 		},
 		"JSONStream": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-			"integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
 			"dev": true,
 			"requires": {
 				"jsonparse": "^1.2.0",
@@ -1047,9 +888,9 @@
 			}
 		},
 		"assert-plus": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 			"dev": true
 		},
 		"assign-symbols": {
@@ -1064,11 +905,20 @@
 			"integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ==",
 			"dev": true
 		},
-		"async": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+		"astral-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
 			"dev": true
+		},
+		"async": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.10"
+			}
 		},
 		"async-each": {
 			"version": "1.0.1",
@@ -1423,15 +1273,15 @@
 			}
 		},
 		"aws-sign2": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
 			"dev": true
 		},
 		"babel-code-frame": {
@@ -1453,7 +1303,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
@@ -1688,7 +1538,7 @@
 		},
 		"babel-helper-is-nodes-equiv": {
 			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
 			"integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=",
 			"dev": true
 		},
@@ -1932,7 +1782,7 @@
 		},
 		"babel-plugin-react-docgen": {
 			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.9.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.9.0.tgz",
 			"integrity": "sha512-8lQ73p4BL+xcgba03NTiHrddl2X8J6PDMQHPpz73sesrRBf6JtAscQPLIjFWQR/abLokdv81HdshpjYGppOXgA==",
 			"dev": true,
 			"requires": {
@@ -1943,79 +1793,79 @@
 		},
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
 			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
 			"dev": true
 		},
 		"babel-plugin-syntax-async-generators": {
 			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
 			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
 			"dev": true
 		},
 		"babel-plugin-syntax-class-constructor-call": {
 			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
 			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY=",
 			"dev": true
 		},
 		"babel-plugin-syntax-class-properties": {
 			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
 			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
 			"dev": true
 		},
 		"babel-plugin-syntax-decorators": {
 			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
 			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
 			"dev": true
 		},
 		"babel-plugin-syntax-do-expressions": {
 			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz",
 			"integrity": "sha1-V0d1YTmqJtOQ0JQQsDdEugfkeW0=",
 			"dev": true
 		},
 		"babel-plugin-syntax-dynamic-import": {
 			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
 			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
 			"dev": true
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
 			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
 			"dev": true
 		},
 		"babel-plugin-syntax-export-extensions": {
 			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
 			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE=",
 			"dev": true
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
 			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
 			"dev": true
 		},
 		"babel-plugin-syntax-function-bind": {
 			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz",
 			"integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y=",
 			"dev": true
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
 			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
 			"dev": true
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
 			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
 			"dev": true
 		},
@@ -2942,12 +2792,6 @@
 				}
 			}
 		},
-		"babylon": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
-			"integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg==",
-			"dev": true
-		},
 		"bail": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
@@ -3027,12 +2871,6 @@
 			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
 			"dev": true
 		},
-		"base64url": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-			"integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs=",
-			"dev": true
-		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -3050,38 +2888,37 @@
 			"dev": true
 		},
 		"bin-version": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
-			"integrity": "sha1-nrSY7m/Xb3q5p8FgQ2+JV5Q1144=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/bin-version/-/bin-version-2.0.0.tgz",
+			"integrity": "sha1-LMldg7Uive8umZeOdq61SRyBFP8=",
 			"dev": true,
 			"requires": {
-				"find-versions": "^1.0.0"
+				"execa": "^0.1.1",
+				"find-versions": "^2.0.0"
+			},
+			"dependencies": {
+				"execa": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.1.1.tgz",
+					"integrity": "sha1-sJwqkwm8DvBQFHlHLbMYD41MPt0=",
+					"dev": true,
+					"requires": {
+						"cross-spawn-async": "^2.1.1",
+						"object-assign": "^4.0.1",
+						"strip-eof": "^1.0.0"
+					}
+				}
 			}
 		},
 		"bin-version-check": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
-			"integrity": "sha1-5OXfKQuQaffRETJAMe/BP90RpbA=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-3.0.0.tgz",
+			"integrity": "sha1-4k6/prY8sDh8X8F0+G5cyBLKfMk=",
 			"dev": true,
 			"requires": {
-				"bin-version": "^1.0.0",
-				"minimist": "^1.1.0",
-				"semver": "^4.0.3",
+				"bin-version": "^2.0.0",
+				"semver": "^5.1.0",
 				"semver-truncate": "^1.0.0"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				},
-				"semver": {
-					"version": "4.3.6",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-					"integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-					"dev": true
-				}
 			}
 		},
 		"binary-extensions": {
@@ -3255,7 +3092,7 @@
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"dev": true,
 			"requires": {
@@ -3291,7 +3128,7 @@
 		},
 		"browserify-rsa": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"dev": true,
 			"requires": {
@@ -3341,7 +3178,7 @@
 		},
 		"buffer": {
 			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+			"resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 			"dev": true,
 			"requires": {
@@ -3612,9 +3449,9 @@
 			"dev": true
 		},
 		"caseless": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-			"integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
 		},
 		"ccount": {
@@ -3756,7 +3593,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
@@ -4104,7 +3941,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
@@ -4144,7 +3981,7 @@
 				},
 				"yargs": {
 					"version": "1.3.3",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz",
+					"resolved": "http://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz",
 					"integrity": "sha1-BU3oth8i7v23IHBZ6u+da4P7kxo=",
 					"dev": true
 				}
@@ -4244,6 +4081,17 @@
 			"requires": {
 				"array-ify": "^1.0.0",
 				"dot-prop": "^3.0.0"
+			},
+			"dependencies": {
+				"dot-prop": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+					"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+					"dev": true,
+					"requires": {
+						"is-obj": "^1.0.0"
+					}
+				}
 			}
 		},
 		"component-emitter": {
@@ -4296,6 +4144,29 @@
 				"md5-hex": "^2.0.0",
 				"semver": "^5.3.0",
 				"well-known-symbols": "^1.0.0"
+			}
+		},
+		"conf": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/conf/-/conf-1.4.0.tgz",
+			"integrity": "sha512-bzlVWS2THbMetHqXKB8ypsXN4DQ/1qopGwNJi1eYbpwesJcd86FBjFciCQX/YwAhp9bM7NVnPFqZ5LpV7gP0Dg==",
+			"dev": true,
+			"requires": {
+				"dot-prop": "^4.1.0",
+				"env-paths": "^1.0.0",
+				"make-dir": "^1.0.0",
+				"pkg-up": "^2.0.0",
+				"write-file-atomic": "^2.3.0"
+			}
+		},
+		"config-chain": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+			"integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+			"dev": true,
+			"requires": {
+				"ini": "^1.3.4",
+				"proto-list": "~1.2.1"
 			}
 		},
 		"configstore": {
@@ -4438,7 +4309,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
@@ -4497,7 +4368,7 @@
 			"dependencies": {
 				"load-json-file": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
@@ -4666,7 +4537,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
@@ -4749,7 +4620,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
@@ -4789,88 +4660,6 @@
 				"git-semver-tags": "^1.3.0",
 				"meow": "^3.3.0",
 				"object-assign": "^4.0.1"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-					"dev": true
-				},
-				"camelcase-keys": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^2.0.0",
-						"map-obj": "^1.0.0"
-					}
-				},
-				"indent-string": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-					"dev": true,
-					"requires": {
-						"repeating": "^2.0.0"
-					}
-				},
-				"map-obj": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-					"dev": true
-				},
-				"meow": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-					"dev": true,
-					"requires": {
-						"camelcase-keys": "^2.0.0",
-						"decamelize": "^1.1.2",
-						"loud-rejection": "^1.0.0",
-						"map-obj": "^1.0.1",
-						"minimist": "^1.1.3",
-						"normalize-package-data": "^2.3.4",
-						"object-assign": "^4.0.1",
-						"read-pkg-up": "^1.0.1",
-						"redent": "^1.0.0",
-						"trim-newlines": "^1.0.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				},
-				"redent": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-					"dev": true,
-					"requires": {
-						"indent-string": "^2.1.0",
-						"strip-indent": "^1.0.1"
-					}
-				},
-				"strip-indent": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-					"dev": true,
-					"requires": {
-						"get-stdin": "^4.0.1"
-					}
-				},
-				"trim-newlines": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-					"dev": true
-				}
 			}
 		},
 		"convert-source-map": {
@@ -4972,7 +4761,7 @@
 		},
 		"create-hash": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"dev": true,
 			"requires": {
@@ -4985,7 +4774,7 @@
 		},
 		"create-hmac": {
 			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"dev": true,
 			"requires": {
@@ -5240,7 +5029,7 @@
 				},
 				"readable-stream": {
 					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
 					"dev": true,
 					"requires": {
@@ -5686,7 +5475,7 @@
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 			"dev": true,
 			"requires": {
@@ -5735,14 +5524,28 @@
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "3.2.7",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.7.tgz",
-					"integrity": "sha512-oYVLxFVqpX9uMhOIQBLtZL+CX4uY8ZpWcjNTaxyWl5rO8yA9SSNikFnAfvk8J3P/7z3BZwNmEqFKaJoYltj3MQ==",
+					"version": "3.2.8",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+					"integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
 					"dev": true,
 					"requires": {
-						"caniuse-lite": "^1.0.30000835",
-						"electron-to-chromium": "^1.3.45"
+						"caniuse-lite": "^1.0.30000844",
+						"electron-to-chromium": "^1.3.47"
+					},
+					"dependencies": {
+						"caniuse-lite": {
+							"version": "1.0.30000885",
+							"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000885.tgz",
+							"integrity": "sha512-cXKbYwpxBLd7qHyej16JazPoUacqoVuDhvR61U7Fr5vSxMUiodzcYa1rQYRYfZ5GexV03vGZHd722vNPLjPJGQ==",
+							"dev": true
+						}
 					}
+				},
+				"electron-to-chromium": {
+					"version": "1.3.66",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.66.tgz",
+					"integrity": "sha512-EXfLtc9JxX2AZxISZ10o6hXEXTtnLtj7il5eye5YMgmDf4HbBbg+QDXpUEspsFrUcUugJZd5QJ4iIkRrmQQqIg==",
+					"dev": true
 				},
 				"isarray": {
 					"version": "0.0.1",
@@ -5751,9 +5554,9 @@
 					"dev": true
 				},
 				"postcss": {
-					"version": "6.0.22",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-					"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+					"version": "6.0.23",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
@@ -5771,7 +5574,7 @@
 				},
 				"readable-stream": {
 					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"dev": true,
 					"requires": {
@@ -5807,7 +5610,7 @@
 		},
 		"dom-converter": {
 			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
+			"resolved": "http://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
 			"integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
 			"dev": true,
 			"requires": {
@@ -5884,9 +5687,9 @@
 			}
 		},
 		"dot-prop": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-			"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
 			"dev": true,
 			"requires": {
 				"is-obj": "^1.0.0"
@@ -5919,7 +5722,7 @@
 		},
 		"duplexer": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
 			"dev": true
 		},
@@ -5940,7 +5743,7 @@
 				},
 				"readable-stream": {
 					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
 					"dev": true,
 					"requires": {
@@ -6089,6 +5892,12 @@
 			"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
 			"dev": true
 		},
+		"env-paths": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
+			"integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=",
+			"dev": true
+		},
 		"equal-length": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/equal-length/-/equal-length-1.0.1.tgz",
@@ -6193,7 +6002,7 @@
 		},
 		"es6-promise": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+			"resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
 			"integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
 			"dev": true
 		},
@@ -6601,7 +6410,7 @@
 		},
 		"express": {
 			"version": "4.16.3",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+			"resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
 			"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
 			"dev": true,
 			"requires": {
@@ -6923,6 +6732,33 @@
 			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
 			"dev": true
 		},
+		"filename-reserved-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
+			"integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
+			"dev": true
+		},
+		"filenamify": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
+			"integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
+			"dev": true,
+			"requires": {
+				"filename-reserved-regex": "^1.0.0",
+				"strip-outer": "^1.0.0",
+				"trim-repeated": "^1.0.0"
+			}
+		},
+		"filenamify-url": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-1.0.0.tgz",
+			"integrity": "sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=",
+			"dev": true,
+			"requires": {
+				"filenamify": "^1.0.0",
+				"humanize-url": "^1.0.0"
+			}
+		},
 		"filesize": {
 			"version": "3.5.11",
 			"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.11.tgz",
@@ -7005,97 +6841,13 @@
 			}
 		},
 		"find-versions": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz",
-			"integrity": "sha1-y96fEuOFdaCvG+G5osXV/Y8Ya2I=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-2.0.0.tgz",
+			"integrity": "sha1-KtkNSQ9oKMGqQCks9wmsMxghDDw=",
 			"dev": true,
 			"requires": {
 				"array-uniq": "^1.0.0",
-				"get-stdin": "^4.0.1",
-				"meow": "^3.5.0",
 				"semver-regex": "^1.0.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-					"dev": true
-				},
-				"camelcase-keys": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^2.0.0",
-						"map-obj": "^1.0.0"
-					}
-				},
-				"indent-string": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-					"dev": true,
-					"requires": {
-						"repeating": "^2.0.0"
-					}
-				},
-				"map-obj": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-					"dev": true
-				},
-				"meow": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-					"dev": true,
-					"requires": {
-						"camelcase-keys": "^2.0.0",
-						"decamelize": "^1.1.2",
-						"loud-rejection": "^1.0.0",
-						"map-obj": "^1.0.1",
-						"minimist": "^1.1.3",
-						"normalize-package-data": "^2.3.4",
-						"object-assign": "^4.0.1",
-						"read-pkg-up": "^1.0.1",
-						"redent": "^1.0.0",
-						"trim-newlines": "^1.0.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				},
-				"redent": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-					"dev": true,
-					"requires": {
-						"indent-string": "^2.1.0",
-						"strip-indent": "^1.0.1"
-					}
-				},
-				"strip-indent": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-					"dev": true,
-					"requires": {
-						"get-stdin": "^4.0.1"
-					}
-				},
-				"trim-newlines": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-					"dev": true
-				}
 			}
 		},
 		"first-chunk-stream": {
@@ -7175,13 +6927,13 @@
 			"dev": true
 		},
 		"form-data": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-			"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.5",
+				"combined-stream": "1.0.6",
 				"mime-types": "^2.1.12"
 			}
 		},
@@ -7264,27 +7016,27 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
 					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
 					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
 					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 					"dev": true,
 					"optional": true,
@@ -7295,13 +7047,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"dev": true,
 					"requires": {
@@ -7311,39 +7063,39 @@
 				},
 				"chownr": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
 					"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
 					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 					"dev": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "2.6.9",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"dev": true,
 					"optional": true,
@@ -7352,29 +7104,29 @@
 					}
 				},
 				"deep-extend": {
-					"version": "0.4.2",
-					"resolved": false,
-					"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 					"dev": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
 					"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 					"dev": true,
 					"optional": true,
@@ -7384,14 +7136,14 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"dev": true,
 					"optional": true,
@@ -7408,7 +7160,7 @@
 				},
 				"glob": {
 					"version": "7.1.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"dev": true,
 					"optional": true,
@@ -7423,14 +7175,14 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.21",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
 					"integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
 					"dev": true,
 					"optional": true,
@@ -7440,7 +7192,7 @@
 				},
 				"ignore-walk": {
 					"version": "3.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
 					"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 					"dev": true,
 					"optional": true,
@@ -7450,7 +7202,7 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"dev": true,
 					"optional": true,
@@ -7461,20 +7213,13 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 					"dev": true
 				},
-				"ini": {
-					"version": "1.3.5",
-					"resolved": false,
-					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-					"dev": true,
-					"optional": true
-				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
@@ -7483,14 +7228,14 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
 					"requires": {
@@ -7499,13 +7244,13 @@
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"dev": true
 				},
 				"minipass": {
 					"version": "2.2.4",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
 					"integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
 					"dev": true,
 					"requires": {
@@ -7515,7 +7260,7 @@
 				},
 				"minizlib": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
 					"integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
 					"dev": true,
 					"optional": true,
@@ -7525,7 +7270,7 @@
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"dev": true,
 					"requires": {
@@ -7534,14 +7279,14 @@
 				},
 				"ms": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
 					"integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
 					"dev": true,
 					"optional": true,
@@ -7553,7 +7298,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.9.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-8RwHUW3ZL4cZnbx+GDjqt81WyeA=",
 					"dev": true,
 					"optional": true,
@@ -7572,7 +7317,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,
@@ -7583,14 +7328,14 @@
 				},
 				"npm-bundled": {
 					"version": "1.0.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
 					"integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.1.10",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
 					"integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
 					"dev": true,
 					"optional": true,
@@ -7601,7 +7346,7 @@
 				},
 				"npmlog": {
 					"version": "4.1.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 					"dev": true,
 					"optional": true,
@@ -7614,20 +7359,20 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
 					"requires": {
@@ -7636,21 +7381,21 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 					"dev": true,
 					"optional": true,
@@ -7661,26 +7406,26 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
 					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 					"dev": true,
 					"optional": true
 				},
 				"rc": {
-					"version": "1.2.6",
-					"resolved": false,
-					"integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
+					"version": "1.2.8",
+					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+					"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "~0.4.0",
+						"deep-extend": "^0.6.0",
 						"ini": "~1.3.0",
 						"minimist": "^1.2.0",
 						"strip-json-comments": "~2.0.1"
@@ -7688,7 +7433,7 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"resolved": false,
+							"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 							"dev": true,
 							"optional": true
@@ -7697,7 +7442,7 @@
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"optional": true,
@@ -7713,7 +7458,7 @@
 				},
 				"rimraf": {
 					"version": "2.6.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 					"dev": true,
 					"optional": true,
@@ -7723,48 +7468,48 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
 					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
 					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 					"dev": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.5.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
 					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
 					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
@@ -7775,7 +7520,7 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"optional": true,
@@ -7785,23 +7530,16 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
 				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"resolved": false,
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-					"dev": true,
-					"optional": true
-				},
 				"tar": {
 					"version": "4.4.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
 					"integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
 					"dev": true,
 					"optional": true,
@@ -7817,14 +7555,14 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
 					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 					"dev": true,
 					"optional": true,
@@ -7834,13 +7572,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
 					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
 					"dev": true
 				}
@@ -7964,27 +7702,12 @@
 			}
 		},
 		"gaze": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
-			"integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+			"integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
 			"dev": true,
 			"requires": {
 				"globule": "^1.0.0"
-			}
-		},
-		"generate-function": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-			"dev": true
-		},
-		"generate-object-property": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-			"dev": true,
-			"requires": {
-				"is-property": "^1.0.0"
 			}
 		},
 		"get-caller-file": {
@@ -8004,88 +7727,6 @@
 				"normalize-package-data": "^2.3.0",
 				"parse-github-repo-url": "^1.3.0",
 				"through2": "^2.0.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-					"dev": true
-				},
-				"camelcase-keys": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^2.0.0",
-						"map-obj": "^1.0.0"
-					}
-				},
-				"indent-string": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-					"dev": true,
-					"requires": {
-						"repeating": "^2.0.0"
-					}
-				},
-				"map-obj": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-					"dev": true
-				},
-				"meow": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-					"dev": true,
-					"requires": {
-						"camelcase-keys": "^2.0.0",
-						"decamelize": "^1.1.2",
-						"loud-rejection": "^1.0.0",
-						"map-obj": "^1.0.1",
-						"minimist": "^1.1.3",
-						"normalize-package-data": "^2.3.4",
-						"object-assign": "^4.0.1",
-						"read-pkg-up": "^1.0.1",
-						"redent": "^1.0.0",
-						"trim-newlines": "^1.0.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				},
-				"redent": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-					"dev": true,
-					"requires": {
-						"indent-string": "^2.1.0",
-						"strip-indent": "^1.0.1"
-					}
-				},
-				"strip-indent": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-					"dev": true,
-					"requires": {
-						"get-stdin": "^4.0.1"
-					}
-				},
-				"trim-newlines": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-					"dev": true
-				}
 			}
 		},
 		"get-port": {
@@ -8130,34 +7771,30 @@
 			}
 		},
 		"gh-pages": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-1.1.0.tgz",
-			"integrity": "sha512-ZpDkeOVmIrN5mz+sBWDz5zmTqcbNJzI/updCwEv/7rrSdpTNlj1B5GhBqG7f4Q8p5sJOdnBV0SIqxJrxtZQ9FA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-1.2.0.tgz",
+			"integrity": "sha512-cGLYAvxtlQ1iTwAS4g7FreZPXoE/g62Fsxln2mmR19mgs4zZI+XJ+wVVUhBFCF/0+Nmvbq+abyTWue1m1BSnmg==",
 			"dev": true,
 			"requires": {
-				"async": "2.6.0",
-				"base64url": "^2.0.0",
-				"commander": "2.11.0",
-				"fs-extra": "^4.0.2",
+				"async": "2.6.1",
+				"commander": "2.15.1",
+				"filenamify-url": "^1.0.0",
+				"fs-extra": "^5.0.0",
 				"globby": "^6.1.0",
 				"graceful-fs": "4.1.11",
 				"rimraf": "^2.6.2"
 			},
 			"dependencies": {
-				"async": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-					"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+				"fs-extra": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+					"integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
 					"dev": true,
 					"requires": {
-						"lodash": "^4.14.0"
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
 					}
-				},
-				"commander": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-					"dev": true
 				}
 			}
 		},
@@ -8205,7 +7842,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
@@ -8291,7 +7928,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
@@ -8466,20 +8103,16 @@
 			}
 		},
 		"global-tunnel-ng": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/global-tunnel-ng/-/global-tunnel-ng-2.1.1.tgz",
-			"integrity": "sha1-2rgkQyJgtty3DRc7eCiOL6bguIA=",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/global-tunnel-ng/-/global-tunnel-ng-2.6.0.tgz",
+			"integrity": "sha512-glWGTgPzsOQs0mPRxHnWIwqYrEuQcxYpUFWF7BJxJL+c2F4fW304vdn53pqgod4PzOqZKDr1cex+a/pXCwrncA==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.0",
-				"tunnel": "^0.0.4"
+				"encodeurl": "^1.0.2",
+				"lodash": "^4.17.10",
+				"npm-conf": "^1.1.3",
+				"tunnel": "^0.0.5"
 			}
-		},
-		"globals": {
-			"version": "11.5.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
-			"integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
-			"dev": true
 		},
 		"globby": {
 			"version": "6.1.0",
@@ -8509,36 +8142,19 @@
 			"dev": true
 		},
 		"globule": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
-			"integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
+			"integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
 			"dev": true,
 			"requires": {
 				"glob": "~7.1.1",
-				"lodash": "~4.17.4",
+				"lodash": "~4.17.10",
 				"minimatch": "~3.0.2"
-			}
-		},
-		"gonzales-pe": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.3.tgz",
-			"integrity": "sha512-Kjhohco0esHQnOiqqdJeNz/5fyPkOMD/d6XVjwTAoPGUFh0mCollPUTUTa2OZy4dYNAqlPIQdTiNzJTWdd9Htw==",
-			"dev": true,
-			"requires": {
-				"minimist": "1.1.x"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-					"integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
-					"dev": true
-				}
 			}
 		},
 		"got": {
 			"version": "6.7.1",
-			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+			"resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 			"dev": true,
 			"requires": {
@@ -8580,52 +8196,75 @@
 			}
 		},
 		"handlebars": {
-			"version": "4.0.11",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+			"version": "4.0.12",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
+			"integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
 			"dev": true,
 			"requires": {
-				"async": "^1.4.0",
+				"async": "^2.5.0",
 				"optimist": "^0.6.1",
-				"source-map": "^0.4.4",
-				"uglify-js": "^2.6"
-			}
-		},
-		"har-validator": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-			"integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-			"dev": true,
-			"requires": {
-				"chalk": "^1.1.1",
-				"commander": "^2.9.0",
-				"is-my-json-valid": "^2.12.4",
-				"pinkie-promise": "^2.0.0"
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+				"commander": {
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+					"dev": true,
+					"optional": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+				"uglify-js": {
+					"version": "3.4.9",
+					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+					"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"commander": "~2.17.1",
+						"source-map": "~0.6.1"
+					}
+				}
+			}
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"dev": true
+		},
+		"har-validator": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"dev": true,
+			"requires": {
+				"ajv": "^5.1.0",
+				"har-schema": "^2.0.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "5.5.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"co": "^4.6.0",
+						"fast-deep-equal": "^1.0.0",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.3.0"
 					}
 				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+				"fast-deep-equal": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+					"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
 					"dev": true
 				}
 			}
@@ -9013,7 +8652,7 @@
 		},
 		"http-errors": {
 			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"dev": true,
 			"requires": {
@@ -9040,12 +8679,12 @@
 			}
 		},
 		"http-signature": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^0.2.0",
+				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
 				"sshpk": "^1.7.0"
 			}
@@ -9121,6 +8760,16 @@
 			"dev": true,
 			"requires": {
 				"decamelize": "^1.0.0"
+			}
+		},
+		"humanize-url": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz",
+			"integrity": "sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=",
+			"dev": true,
+			"requires": {
+				"normalize-url": "^1.0.0",
+				"strip-url-auth": "^1.0.0"
 			}
 		},
 		"hyphenate-style-name": {
@@ -9200,12 +8849,6 @@
 			"version": "3.8.2",
 			"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
 			"integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
-			"dev": true
-		},
-		"import-lazy": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
-			"integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==",
 			"dev": true
 		},
 		"import-local": {
@@ -9320,194 +8963,72 @@
 			}
 		},
 		"insight": {
-			"version": "0.8.4",
-			"resolved": "https://registry.npmjs.org/insight/-/insight-0.8.4.tgz",
-			"integrity": "sha1-ZxyvZbR8n+jD0bMgbPRbshG3WIQ=",
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/insight/-/insight-0.10.1.tgz",
+			"integrity": "sha512-kLGeYQkh18f8KuC68QKdi0iwUcIaayJVB/STpX7x452/7pAUm1yfG4giJwcxbrTh0zNYtc8kBR+6maLMOzglOQ==",
 			"dev": true,
 			"requires": {
-				"async": "^1.4.2",
-				"chalk": "^1.0.0",
-				"configstore": "^1.0.0",
-				"inquirer": "^0.10.0",
-				"lodash.debounce": "^3.0.1",
-				"object-assign": "^4.0.1",
-				"os-name": "^1.0.0",
+				"async": "^2.1.4",
+				"chalk": "^2.3.0",
+				"conf": "^1.3.1",
+				"inquirer": "^5.0.0",
+				"lodash.debounce": "^4.0.8",
+				"os-name": "^2.0.1",
 				"request": "^2.74.0",
 				"tough-cookie": "^2.0.0",
 				"uuid": "^3.0.0"
 			},
 			"dependencies": {
-				"ansi-escapes": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"cli-cursor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-					"dev": true,
-					"requires": {
-						"restore-cursor": "^1.0.1"
-					}
-				},
-				"cli-width": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
-					"integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
-					"dev": true
-				},
-				"configstore": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
-					"integrity": "sha1-w1eB0FAdJowlxUuLF/YkDopPsCE=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"mkdirp": "^0.5.0",
-						"object-assign": "^4.0.1",
-						"os-tmpdir": "^1.0.0",
-						"osenv": "^0.1.0",
-						"uuid": "^2.0.1",
-						"write-file-atomic": "^1.1.2",
-						"xdg-basedir": "^2.0.0"
-					},
-					"dependencies": {
-						"uuid": {
-							"version": "2.0.3",
-							"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-							"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-							"dev": true
-						}
-					}
-				},
-				"figures": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-					"dev": true,
-					"requires": {
-						"escape-string-regexp": "^1.0.5",
-						"object-assign": "^4.1.0"
-					}
 				},
 				"inquirer": {
-					"version": "0.10.1",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.10.1.tgz",
-					"integrity": "sha1-6iXkzmnKFF4FyZ5G3P7AXkASWUo=",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+					"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "^1.1.0",
-						"ansi-regex": "^2.0.0",
-						"chalk": "^1.0.0",
-						"cli-cursor": "^1.0.1",
-						"cli-width": "^1.0.1",
-						"figures": "^1.3.5",
-						"lodash": "^3.3.1",
-						"readline2": "^1.0.1",
-						"run-async": "^0.1.0",
-						"rx-lite": "^3.1.2",
-						"strip-ansi": "^3.0.0",
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.0",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^2.1.0",
+						"figures": "^2.0.0",
+						"lodash": "^4.3.0",
+						"mute-stream": "0.0.7",
+						"run-async": "^2.2.0",
+						"rxjs": "^5.5.2",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^4.0.0",
 						"through": "^2.3.6"
 					}
 				},
-				"lodash": {
-					"version": "3.10.1",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-					"dev": true
-				},
-				"lodash.debounce": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
-					"integrity": "sha1-gSIRw3ipTMKdWqTjNGzwv846ffU=",
+				"rxjs": {
+					"version": "5.5.12",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+					"integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
 					"dev": true,
 					"requires": {
-						"lodash._getnative": "^3.0.0"
+						"symbol-observable": "1.0.1"
 					}
 				},
-				"onetime": {
-					"version": "1.1.0",
-					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-					"dev": true
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
 				},
-				"restore-cursor": {
+				"symbol-observable": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-					"dev": true,
-					"requires": {
-						"exit-hook": "^1.0.0",
-						"onetime": "^1.0.0"
-					}
-				},
-				"run-async": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-					"integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-					"dev": true,
-					"requires": {
-						"once": "^1.3.0"
-					}
-				},
-				"rx-lite": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-					"integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+					"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
 					"dev": true
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				},
-				"uuid": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-					"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-					"dev": true
-				},
-				"write-file-atomic": {
-					"version": "1.3.4",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.11",
-						"imurmurhash": "^0.1.4",
-						"slide": "^1.1.5"
-					}
-				},
-				"xdg-basedir": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-					"integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
-					"dev": true,
-					"requires": {
-						"os-homedir": "^1.0.0"
-					}
 				}
 			}
 		},
@@ -9810,25 +9331,6 @@
 				"is-path-inside": "^1.0.0"
 			}
 		},
-		"is-my-ip-valid": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-			"integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
-			"dev": true
-		},
-		"is-my-json-valid": {
-			"version": "2.17.2",
-			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-			"integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
-			"dev": true,
-			"requires": {
-				"generate-function": "^2.0.0",
-				"generate-object-property": "^1.1.0",
-				"is-my-ip-valid": "^1.0.0",
-				"jsonpointer": "^4.0.0",
-				"xtend": "^4.0.0"
-			}
-		},
 		"is-npm": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -9846,7 +9348,7 @@
 		},
 		"is-obj": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 			"dev": true
 		},
@@ -9966,12 +9468,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
 			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-			"dev": true
-		},
-		"is-property": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
 			"dev": true
 		},
 		"is-redirect": {
@@ -10236,6 +9732,15 @@
 			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
 			"dev": true
 		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"dev": true,
+			"requires": {
+				"jsonify": "~0.0.0"
+			}
+		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -10299,7 +9804,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
@@ -10345,12 +9850,6 @@
 			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
 			"dev": true
 		},
-		"jsonpointer": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-			"dev": true
-		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -10394,12 +9893,6 @@
 			"requires": {
 				"is-buffer": "^1.1.5"
 			}
-		},
-		"known-css-properties": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.6.1.tgz",
-			"integrity": "sha512-nQRpMcHm1cQ6gmztdvLcIvxocznSMqH/y6XtERrWrHaymOYdDGroRqetJvJycxGEr1aakXiigDgn7JnzuXlk6A==",
-			"dev": true
 		},
 		"last-line-stream": {
 			"version": "1.0.0",
@@ -10490,9 +9983,9 @@
 			}
 		},
 		"lerna": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/lerna/-/lerna-2.4.0.tgz",
-			"integrity": "sha512-hpoIS0PuhIUpulMF4sQ/aWLUMoH8x7L5fSKF4cf1oNJhmC5FukTpR5fWe8EzmUszFo6Nj/bdJfN36OYDrEJAOA==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/lerna/-/lerna-2.11.0.tgz",
+			"integrity": "sha512-kgM6zwe2P2tR30MYvgiLLW+9buFCm6E7o8HnRlhTgm70WVBvXVhydqv+q/MF2HrVZkCawfVtCfetyQmtd4oHhQ==",
 			"dev": true,
 			"requires": {
 				"async": "^1.5.0",
@@ -10500,8 +9993,8 @@
 				"cmd-shim": "^2.0.2",
 				"columnify": "^1.5.4",
 				"command-join": "^2.0.0",
-				"conventional-changelog-cli": "^1.3.2",
-				"conventional-recommended-bump": "^1.0.1",
+				"conventional-changelog-cli": "^1.3.13",
+				"conventional-recommended-bump": "^1.2.1",
 				"dedent": "^0.7.0",
 				"execa": "^0.8.0",
 				"find-up": "^2.1.0",
@@ -10514,18 +10007,20 @@
 				"hosted-git-info": "^2.5.0",
 				"inquirer": "^3.2.2",
 				"is-ci": "^1.0.10",
-				"load-json-file": "^3.0.0",
+				"load-json-file": "^4.0.0",
 				"lodash": "^4.17.4",
 				"minimatch": "^3.0.4",
 				"npmlog": "^4.1.2",
 				"p-finally": "^1.0.0",
+				"package-json": "^4.0.1",
 				"path-exists": "^3.0.0",
 				"read-cmd-shim": "^1.0.1",
-				"read-pkg": "^2.0.0",
+				"read-pkg": "^3.0.0",
 				"rimraf": "^2.6.1",
 				"safe-buffer": "^5.1.1",
 				"semver": "^5.4.1",
 				"signal-exit": "^3.0.2",
+				"slash": "^1.0.0",
 				"strong-log-transformer": "^1.0.6",
 				"temp-write": "^3.3.0",
 				"write-file-atomic": "^2.3.0",
@@ -10534,6 +10029,12 @@
 				"yargs": "^8.0.2"
 			},
 			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
+				},
 				"execa": {
 					"version": "0.8.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
@@ -10547,6 +10048,43 @@
 						"p-finally": "^1.0.0",
 						"signal-exit": "^3.0.0",
 						"strip-eof": "^1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"read-pkg": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
+					}
+				},
+				"write-json-file": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
+					"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
+					"dev": true,
+					"requires": {
+						"detect-indent": "^5.0.0",
+						"graceful-fs": "^4.1.2",
+						"make-dir": "^1.0.0",
+						"pify": "^3.0.0",
+						"sort-keys": "^2.0.0",
+						"write-file-atomic": "^2.0.0"
 					}
 				}
 			}
@@ -10582,7 +10120,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
@@ -10640,7 +10178,7 @@
 				},
 				"jsonfile": {
 					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+					"resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
 					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
 					"dev": true,
 					"requires": {
@@ -10649,7 +10187,7 @@
 				},
 				"os-locale": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+					"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"dev": true,
 					"requires": {
@@ -10681,7 +10219,7 @@
 				},
 				"yargs": {
 					"version": "6.6.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+					"resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
 					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
 					"dev": true,
 					"requires": {
@@ -10711,35 +10249,6 @@
 				}
 			}
 		},
-		"load-json-file": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-3.0.0.tgz",
-			"integrity": "sha1-frNzXZg6ftImKt5P92mvU2nFxEA=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"parse-json": "^3.0.0",
-				"pify": "^2.0.0",
-				"strip-bom": "^3.0.0"
-			},
-			"dependencies": {
-				"parse-json": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
-					"integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.3.1"
-					}
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				}
-			}
-		},
 		"loader-runner": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
@@ -10766,6 +10275,12 @@
 				"p-locate": "^2.0.0",
 				"path-exists": "^3.0.0"
 			}
+		},
+		"locutus": {
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.10.tgz",
+			"integrity": "sha512-AZg2kCqrquMJ5FehDsBidV0qHl98NrsYtseUClzjAQ3HFnsDBJTCwGVplSQ82t9/QfgahqvTjaKcZqZkHmS0wQ==",
+			"dev": true
 		},
 		"lodash": {
 			"version": "4.17.10",
@@ -11028,9 +10543,15 @@
 			}
 		},
 		"macaddress": {
-			"version": "0.2.8",
-			"resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
-			"integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.9.tgz",
+			"integrity": "sha512-k4F1JUof6cQXxNFzx3thLby4oJzXTXQueAOOts944Vqizn+Rjc2QNFenT9FJSLU1CH3PmrHRSyZs2E+Cqw+P2w==",
+			"dev": true
+		},
+		"macos-release": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
+			"integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA==",
 			"dev": true
 		},
 		"make-dir": {
@@ -11307,7 +10828,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
@@ -11476,9 +10997,9 @@
 			"dev": true
 		},
 		"mimic-response": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
-			"integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
 			"dev": true
 		},
 		"min-document": {
@@ -11513,7 +11034,7 @@
 		},
 		"minimist": {
 			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 			"dev": true
 		},
@@ -11586,7 +11107,7 @@
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"dev": true,
 			"requires": {
@@ -11600,9 +11121,9 @@
 			"dev": true
 		},
 		"moment": {
-			"version": "2.22.1",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
-			"integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ==",
+			"version": "2.22.2",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+			"integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
 			"dev": true
 		},
 		"move-concurrently": {
@@ -11741,20 +11262,19 @@
 			}
 		},
 		"node-gyp": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
-			"integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+			"integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
 			"dev": true,
 			"requires": {
 				"fstream": "^1.0.0",
 				"glob": "^7.0.3",
 				"graceful-fs": "^4.1.2",
-				"minimatch": "^3.0.2",
 				"mkdirp": "^0.5.0",
 				"nopt": "2 || 3",
 				"npmlog": "0 || 1 || 2 || 3 || 4",
 				"osenv": "0",
-				"request": "2",
+				"request": "^2.87.0",
 				"rimraf": "2",
 				"semver": "~5.3.0",
 				"tar": "^2.0.0",
@@ -11815,9 +11335,9 @@
 			}
 		},
 		"node-sass": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.0.tgz",
-			"integrity": "sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==",
+			"version": "4.9.3",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.3.tgz",
+			"integrity": "sha512-XzXyGjO+84wxyH7fV6IwBOTrEBe2f0a6SBze9QWWYR/cL74AcQUks2AsqcCZenl/Fp/JVbuEaLpgrLtocwBUww==",
 			"dev": true,
 			"requires": {
 				"async-foreach": "^0.1.3",
@@ -11833,9 +11353,9 @@
 				"meow": "^3.7.0",
 				"mkdirp": "^0.5.1",
 				"nan": "^2.10.0",
-				"node-gyp": "^3.3.1",
+				"node-gyp": "^3.8.0",
 				"npmlog": "^4.0.0",
-				"request": "~2.79.0",
+				"request": "2.87.0",
 				"sass-graph": "^2.2.4",
 				"stdout-stream": "^1.4.0",
 				"true-case-path": "^1.0.2"
@@ -11847,25 +11367,9 @@
 					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
 					"dev": true
 				},
-				"camelcase": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-					"dev": true
-				},
-				"camelcase-keys": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^2.0.0",
-						"map-obj": "^1.0.0"
-					}
-				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
@@ -11886,74 +11390,10 @@
 						"which": "^1.2.9"
 					}
 				},
-				"indent-string": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-					"dev": true,
-					"requires": {
-						"repeating": "^2.0.0"
-					}
-				},
-				"map-obj": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-					"dev": true
-				},
-				"meow": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-					"dev": true,
-					"requires": {
-						"camelcase-keys": "^2.0.0",
-						"decamelize": "^1.1.2",
-						"loud-rejection": "^1.0.0",
-						"map-obj": "^1.0.1",
-						"minimist": "^1.1.3",
-						"normalize-package-data": "^2.3.4",
-						"object-assign": "^4.0.1",
-						"read-pkg-up": "^1.0.1",
-						"redent": "^1.0.0",
-						"trim-newlines": "^1.0.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				},
-				"redent": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-					"dev": true,
-					"requires": {
-						"indent-string": "^2.1.0",
-						"strip-indent": "^1.0.1"
-					}
-				},
-				"strip-indent": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-					"dev": true,
-					"requires": {
-						"get-stdin": "^4.0.1"
-					}
-				},
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				},
-				"trim-newlines": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
 					"dev": true
 				}
 			}
@@ -12115,6 +11555,16 @@
 				}
 			}
 		},
+		"npm-conf": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
+			"integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
+			"dev": true,
+			"requires": {
+				"config-chain": "^1.1.11",
+				"pify": "^3.0.0"
+			}
+		},
 		"npm-keyword": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/npm-keyword/-/npm-keyword-5.0.0.tgz",
@@ -12250,9 +11700,19 @@
 				"npm": "5.1.0"
 			},
 			"dependencies": {
+				"ajv": {
+					"version": "4.11.8",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+					"dev": true,
+					"requires": {
+						"co": "^4.6.0",
+						"json-stable-stringify": "^1.0.1"
+					}
+				},
 				"ansi-align": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
 					"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
 					"dev": true,
 					"requires": {
@@ -12261,28 +11721,40 @@
 				},
 				"ansi-regex": {
 					"version": "3.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
 				},
+				"assert-plus": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+					"dev": true
+				},
+				"aws-sign2": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+					"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+					"dev": true
+				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 					"dev": true
 				},
 				"boxen": {
 					"version": "1.3.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
 					"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
 					"dev": true,
 					"requires": {
@@ -12297,7 +11769,7 @@
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"dev": true,
 					"requires": {
@@ -12307,25 +11779,54 @@
 				},
 				"builtins": {
 					"version": "1.0.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
 					"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
 					"dev": true
 				},
+				"cacache": {
+					"version": "9.2.9",
+					"resolved": "https://registry.npmjs.org/cacache/-/cacache-9.2.9.tgz",
+					"integrity": "sha512-ghg1j5OyTJ6qsrqU++dN23QiTDxb5AZCFGsF3oB+v9v/gY+F4X8L/0gdQMEjd+8Ot3D29M2etX5PKozHRn2JQw==",
+					"dev": true,
+					"requires": {
+						"bluebird": "^3.5.0",
+						"chownr": "^1.0.1",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.1.11",
+						"lru-cache": "^4.1.1",
+						"mississippi": "^1.3.0",
+						"mkdirp": "^0.5.1",
+						"move-concurrently": "^1.0.1",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^2.6.1",
+						"ssri": "^4.1.6",
+						"unique-filename": "^1.1.0",
+						"y18n": "^3.2.1"
+					},
+					"dependencies": {
+						"y18n": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+							"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+							"dev": true
+						}
+					}
+				},
 				"camelcase": {
 					"version": "4.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
 					"dev": true
 				},
 				"capture-stack-trace": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
 					"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
 					"dev": true
 				},
 				"chalk": {
 					"version": "2.3.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
@@ -12336,19 +11837,19 @@
 				},
 				"ci-info": {
 					"version": "1.1.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
 					"integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
 					"dev": true
 				},
 				"cli-boxes": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
 					"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
 					"dev": true
 				},
 				"cliui": {
 					"version": "4.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
 					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
 					"dev": true,
 					"requires": {
@@ -12359,13 +11860,13 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 					"dev": true
 				},
 				"color-convert": {
 					"version": "1.9.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 					"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 					"dev": true,
 					"requires": {
@@ -12374,19 +11875,19 @@
 				},
 				"color-name": {
 					"version": "1.1.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 					"dev": true
 				},
 				"configstore": {
 					"version": "3.1.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
 					"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
 					"dev": true,
 					"requires": {
@@ -12400,7 +11901,7 @@
 				},
 				"create-error-class": {
 					"version": "3.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
 					"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
 					"dev": true,
 					"requires": {
@@ -12409,7 +11910,7 @@
 				},
 				"cross-spawn": {
 					"version": "5.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"dev": true,
 					"requires": {
@@ -12420,25 +11921,25 @@
 				},
 				"crypto-random-string": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
 					"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
 					"dev": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 					"dev": true
 				},
 				"deep-extend": {
 					"version": "0.4.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
 					"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
 					"dev": true
 				},
 				"dot-prop": {
 					"version": "4.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
 					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
 					"dev": true,
 					"requires": {
@@ -12447,25 +11948,25 @@
 				},
 				"dotenv": {
 					"version": "5.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
 					"integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
 					"dev": true
 				},
 				"duplexer3": {
 					"version": "0.1.4",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
 					"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
 					"dev": true
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 					"dev": true,
 					"requires": {
@@ -12480,34 +11981,45 @@
 				},
 				"find-up": {
 					"version": "2.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
 				},
+				"form-data": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+					"dev": true,
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.5",
+						"mime-types": "^2.1.12"
+					}
+				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 					"dev": true
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
 					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
 					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 					"dev": true
 				},
 				"glob": {
 					"version": "7.1.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"dev": true,
 					"requires": {
@@ -12521,7 +12033,7 @@
 				},
 				"global-dirs": {
 					"version": "0.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
 					"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
 					"dev": true,
 					"requires": {
@@ -12530,7 +12042,7 @@
 				},
 				"got": {
 					"version": "6.7.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
 					"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 					"dev": true,
 					"requires": {
@@ -12549,37 +12061,64 @@
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
 					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
 					"dev": true
 				},
+				"har-schema": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+					"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+					"dev": true
+				},
+				"har-validator": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+					"dev": true,
+					"requires": {
+						"ajv": "^4.9.1",
+						"har-schema": "^1.0.5"
+					}
+				},
 				"has-flag": {
 					"version": "3.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 					"dev": true
 				},
 				"hosted-git-info": {
 					"version": "2.6.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
 					"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
 					"dev": true
 				},
+				"http-signature": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+					"dev": true,
+					"requires": {
+						"assert-plus": "^0.2.0",
+						"jsprim": "^1.2.2",
+						"sshpk": "^1.7.0"
+					}
+				},
 				"import-lazy": {
 					"version": "2.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
 					"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
 					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 					"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
 					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"dev": true,
 					"requires": {
@@ -12589,25 +12128,25 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
 					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 					"dev": true
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
 					"dev": true
 				},
 				"is-ci": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
 					"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
 					"dev": true,
 					"requires": {
@@ -12616,13 +12155,13 @@
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 					"dev": true
 				},
 				"is-installed-globally": {
 					"version": "0.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
 					"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
 					"dev": true,
 					"requires": {
@@ -12632,19 +12171,19 @@
 				},
 				"is-npm": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
 					"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
 					"dev": true
 				},
 				"is-obj": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 					"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 					"dev": true
 				},
 				"is-path-inside": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 					"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 					"dev": true,
 					"requires": {
@@ -12653,31 +12192,31 @@
 				},
 				"is-redirect": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
 					"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
 					"dev": true
 				},
 				"is-retry-allowed": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
 					"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
 					"dev": true
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
 					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 					"dev": true
 				},
 				"latest-version": {
 					"version": "3.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
 					"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
 					"dev": true,
 					"requires": {
@@ -12686,7 +12225,7 @@
 				},
 				"lcid": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 					"dev": true,
 					"requires": {
@@ -12695,7 +12234,7 @@
 				},
 				"libnpx": {
 					"version": "10.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/libnpx/-/libnpx-10.2.0.tgz",
 					"integrity": "sha512-X28coei8/XRCt15cYStbLBph+KGhFra4VQhRBPuH/HHMkC5dxM8v24RVgUsvODKCrUZ0eTgiTqJp6zbl0sskQQ==",
 					"dev": true,
 					"requires": {
@@ -12711,7 +12250,7 @@
 				},
 				"locate-path": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"dev": true,
 					"requires": {
@@ -12721,13 +12260,13 @@
 				},
 				"lowercase-keys": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
 					"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
 					"dev": true
 				},
 				"lru-cache": {
 					"version": "4.1.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
 					"integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
 					"dev": true,
 					"requires": {
@@ -12737,16 +12276,97 @@
 				},
 				"make-dir": {
 					"version": "1.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
 					"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
 					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
 				},
+				"make-fetch-happen": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.6.0.tgz",
+					"integrity": "sha512-FFq0lNI0ax+n9IWzWpH8A4JdgYiAp2DDYIZ3rsaav8JDe8I+72CzK6PQW/oom15YDZpV5bYW/9INd6nIJ2ZfZw==",
+					"dev": true,
+					"requires": {
+						"agentkeepalive": "^3.3.0",
+						"cacache": "^10.0.0",
+						"http-cache-semantics": "^3.8.0",
+						"http-proxy-agent": "^2.0.0",
+						"https-proxy-agent": "^2.1.0",
+						"lru-cache": "^4.1.1",
+						"mississippi": "^1.2.0",
+						"node-fetch-npm": "^2.0.2",
+						"promise-retry": "^1.1.1",
+						"socks-proxy-agent": "^3.0.1",
+						"ssri": "^5.0.0"
+					},
+					"dependencies": {
+						"cacache": {
+							"version": "10.0.4",
+							"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+							"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+							"dev": true,
+							"requires": {
+								"bluebird": "^3.5.1",
+								"chownr": "^1.0.1",
+								"glob": "^7.1.2",
+								"graceful-fs": "^4.1.11",
+								"lru-cache": "^4.1.1",
+								"mississippi": "^2.0.0",
+								"mkdirp": "^0.5.1",
+								"move-concurrently": "^1.0.1",
+								"promise-inflight": "^1.0.1",
+								"rimraf": "^2.6.2",
+								"ssri": "^5.2.4",
+								"unique-filename": "^1.1.0",
+								"y18n": "^4.0.0"
+							},
+							"dependencies": {
+								"mississippi": {
+									"version": "2.0.0",
+									"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+									"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+									"dev": true,
+									"requires": {
+										"concat-stream": "^1.5.0",
+										"duplexify": "^3.4.2",
+										"end-of-stream": "^1.1.0",
+										"flush-write-stream": "^1.0.0",
+										"from2": "^2.1.0",
+										"parallel-transform": "^1.1.0",
+										"pump": "^2.0.1",
+										"pumpify": "^1.3.3",
+										"stream-each": "^1.1.0",
+										"through2": "^2.0.0"
+									}
+								}
+							}
+						},
+						"pump": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+							"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+							"dev": true,
+							"requires": {
+								"end-of-stream": "^1.1.0",
+								"once": "^1.3.1"
+							}
+						},
+						"ssri": {
+							"version": "5.3.0",
+							"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+							"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+							"dev": true,
+							"requires": {
+								"safe-buffer": "^5.1.1"
+							}
+						}
+					}
+				},
 				"mem": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 					"dev": true,
 					"requires": {
@@ -12755,13 +12375,13 @@
 				},
 				"mimic-fn": {
 					"version": "1.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
 					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
 					"dev": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
 					"requires": {
@@ -12770,13 +12390,31 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
+				"mississippi": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.1.tgz",
+					"integrity": "sha512-/6rB8YXFbAtsUVRphIRQqB0+9c7VaPHCjVtvto+JqwVxgz8Zz+I+f68/JgQ+Pb4VlZb2svA9OtdXnHHsZz7ltg==",
+					"dev": true,
+					"requires": {
+						"concat-stream": "^1.5.0",
+						"duplexify": "^3.4.2",
+						"end-of-stream": "^1.1.0",
+						"flush-write-stream": "^1.0.0",
+						"from2": "^2.1.0",
+						"parallel-transform": "^1.1.0",
+						"pump": "^1.0.0",
+						"pumpify": "^1.3.3",
+						"stream-each": "^1.1.0",
+						"through2": "^2.0.0"
+					}
+				},
 				"npm": {
 					"version": "5.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/npm/-/npm-5.1.0.tgz",
 					"integrity": "sha512-pt5ClxEmY/dLpb60SmGQQBKi3nB6Ljx1FXmpoCUdAULlGqGVn2uCyXxPCWFbcuHGthT7qGiaGa1wOfs/UjGYMw==",
 					"dev": true,
 					"requires": {
@@ -12880,7 +12518,7 @@
 					"dependencies": {
 						"JSONStream": {
 							"version": "1.3.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
 							"integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
 							"dev": true,
 							"requires": {
@@ -12890,13 +12528,13 @@
 							"dependencies": {
 								"jsonparse": {
 									"version": "1.3.1",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
 									"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
 									"dev": true
 								},
 								"through": {
 									"version": "2.3.8",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 									"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 									"dev": true
 								}
@@ -12904,114 +12542,61 @@
 						},
 						"abbrev": {
 							"version": "1.1.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
 							"integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
 							"dev": true
 						},
 						"ansi-regex": {
 							"version": "3.0.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 							"dev": true
 						},
 						"ansicolors": {
 							"version": "0.3.2",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
 							"integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
 							"dev": true
 						},
 						"ansistyles": {
 							"version": "0.1.3",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
 							"integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
 							"dev": true
 						},
 						"aproba": {
 							"version": "1.1.2",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
 							"integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
 							"dev": true
 						},
 						"archy": {
 							"version": "1.0.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
 							"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
 							"dev": true
 						},
 						"bluebird": {
 							"version": "3.5.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
 							"integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
 							"dev": true
 						},
-						"cacache": {
-							"version": "9.2.9",
-							"resolved": false,
-							"integrity": "sha512-ghg1j5OyTJ6qsrqU++dN23QiTDxb5AZCFGsF3oB+v9v/gY+F4X8L/0gdQMEjd+8Ot3D29M2etX5PKozHRn2JQw==",
-							"dev": true,
-							"requires": {
-								"bluebird": "^3.5.0",
-								"chownr": "^1.0.1",
-								"glob": "^7.1.2",
-								"graceful-fs": "^4.1.11",
-								"lru-cache": "^4.1.1",
-								"mississippi": "^1.3.0",
-								"mkdirp": "^0.5.1",
-								"move-concurrently": "^1.0.1",
-								"promise-inflight": "^1.0.1",
-								"rimraf": "^2.6.1",
-								"ssri": "^4.1.6",
-								"unique-filename": "^1.1.0",
-								"y18n": "^3.2.1"
-							},
-							"dependencies": {
-								"lru-cache": {
-									"version": "4.1.1",
-									"resolved": false,
-									"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-									"dev": true,
-									"requires": {
-										"pseudomap": "^1.0.2",
-										"yallist": "^2.1.2"
-									},
-									"dependencies": {
-										"pseudomap": {
-											"version": "1.0.2",
-											"resolved": false,
-											"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-											"dev": true
-										},
-										"yallist": {
-											"version": "2.1.2",
-											"resolved": false,
-											"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-											"dev": true
-										}
-									}
-								},
-								"y18n": {
-									"version": "3.2.1",
-									"resolved": false,
-									"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-									"dev": true
-								}
-							}
-						},
 						"call-limit": {
 							"version": "1.1.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.0.tgz",
 							"integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o=",
 							"dev": true
 						},
 						"chownr": {
 							"version": "1.0.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
 							"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
 							"dev": true
 						},
 						"cmd-shim": {
 							"version": "2.0.2",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
 							"integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
 							"dev": true,
 							"requires": {
@@ -13021,7 +12606,7 @@
 						},
 						"columnify": {
 							"version": "1.5.4",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
 							"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
 							"dev": true,
 							"requires": {
@@ -13031,7 +12616,7 @@
 							"dependencies": {
 								"strip-ansi": {
 									"version": "3.0.1",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 									"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 									"dev": true,
 									"requires": {
@@ -13040,7 +12625,7 @@
 									"dependencies": {
 										"ansi-regex": {
 											"version": "2.1.1",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 											"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 											"dev": true
 										}
@@ -13048,7 +12633,7 @@
 								},
 								"wcwidth": {
 									"version": "1.0.1",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
 									"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
 									"dev": true,
 									"requires": {
@@ -13057,7 +12642,7 @@
 									"dependencies": {
 										"defaults": {
 											"version": "1.0.3",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
 											"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
 											"dev": true,
 											"requires": {
@@ -13066,7 +12651,7 @@
 											"dependencies": {
 												"clone": {
 													"version": "1.0.2",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
 													"integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
 													"dev": true
 												}
@@ -13078,7 +12663,7 @@
 						},
 						"config-chain": {
 							"version": "1.1.11",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
 							"integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
 							"dev": true,
 							"requires": {
@@ -13088,7 +12673,7 @@
 							"dependencies": {
 								"proto-list": {
 									"version": "1.2.4",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
 									"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
 									"dev": true
 								}
@@ -13096,19 +12681,25 @@
 						},
 						"debuglog": {
 							"version": "1.0.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
 							"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+							"dev": true
+						},
+						"deep-extend": {
+							"version": "0.6.0",
+							"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+							"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 							"dev": true
 						},
 						"detect-indent": {
 							"version": "5.0.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
 							"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
 							"dev": true
 						},
 						"dezalgo": {
 							"version": "1.0.3",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
 							"integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
 							"dev": true,
 							"requires": {
@@ -13118,7 +12709,7 @@
 							"dependencies": {
 								"asap": {
 									"version": "2.0.5",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
 									"integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8=",
 									"dev": true
 								}
@@ -13126,13 +12717,13 @@
 						},
 						"editor": {
 							"version": "1.0.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
 							"integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
 							"dev": true
 						},
 						"fs-vacuum": {
 							"version": "1.2.10",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
 							"integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
 							"dev": true,
 							"requires": {
@@ -13143,7 +12734,7 @@
 						},
 						"fs-write-stream-atomic": {
 							"version": "1.0.10",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
 							"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
 							"dev": true,
 							"requires": {
@@ -13155,7 +12746,7 @@
 						},
 						"fstream": {
 							"version": "1.0.11",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
 							"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 							"dev": true,
 							"requires": {
@@ -13167,7 +12758,7 @@
 						},
 						"fstream-npm": {
 							"version": "1.2.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.1.tgz",
 							"integrity": "sha512-iBHpm/LmD1qw0TlHMAqVd9rwdU6M+EHRUnPkXpRi5G/Hf0FIFH+oZFryodAU2MFNfGRh/CzhUFlMKV3pdeOTDw==",
 							"dev": true,
 							"requires": {
@@ -13177,7 +12768,7 @@
 							"dependencies": {
 								"fstream-ignore": {
 									"version": "1.0.5",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
 									"integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
 									"dev": true,
 									"requires": {
@@ -13188,7 +12779,7 @@
 									"dependencies": {
 										"minimatch": {
 											"version": "3.0.4",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 											"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 											"dev": true,
 											"requires": {
@@ -13197,7 +12788,7 @@
 											"dependencies": {
 												"brace-expansion": {
 													"version": "1.1.8",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 													"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
 													"dev": true,
 													"requires": {
@@ -13207,13 +12798,13 @@
 													"dependencies": {
 														"balanced-match": {
 															"version": "1.0.0",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 															"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 															"dev": true
 														},
 														"concat-map": {
 															"version": "0.0.1",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 															"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 															"dev": true
 														}
@@ -13227,7 +12818,7 @@
 						},
 						"glob": {
 							"version": "7.1.2",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 							"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 							"dev": true,
 							"requires": {
@@ -13241,13 +12832,13 @@
 							"dependencies": {
 								"fs.realpath": {
 									"version": "1.0.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 									"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 									"dev": true
 								},
 								"minimatch": {
 									"version": "3.0.4",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 									"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 									"dev": true,
 									"requires": {
@@ -13256,7 +12847,7 @@
 									"dependencies": {
 										"brace-expansion": {
 											"version": "1.1.8",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 											"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
 											"dev": true,
 											"requires": {
@@ -13266,13 +12857,13 @@
 											"dependencies": {
 												"balanced-match": {
 													"version": "1.0.0",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 													"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 													"dev": true
 												},
 												"concat-map": {
 													"version": "0.0.1",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 													"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 													"dev": true
 												}
@@ -13282,7 +12873,7 @@
 								},
 								"path-is-absolute": {
 									"version": "1.0.1",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 									"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 									"dev": true
 								}
@@ -13290,37 +12881,37 @@
 						},
 						"graceful-fs": {
 							"version": "4.1.11",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
 							"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
 							"dev": true
 						},
 						"has-unicode": {
 							"version": "2.0.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 							"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 							"dev": true
 						},
 						"hosted-git-info": {
 							"version": "2.5.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
 							"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
 							"dev": true
 						},
 						"iferr": {
 							"version": "0.1.5",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
 							"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
 							"dev": true
 						},
 						"imurmurhash": {
 							"version": "0.1.4",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 							"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
 							"dev": true
 						},
 						"inflight": {
 							"version": "1.0.6",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 							"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 							"dev": true,
 							"requires": {
@@ -13330,19 +12921,19 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 							"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 							"dev": true
 						},
 						"ini": {
 							"version": "1.3.4",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
 							"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
 							"dev": true
 						},
 						"init-package-json": {
 							"version": "1.10.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.1.tgz",
 							"integrity": "sha1-zYc6FneWvvuZYSsodioLY5P9j2o=",
 							"dev": true,
 							"requires": {
@@ -13358,7 +12949,7 @@
 							"dependencies": {
 								"promzard": {
 									"version": "0.3.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
 									"integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
 									"dev": true,
 									"requires": {
@@ -13369,25 +12960,25 @@
 						},
 						"lazy-property": {
 							"version": "1.0.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
 							"integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
 							"dev": true
 						},
 						"lockfile": {
 							"version": "1.0.3",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
 							"integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k=",
 							"dev": true
 						},
 						"lodash._baseindexof": {
 							"version": "3.1.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
 							"integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
 							"dev": true
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
 							"integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
 							"dev": true,
 							"requires": {
@@ -13397,13 +12988,13 @@
 							"dependencies": {
 								"lodash._createset": {
 									"version": "4.0.3",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
 									"integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
 									"dev": true
 								},
 								"lodash._root": {
 									"version": "3.0.1",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
 									"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
 									"dev": true
 								}
@@ -13411,19 +13002,19 @@
 						},
 						"lodash._bindcallback": {
 							"version": "3.0.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
 							"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
 							"dev": true
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
 							"integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
 							"dev": true
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
 							"integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
 							"dev": true,
 							"requires": {
@@ -13432,43 +13023,43 @@
 						},
 						"lodash._getnative": {
 							"version": "3.9.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
 							"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
 							"dev": true
 						},
 						"lodash.clonedeep": {
 							"version": "4.5.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
 							"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
 							"dev": true
 						},
 						"lodash.restparam": {
 							"version": "3.6.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
 							"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
 							"dev": true
 						},
 						"lodash.union": {
 							"version": "4.6.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
 							"integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
 							"dev": true
 						},
 						"lodash.uniq": {
 							"version": "4.5.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 							"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
 							"dev": true
 						},
 						"lodash.without": {
 							"version": "4.4.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
 							"integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
 							"dev": true
 						},
 						"lru-cache": {
 							"version": "4.1.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
 							"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
 							"dev": true,
 							"requires": {
@@ -13478,13 +13069,13 @@
 							"dependencies": {
 								"pseudomap": {
 									"version": "1.0.2",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
 									"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
 									"dev": true
 								},
 								"yallist": {
 									"version": "2.1.2",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
 									"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
 									"dev": true
 								}
@@ -13492,7 +13083,7 @@
 						},
 						"mississippi": {
 							"version": "1.3.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
 							"integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
 							"dev": true,
 							"requires": {
@@ -13510,7 +13101,7 @@
 							"dependencies": {
 								"concat-stream": {
 									"version": "1.6.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
 									"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
 									"dev": true,
 									"requires": {
@@ -13521,7 +13112,7 @@
 									"dependencies": {
 										"typedarray": {
 											"version": "0.0.6",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 											"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 											"dev": true
 										}
@@ -13529,7 +13120,7 @@
 								},
 								"duplexify": {
 									"version": "3.5.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
 									"integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
 									"dev": true,
 									"requires": {
@@ -13541,7 +13132,7 @@
 									"dependencies": {
 										"end-of-stream": {
 											"version": "1.0.0",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
 											"integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
 											"dev": true,
 											"requires": {
@@ -13550,7 +13141,7 @@
 											"dependencies": {
 												"once": {
 													"version": "1.3.3",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
 													"integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
 													"dev": true,
 													"requires": {
@@ -13561,7 +13152,7 @@
 										},
 										"stream-shift": {
 											"version": "1.0.0",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
 											"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
 											"dev": true
 										}
@@ -13569,7 +13160,7 @@
 								},
 								"end-of-stream": {
 									"version": "1.4.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
 									"integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
 									"dev": true,
 									"requires": {
@@ -13578,7 +13169,7 @@
 								},
 								"flush-write-stream": {
 									"version": "1.0.2",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
 									"integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
 									"dev": true,
 									"requires": {
@@ -13588,7 +13179,7 @@
 								},
 								"from2": {
 									"version": "2.3.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
 									"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
 									"dev": true,
 									"requires": {
@@ -13598,7 +13189,7 @@
 								},
 								"parallel-transform": {
 									"version": "1.1.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
 									"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
 									"dev": true,
 									"requires": {
@@ -13609,7 +13200,7 @@
 									"dependencies": {
 										"cyclist": {
 											"version": "0.2.2",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
 											"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
 											"dev": true
 										}
@@ -13617,7 +13208,7 @@
 								},
 								"pump": {
 									"version": "1.0.2",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
 									"integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
 									"dev": true,
 									"requires": {
@@ -13627,7 +13218,7 @@
 								},
 								"pumpify": {
 									"version": "1.3.5",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
 									"integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
 									"dev": true,
 									"requires": {
@@ -13638,7 +13229,7 @@
 								},
 								"stream-each": {
 									"version": "1.2.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.0.tgz",
 									"integrity": "sha1-HpXUdXP1gNgU3A/4zQ9m8c5TyZE=",
 									"dev": true,
 									"requires": {
@@ -13648,7 +13239,7 @@
 									"dependencies": {
 										"stream-shift": {
 											"version": "1.0.0",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
 											"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
 											"dev": true
 										}
@@ -13656,7 +13247,7 @@
 								},
 								"through2": {
 									"version": "2.0.3",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 									"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 									"dev": true,
 									"requires": {
@@ -13666,7 +13257,7 @@
 									"dependencies": {
 										"xtend": {
 											"version": "4.0.1",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 											"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
 											"dev": true
 										}
@@ -13676,7 +13267,7 @@
 						},
 						"mkdirp": {
 							"version": "0.5.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 							"dev": true,
 							"requires": {
@@ -13685,7 +13276,7 @@
 							"dependencies": {
 								"minimist": {
 									"version": "0.0.8",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 									"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 									"dev": true
 								}
@@ -13693,7 +13284,7 @@
 						},
 						"move-concurrently": {
 							"version": "1.0.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
 							"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
 							"dev": true,
 							"requires": {
@@ -13707,7 +13298,7 @@
 							"dependencies": {
 								"copy-concurrently": {
 									"version": "1.0.3",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.3.tgz",
 									"integrity": "sha1-Rft4ZiSaHKiJqlcI5svSc+dbslA=",
 									"dev": true,
 									"requires": {
@@ -13721,7 +13312,7 @@
 								},
 								"run-queue": {
 									"version": "1.0.3",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
 									"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
 									"dev": true,
 									"requires": {
@@ -13732,7 +13323,7 @@
 						},
 						"node-gyp": {
 							"version": "3.6.2",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
 							"integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
 							"dev": true,
 							"requires": {
@@ -13753,7 +13344,7 @@
 							"dependencies": {
 								"minimatch": {
 									"version": "3.0.4",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 									"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 									"dev": true,
 									"requires": {
@@ -13762,7 +13353,7 @@
 									"dependencies": {
 										"brace-expansion": {
 											"version": "1.1.8",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 											"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
 											"dev": true,
 											"requires": {
@@ -13772,13 +13363,13 @@
 											"dependencies": {
 												"balanced-match": {
 													"version": "1.0.0",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 													"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 													"dev": true
 												},
 												"concat-map": {
 													"version": "0.0.1",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 													"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 													"dev": true
 												}
@@ -13788,7 +13379,7 @@
 								},
 								"nopt": {
 									"version": "3.0.6",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 									"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
 									"dev": true,
 									"requires": {
@@ -13799,7 +13390,7 @@
 						},
 						"nopt": {
 							"version": "4.0.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
 							"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 							"dev": true,
 							"requires": {
@@ -13809,7 +13400,7 @@
 						},
 						"normalize-package-data": {
 							"version": "2.4.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 							"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 							"dev": true,
 							"requires": {
@@ -13821,7 +13412,7 @@
 							"dependencies": {
 								"is-builtin-module": {
 									"version": "1.0.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 									"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 									"dev": true,
 									"requires": {
@@ -13830,7 +13421,7 @@
 									"dependencies": {
 										"builtin-modules": {
 											"version": "1.1.1",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
 											"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
 											"dev": true
 										}
@@ -13840,13 +13431,13 @@
 						},
 						"npm-cache-filename": {
 							"version": "1.0.2",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
 							"integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
 							"dev": true
 						},
 						"npm-install-checks": {
 							"version": "3.0.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
 							"integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
 							"dev": true,
 							"requires": {
@@ -13855,7 +13446,7 @@
 						},
 						"npm-package-arg": {
 							"version": "5.1.2",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
 							"integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
 							"dev": true,
 							"requires": {
@@ -13867,7 +13458,7 @@
 						},
 						"npm-registry-client": {
 							"version": "8.4.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.4.0.tgz",
 							"integrity": "sha512-PVNfqq0lyRdFnE//nDmn3CC9uqTsr8Bya9KPLIevlXMfkP0m4RpCVyFFk0W1Gfx436kKwyhLA6J+lV+rgR81gQ==",
 							"dev": true,
 							"requires": {
@@ -13886,7 +13477,7 @@
 							"dependencies": {
 								"concat-stream": {
 									"version": "1.6.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
 									"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
 									"dev": true,
 									"requires": {
@@ -13897,7 +13488,7 @@
 									"dependencies": {
 										"typedarray": {
 											"version": "0.0.6",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 											"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 											"dev": true
 										}
@@ -13907,13 +13498,13 @@
 						},
 						"npm-user-validate": {
 							"version": "1.0.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.0.tgz",
 							"integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
 							"dev": true
 						},
 						"npmlog": {
 							"version": "4.1.2",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 							"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 							"dev": true,
 							"requires": {
@@ -13925,7 +13516,7 @@
 							"dependencies": {
 								"are-we-there-yet": {
 									"version": "1.1.4",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
 									"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 									"dev": true,
 									"requires": {
@@ -13935,7 +13526,7 @@
 									"dependencies": {
 										"delegates": {
 											"version": "1.0.0",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 											"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 											"dev": true
 										}
@@ -13943,13 +13534,13 @@
 								},
 								"console-control-strings": {
 									"version": "1.1.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 									"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 									"dev": true
 								},
 								"gauge": {
 									"version": "2.7.4",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 									"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 									"dev": true,
 									"requires": {
@@ -13965,19 +13556,19 @@
 									"dependencies": {
 										"object-assign": {
 											"version": "4.1.1",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 											"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 											"dev": true
 										},
 										"signal-exit": {
 											"version": "3.0.2",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 											"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 											"dev": true
 										},
 										"string-width": {
 											"version": "1.0.2",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 											"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 											"dev": true,
 											"requires": {
@@ -13988,13 +13579,13 @@
 											"dependencies": {
 												"code-point-at": {
 													"version": "1.1.0",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 													"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 													"dev": true
 												},
 												"is-fullwidth-code-point": {
 													"version": "1.0.0",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 													"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 													"dev": true,
 													"requires": {
@@ -14003,7 +13594,7 @@
 													"dependencies": {
 														"number-is-nan": {
 															"version": "1.0.1",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 															"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 															"dev": true
 														}
@@ -14013,7 +13604,7 @@
 										},
 										"strip-ansi": {
 											"version": "3.0.1",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 											"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 											"dev": true,
 											"requires": {
@@ -14022,7 +13613,7 @@
 											"dependencies": {
 												"ansi-regex": {
 													"version": "2.1.1",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 													"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 													"dev": true
 												}
@@ -14030,7 +13621,7 @@
 										},
 										"wide-align": {
 											"version": "1.1.2",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
 											"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 											"dev": true,
 											"requires": {
@@ -14041,7 +13632,7 @@
 								},
 								"set-blocking": {
 									"version": "2.0.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 									"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 									"dev": true
 								}
@@ -14049,7 +13640,7 @@
 						},
 						"once": {
 							"version": "1.4.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 							"dev": true,
 							"requires": {
@@ -14058,13 +13649,13 @@
 						},
 						"opener": {
 							"version": "1.4.3",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
 							"integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
 							"dev": true
 						},
 						"osenv": {
 							"version": "0.1.4",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
 							"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
 							"dev": true,
 							"requires": {
@@ -14074,13 +13665,13 @@
 							"dependencies": {
 								"os-homedir": {
 									"version": "1.0.2",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 									"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 									"dev": true
 								},
 								"os-tmpdir": {
 									"version": "1.0.2",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 									"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 									"dev": true
 								}
@@ -14088,7 +13679,7 @@
 						},
 						"pacote": {
 							"version": "2.7.38",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/pacote/-/pacote-2.7.38.tgz",
 							"integrity": "sha512-XxHUyHQB7QCVBxoXeVu0yKxT+2PvJucsc0+1E+6f95lMUxEAYERgSAc71ckYXrYr35Ew3xFU/LrhdIK21GQFFA==",
 							"dev": true,
 							"requires": {
@@ -14115,289 +13706,9 @@
 								"which": "^1.2.12"
 							},
 							"dependencies": {
-								"make-fetch-happen": {
-									"version": "2.4.13",
-									"resolved": false,
-									"integrity": "sha512-73CsTlMRSLdGr7VvOE8iYl/ejOSIxyfRYg7jZhepGGEqIlgdq6FLe2DEAI5bo813Jdg5fS/Ku62SRQ/UpT6NJA==",
-									"dev": true,
-									"requires": {
-										"agentkeepalive": "^3.3.0",
-										"cacache": "^9.2.9",
-										"http-cache-semantics": "^3.7.3",
-										"http-proxy-agent": "^2.0.0",
-										"https-proxy-agent": "^2.0.0",
-										"lru-cache": "^4.1.1",
-										"mississippi": "^1.2.0",
-										"node-fetch-npm": "^2.0.1",
-										"promise-retry": "^1.1.1",
-										"socks-proxy-agent": "^3.0.0",
-										"ssri": "^4.1.6"
-									},
-									"dependencies": {
-										"agentkeepalive": {
-											"version": "3.3.0",
-											"resolved": false,
-											"integrity": "sha512-9yhcpXti2ZQE7bxuCsjjWNIZoQOd9sZ1ZBovHG0YeCRohFv73SLvcm73PC9T3olM4GyozaQb+4MGdQpcD8m7NQ==",
-											"dev": true,
-											"requires": {
-												"humanize-ms": "^1.2.1"
-											},
-											"dependencies": {
-												"humanize-ms": {
-													"version": "1.2.1",
-													"resolved": false,
-													"integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
-													"dev": true,
-													"requires": {
-														"ms": "^2.0.0"
-													},
-													"dependencies": {
-														"ms": {
-															"version": "2.0.0",
-															"resolved": false,
-															"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-															"dev": true
-														}
-													}
-												}
-											}
-										},
-										"http-cache-semantics": {
-											"version": "3.7.3",
-											"resolved": false,
-											"integrity": "sha1-LzXFMuzSnx5UE7mvgztySjxvf3I=",
-											"dev": true
-										},
-										"http-proxy-agent": {
-											"version": "2.0.0",
-											"resolved": false,
-											"integrity": "sha1-RkgqLwUjpNYIJVFwn0acs+SoX/Q=",
-											"dev": true,
-											"requires": {
-												"agent-base": "4",
-												"debug": "2"
-											},
-											"dependencies": {
-												"agent-base": {
-													"version": "4.1.0",
-													"resolved": false,
-													"integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
-													"dev": true,
-													"requires": {
-														"es6-promisify": "^5.0.0"
-													},
-													"dependencies": {
-														"es6-promisify": {
-															"version": "5.0.0",
-															"resolved": false,
-															"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-															"dev": true,
-															"requires": {
-																"es6-promise": "^4.0.3"
-															},
-															"dependencies": {
-																"es6-promise": {
-																	"version": "4.1.1",
-																	"resolved": false,
-																	"integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
-																	"dev": true
-																}
-															}
-														}
-													}
-												},
-												"debug": {
-													"version": "2.6.8",
-													"resolved": false,
-													"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-													"dev": true,
-													"requires": {
-														"ms": "2.0.0"
-													},
-													"dependencies": {
-														"ms": {
-															"version": "2.0.0",
-															"resolved": false,
-															"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-															"dev": true
-														}
-													}
-												}
-											}
-										},
-										"https-proxy-agent": {
-											"version": "2.0.0",
-											"resolved": false,
-											"integrity": "sha1-/6pLb69YasNAwYoUBDHna31/KUQ=",
-											"dev": true,
-											"requires": {
-												"agent-base": "^4.1.0",
-												"debug": "^2.4.1"
-											},
-											"dependencies": {
-												"agent-base": {
-													"version": "4.1.0",
-													"resolved": false,
-													"integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
-													"dev": true,
-													"requires": {
-														"es6-promisify": "^5.0.0"
-													},
-													"dependencies": {
-														"es6-promisify": {
-															"version": "5.0.0",
-															"resolved": false,
-															"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-															"dev": true,
-															"requires": {
-																"es6-promise": "^4.0.3"
-															},
-															"dependencies": {
-																"es6-promise": {
-																	"version": "4.1.1",
-																	"resolved": false,
-																	"integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
-																	"dev": true
-																}
-															}
-														}
-													}
-												},
-												"debug": {
-													"version": "2.6.8",
-													"resolved": false,
-													"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-													"dev": true,
-													"requires": {
-														"ms": "2.0.0"
-													},
-													"dependencies": {
-														"ms": {
-															"version": "2.0.0",
-															"resolved": false,
-															"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-															"dev": true
-														}
-													}
-												}
-											}
-										},
-										"node-fetch-npm": {
-											"version": "2.0.1",
-											"resolved": false,
-											"integrity": "sha512-W3onhopST5tqpX0/MGSL47pDQLLKobNR83AvkiOWQKaw54h+uYUfzeLAxCiyhWlUOiuI+GIb4O9ojLaAFlhCCA==",
-											"dev": true,
-											"requires": {
-												"encoding": "^0.1.11",
-												"json-parse-helpfulerror": "^1.0.3",
-												"safe-buffer": "^5.0.1"
-											},
-											"dependencies": {
-												"encoding": {
-													"version": "0.1.12",
-													"resolved": false,
-													"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-													"dev": true,
-													"requires": {
-														"iconv-lite": "~0.4.13"
-													},
-													"dependencies": {
-														"iconv-lite": {
-															"version": "0.4.18",
-															"resolved": false,
-															"integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
-															"dev": true
-														}
-													}
-												},
-												"json-parse-helpfulerror": {
-													"version": "1.0.3",
-													"resolved": false,
-													"integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
-													"dev": true,
-													"requires": {
-														"jju": "^1.1.0"
-													},
-													"dependencies": {
-														"jju": {
-															"version": "1.3.0",
-															"resolved": false,
-															"integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
-															"dev": true
-														}
-													}
-												}
-											}
-										},
-										"socks-proxy-agent": {
-											"version": "3.0.0",
-											"resolved": false,
-											"integrity": "sha512-YJcT+SNNBgFoK/NpO20PChz0VnBOhkjG3X10BwlrYujd0NZlSsH1jbxSQ1S0njt3sOvzwQ2PvGqqUIvP4rNk/w==",
-											"dev": true,
-											"requires": {
-												"agent-base": "^4.0.1",
-												"socks": "^1.1.10"
-											},
-											"dependencies": {
-												"agent-base": {
-													"version": "4.1.0",
-													"resolved": false,
-													"integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
-													"dev": true,
-													"requires": {
-														"es6-promisify": "^5.0.0"
-													},
-													"dependencies": {
-														"es6-promisify": {
-															"version": "5.0.0",
-															"resolved": false,
-															"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-															"dev": true,
-															"requires": {
-																"es6-promise": "^4.0.3"
-															},
-															"dependencies": {
-																"es6-promise": {
-																	"version": "4.1.1",
-																	"resolved": false,
-																	"integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
-																	"dev": true
-																}
-															}
-														}
-													}
-												},
-												"socks": {
-													"version": "1.1.10",
-													"resolved": false,
-													"integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
-													"dev": true,
-													"requires": {
-														"ip": "^1.1.4",
-														"smart-buffer": "^1.0.13"
-													},
-													"dependencies": {
-														"ip": {
-															"version": "1.1.5",
-															"resolved": false,
-															"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-															"dev": true
-														},
-														"smart-buffer": {
-															"version": "1.1.15",
-															"resolved": false,
-															"integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
-															"dev": true
-														}
-													}
-												}
-											}
-										}
-									}
-								},
 								"minimatch": {
 									"version": "3.0.4",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 									"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 									"dev": true,
 									"requires": {
@@ -14406,7 +13717,7 @@
 									"dependencies": {
 										"brace-expansion": {
 											"version": "1.1.8",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 											"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
 											"dev": true,
 											"requires": {
@@ -14416,13 +13727,13 @@
 											"dependencies": {
 												"balanced-match": {
 													"version": "1.0.0",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 													"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 													"dev": true
 												},
 												"concat-map": {
 													"version": "0.0.1",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 													"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 													"dev": true
 												}
@@ -14432,7 +13743,7 @@
 								},
 								"npm-pick-manifest": {
 									"version": "1.0.4",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-1.0.4.tgz",
 									"integrity": "sha512-MKxNdeyOZysPRTTbHtW0M5Fw38Jo/3ARsoGw5qjCfS+XGjvNB/Gb4qtAZUFmKPM2mVum+eX559eHvKywU856BQ==",
 									"dev": true,
 									"requires": {
@@ -14442,7 +13753,7 @@
 								},
 								"promise-retry": {
 									"version": "1.1.1",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
 									"integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
 									"dev": true,
 									"requires": {
@@ -14452,7 +13763,7 @@
 									"dependencies": {
 										"err-code": {
 											"version": "1.1.2",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
 											"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
 											"dev": true
 										}
@@ -14460,7 +13771,7 @@
 								},
 								"protoduck": {
 									"version": "4.0.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/protoduck/-/protoduck-4.0.0.tgz",
 									"integrity": "sha1-/kh02MeRM2bP2erRJFOiLNNlf44=",
 									"dev": true,
 									"requires": {
@@ -14469,7 +13780,7 @@
 									"dependencies": {
 										"genfun": {
 											"version": "4.0.1",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/genfun/-/genfun-4.0.1.tgz",
 											"integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E=",
 											"dev": true
 										}
@@ -14477,7 +13788,7 @@
 								},
 								"tar-fs": {
 									"version": "1.15.3",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.3.tgz",
 									"integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
 									"dev": true,
 									"requires": {
@@ -14489,7 +13800,7 @@
 									"dependencies": {
 										"pump": {
 											"version": "1.0.2",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
 											"integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
 											"dev": true,
 											"requires": {
@@ -14499,7 +13810,7 @@
 											"dependencies": {
 												"end-of-stream": {
 													"version": "1.4.0",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
 													"integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
 													"dev": true,
 													"requires": {
@@ -14512,7 +13823,7 @@
 								},
 								"tar-stream": {
 									"version": "1.5.4",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
 									"integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
 									"dev": true,
 									"requires": {
@@ -14524,7 +13835,7 @@
 									"dependencies": {
 										"bl": {
 											"version": "1.2.1",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
 											"integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
 											"dev": true,
 											"requires": {
@@ -14533,7 +13844,7 @@
 										},
 										"end-of-stream": {
 											"version": "1.4.0",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
 											"integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
 											"dev": true,
 											"requires": {
@@ -14542,7 +13853,7 @@
 										},
 										"xtend": {
 											"version": "4.0.1",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 											"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
 											"dev": true
 										}
@@ -14552,19 +13863,31 @@
 						},
 						"path-is-inside": {
 							"version": "1.0.2",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
 							"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
 							"dev": true
 						},
 						"promise-inflight": {
 							"version": "1.0.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
 							"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
 							"dev": true
 						},
+						"rc": {
+							"version": "1.2.8",
+							"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+							"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+							"dev": true,
+							"requires": {
+								"deep-extend": "^0.6.0",
+								"ini": "~1.3.0",
+								"minimist": "^1.2.0",
+								"strip-json-comments": "~2.0.1"
+							}
+						},
 						"read": {
 							"version": "1.0.7",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
 							"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
 							"dev": true,
 							"requires": {
@@ -14573,7 +13896,7 @@
 							"dependencies": {
 								"mute-stream": {
 									"version": "0.0.7",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
 									"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
 									"dev": true
 								}
@@ -14581,7 +13904,7 @@
 						},
 						"read-cmd-shim": {
 							"version": "1.0.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
 							"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
 							"dev": true,
 							"requires": {
@@ -14590,7 +13913,7 @@
 						},
 						"read-installed": {
 							"version": "4.0.3",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
 							"integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
 							"dev": true,
 							"requires": {
@@ -14605,7 +13928,7 @@
 							"dependencies": {
 								"util-extend": {
 									"version": "1.0.3",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
 									"integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
 									"dev": true
 								}
@@ -14613,7 +13936,7 @@
 						},
 						"read-package-json": {
 							"version": "2.0.9",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.9.tgz",
 							"integrity": "sha512-vuV8p921IgyelL4UOKv3FsRuRZSaRn30HanLAOKargsr8TbBEq+I3MgloSRXYuKhNdYP1wlEGilMWAIayA2RFg==",
 							"dev": true,
 							"requires": {
@@ -14625,7 +13948,7 @@
 							"dependencies": {
 								"json-parse-helpfulerror": {
 									"version": "1.0.3",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
 									"integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
 									"dev": true,
 									"requires": {
@@ -14634,7 +13957,7 @@
 									"dependencies": {
 										"jju": {
 											"version": "1.3.0",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
 											"integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
 											"dev": true
 										}
@@ -14644,7 +13967,7 @@
 						},
 						"read-package-tree": {
 							"version": "5.1.6",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.6.tgz",
 							"integrity": "sha512-FCX1aT3GWyY658wzDICef4p+n0dB+ENRct8E/Qyvppj6xVpOYerBHfUu7OP5Rt1/393Tdglguf5ju5DEX4wZNg==",
 							"dev": true,
 							"requires": {
@@ -14657,7 +13980,7 @@
 						},
 						"readable-stream": {
 							"version": "2.3.2",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
 							"integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
 							"dev": true,
 							"requires": {
@@ -14672,25 +13995,25 @@
 							"dependencies": {
 								"core-util-is": {
 									"version": "1.0.2",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 									"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 									"dev": true
 								},
 								"isarray": {
 									"version": "1.0.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 									"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 									"dev": true
 								},
 								"process-nextick-args": {
 									"version": "1.0.7",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
 									"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
 									"dev": true
 								},
 								"string_decoder": {
 									"version": "1.0.3",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 									"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
 									"dev": true,
 									"requires": {
@@ -14699,7 +14022,7 @@
 								},
 								"util-deprecate": {
 									"version": "1.0.2",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 									"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 									"dev": true
 								}
@@ -14707,7 +14030,7 @@
 						},
 						"readdir-scoped-modules": {
 							"version": "1.0.2",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
 							"integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
 							"dev": true,
 							"requires": {
@@ -14717,440 +14040,15 @@
 								"once": "^1.3.0"
 							}
 						},
-						"request": {
-							"version": "2.81.0",
-							"resolved": false,
-							"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-							"dev": true,
-							"requires": {
-								"aws-sign2": "~0.6.0",
-								"aws4": "^1.2.1",
-								"caseless": "~0.12.0",
-								"combined-stream": "~1.0.5",
-								"extend": "~3.0.0",
-								"forever-agent": "~0.6.1",
-								"form-data": "~2.1.1",
-								"har-validator": "~4.2.1",
-								"hawk": "~3.1.3",
-								"http-signature": "~1.1.0",
-								"is-typedarray": "~1.0.0",
-								"isstream": "~0.1.2",
-								"json-stringify-safe": "~5.0.1",
-								"mime-types": "~2.1.7",
-								"oauth-sign": "~0.8.1",
-								"performance-now": "^0.2.0",
-								"qs": "~6.4.0",
-								"safe-buffer": "^5.0.1",
-								"stringstream": "~0.0.4",
-								"tough-cookie": "~2.3.0",
-								"tunnel-agent": "^0.6.0",
-								"uuid": "^3.0.0"
-							},
-							"dependencies": {
-								"aws-sign2": {
-									"version": "0.6.0",
-									"resolved": false,
-									"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-									"dev": true
-								},
-								"aws4": {
-									"version": "1.6.0",
-									"resolved": false,
-									"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-									"dev": true
-								},
-								"caseless": {
-									"version": "0.12.0",
-									"resolved": false,
-									"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-									"dev": true
-								},
-								"combined-stream": {
-									"version": "1.0.5",
-									"resolved": false,
-									"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-									"dev": true,
-									"requires": {
-										"delayed-stream": "~1.0.0"
-									},
-									"dependencies": {
-										"delayed-stream": {
-											"version": "1.0.0",
-											"resolved": false,
-											"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-											"dev": true
-										}
-									}
-								},
-								"extend": {
-									"version": "3.0.1",
-									"resolved": false,
-									"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-									"dev": true
-								},
-								"forever-agent": {
-									"version": "0.6.1",
-									"resolved": false,
-									"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-									"dev": true
-								},
-								"form-data": {
-									"version": "2.1.4",
-									"resolved": false,
-									"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-									"dev": true,
-									"requires": {
-										"asynckit": "^0.4.0",
-										"combined-stream": "^1.0.5",
-										"mime-types": "^2.1.12"
-									},
-									"dependencies": {
-										"asynckit": {
-											"version": "0.4.0",
-											"resolved": false,
-											"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-											"dev": true
-										}
-									}
-								},
-								"har-validator": {
-									"version": "4.2.1",
-									"resolved": false,
-									"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-									"dev": true,
-									"requires": {
-										"ajv": "^4.9.1",
-										"har-schema": "^1.0.5"
-									},
-									"dependencies": {
-										"ajv": {
-											"version": "4.11.8",
-											"resolved": false,
-											"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-											"dev": true,
-											"requires": {
-												"co": "^4.6.0",
-												"json-stable-stringify": "^1.0.1"
-											},
-											"dependencies": {
-												"co": {
-													"version": "4.6.0",
-													"resolved": false,
-													"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-													"dev": true
-												},
-												"json-stable-stringify": {
-													"version": "1.0.1",
-													"resolved": false,
-													"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-													"dev": true,
-													"requires": {
-														"jsonify": "~0.0.0"
-													},
-													"dependencies": {
-														"jsonify": {
-															"version": "0.0.0",
-															"resolved": false,
-															"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-															"dev": true
-														}
-													}
-												}
-											}
-										},
-										"har-schema": {
-											"version": "1.0.5",
-											"resolved": false,
-											"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-											"dev": true
-										}
-									}
-								},
-								"hawk": {
-									"version": "3.1.3",
-									"resolved": false,
-									"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-									"dev": true,
-									"requires": {
-										"boom": "2.x.x",
-										"cryptiles": "2.x.x",
-										"hoek": "2.x.x",
-										"sntp": "1.x.x"
-									},
-									"dependencies": {
-										"boom": {
-											"version": "2.10.1",
-											"resolved": false,
-											"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-											"dev": true,
-											"requires": {
-												"hoek": "2.x.x"
-											}
-										},
-										"cryptiles": {
-											"version": "2.0.5",
-											"resolved": false,
-											"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-											"dev": true,
-											"requires": {
-												"boom": "2.x.x"
-											}
-										},
-										"hoek": {
-											"version": "2.16.3",
-											"resolved": false,
-											"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-											"dev": true
-										},
-										"sntp": {
-											"version": "1.0.9",
-											"resolved": false,
-											"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-											"dev": true,
-											"requires": {
-												"hoek": "2.x.x"
-											}
-										}
-									}
-								},
-								"http-signature": {
-									"version": "1.1.1",
-									"resolved": false,
-									"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-									"dev": true,
-									"requires": {
-										"assert-plus": "^0.2.0",
-										"jsprim": "^1.2.2",
-										"sshpk": "^1.7.0"
-									},
-									"dependencies": {
-										"assert-plus": {
-											"version": "0.2.0",
-											"resolved": false,
-											"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-											"dev": true
-										},
-										"jsprim": {
-											"version": "1.4.0",
-											"resolved": false,
-											"integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-											"dev": true,
-											"requires": {
-												"assert-plus": "1.0.0",
-												"extsprintf": "1.0.2",
-												"json-schema": "0.2.3",
-												"verror": "1.3.6"
-											},
-											"dependencies": {
-												"assert-plus": {
-													"version": "1.0.0",
-													"resolved": false,
-													"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-													"dev": true
-												},
-												"extsprintf": {
-													"version": "1.0.2",
-													"resolved": false,
-													"integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-													"dev": true
-												},
-												"json-schema": {
-													"version": "0.2.3",
-													"resolved": false,
-													"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-													"dev": true
-												},
-												"verror": {
-													"version": "1.3.6",
-													"resolved": false,
-													"integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-													"dev": true,
-													"requires": {
-														"extsprintf": "1.0.2"
-													}
-												}
-											}
-										},
-										"sshpk": {
-											"version": "1.13.1",
-											"resolved": false,
-											"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-											"dev": true,
-											"requires": {
-												"asn1": "~0.2.3",
-												"assert-plus": "^1.0.0",
-												"bcrypt-pbkdf": "^1.0.0",
-												"dashdash": "^1.12.0",
-												"ecc-jsbn": "~0.1.1",
-												"getpass": "^0.1.1",
-												"jsbn": "~0.1.0",
-												"tweetnacl": "~0.14.0"
-											},
-											"dependencies": {
-												"asn1": {
-													"version": "0.2.3",
-													"resolved": false,
-													"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-													"dev": true
-												},
-												"assert-plus": {
-													"version": "1.0.0",
-													"resolved": false,
-													"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-													"dev": true
-												},
-												"bcrypt-pbkdf": {
-													"version": "1.0.1",
-													"resolved": false,
-													"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-													"dev": true,
-													"optional": true,
-													"requires": {
-														"tweetnacl": "^0.14.3"
-													}
-												},
-												"dashdash": {
-													"version": "1.14.1",
-													"resolved": false,
-													"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-													"dev": true,
-													"requires": {
-														"assert-plus": "^1.0.0"
-													}
-												},
-												"ecc-jsbn": {
-													"version": "0.1.1",
-													"resolved": false,
-													"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-													"dev": true,
-													"optional": true,
-													"requires": {
-														"jsbn": "~0.1.0"
-													}
-												},
-												"getpass": {
-													"version": "0.1.7",
-													"resolved": false,
-													"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-													"dev": true,
-													"requires": {
-														"assert-plus": "^1.0.0"
-													}
-												},
-												"jsbn": {
-													"version": "0.1.1",
-													"resolved": false,
-													"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-													"dev": true,
-													"optional": true
-												},
-												"tweetnacl": {
-													"version": "0.14.5",
-													"resolved": false,
-													"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-													"dev": true,
-													"optional": true
-												}
-											}
-										}
-									}
-								},
-								"is-typedarray": {
-									"version": "1.0.0",
-									"resolved": false,
-									"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-									"dev": true
-								},
-								"isstream": {
-									"version": "0.1.2",
-									"resolved": false,
-									"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-									"dev": true
-								},
-								"json-stringify-safe": {
-									"version": "5.0.1",
-									"resolved": false,
-									"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-									"dev": true
-								},
-								"mime-types": {
-									"version": "2.1.15",
-									"resolved": false,
-									"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-									"dev": true,
-									"requires": {
-										"mime-db": "~1.27.0"
-									},
-									"dependencies": {
-										"mime-db": {
-											"version": "1.27.0",
-											"resolved": false,
-											"integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-											"dev": true
-										}
-									}
-								},
-								"oauth-sign": {
-									"version": "0.8.2",
-									"resolved": false,
-									"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-									"dev": true
-								},
-								"performance-now": {
-									"version": "0.2.0",
-									"resolved": false,
-									"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-									"dev": true
-								},
-								"qs": {
-									"version": "6.4.0",
-									"resolved": false,
-									"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-									"dev": true
-								},
-								"stringstream": {
-									"version": "0.0.5",
-									"resolved": false,
-									"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-									"dev": true
-								},
-								"tough-cookie": {
-									"version": "2.3.2",
-									"resolved": false,
-									"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-									"dev": true,
-									"requires": {
-										"punycode": "^1.4.1"
-									},
-									"dependencies": {
-										"punycode": {
-											"version": "1.4.1",
-											"resolved": false,
-											"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-											"dev": true
-										}
-									}
-								},
-								"tunnel-agent": {
-									"version": "0.6.0",
-									"resolved": false,
-									"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-									"dev": true,
-									"requires": {
-										"safe-buffer": "^5.0.1"
-									}
-								}
-							}
-						},
 						"retry": {
 							"version": "0.10.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
 							"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
 							"dev": true
 						},
 						"rimraf": {
 							"version": "2.6.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 							"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
 							"dev": true,
 							"requires": {
@@ -15159,19 +14057,19 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
 							"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
 							"dev": true
 						},
 						"semver": {
 							"version": "5.3.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
 							"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
 							"dev": true
 						},
 						"sha": {
 							"version": "2.0.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
 							"integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
 							"dev": true,
 							"requires": {
@@ -15181,19 +14079,19 @@
 						},
 						"slide": {
 							"version": "1.1.6",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
 							"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
 							"dev": true
 						},
 						"sorted-object": {
 							"version": "2.0.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
 							"integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
 							"dev": true
 						},
 						"sorted-union-stream": {
 							"version": "2.1.3",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
 							"integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
 							"dev": true,
 							"requires": {
@@ -15203,7 +14101,7 @@
 							"dependencies": {
 								"from2": {
 									"version": "1.3.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
 									"integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
 									"dev": true,
 									"requires": {
@@ -15213,7 +14111,7 @@
 									"dependencies": {
 										"readable-stream": {
 											"version": "1.1.14",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 											"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
 											"dev": true,
 											"requires": {
@@ -15225,19 +14123,19 @@
 											"dependencies": {
 												"core-util-is": {
 													"version": "1.0.2",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 													"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 													"dev": true
 												},
 												"isarray": {
 													"version": "0.0.1",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
 													"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
 													"dev": true
 												},
 												"string_decoder": {
 													"version": "0.10.31",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 													"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
 													"dev": true
 												}
@@ -15247,7 +14145,7 @@
 								},
 								"stream-iterate": {
 									"version": "1.2.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
 									"integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
 									"dev": true,
 									"requires": {
@@ -15257,7 +14155,7 @@
 									"dependencies": {
 										"stream-shift": {
 											"version": "1.0.0",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
 											"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
 											"dev": true
 										}
@@ -15267,7 +14165,7 @@
 						},
 						"ssri": {
 							"version": "4.1.6",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
 							"integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
 							"dev": true,
 							"requires": {
@@ -15276,7 +14174,7 @@
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 							"dev": true,
 							"requires": {
@@ -15285,7 +14183,7 @@
 							"dependencies": {
 								"ansi-regex": {
 									"version": "3.0.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 									"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 									"dev": true
 								}
@@ -15293,7 +14191,7 @@
 						},
 						"tar": {
 							"version": "2.2.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
 							"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 							"dev": true,
 							"requires": {
@@ -15304,7 +14202,7 @@
 							"dependencies": {
 								"block-stream": {
 									"version": "0.0.9",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
 									"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 									"dev": true,
 									"requires": {
@@ -15315,25 +14213,25 @@
 						},
 						"text-table": {
 							"version": "0.2.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 							"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 							"dev": true
 						},
 						"uid-number": {
 							"version": "0.0.6",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
 							"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
 							"dev": true
 						},
 						"umask": {
 							"version": "1.1.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
 							"integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
 							"dev": true
 						},
 						"unique-filename": {
 							"version": "1.1.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
 							"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
 							"dev": true,
 							"requires": {
@@ -15342,7 +14240,7 @@
 							"dependencies": {
 								"unique-slug": {
 									"version": "2.0.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
 									"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
 									"dev": true,
 									"requires": {
@@ -15353,13 +14251,13 @@
 						},
 						"unpipe": {
 							"version": "1.0.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 							"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
 							"dev": true
 						},
 						"update-notifier": {
 							"version": "2.2.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
 							"integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
 							"dev": true,
 							"requires": {
@@ -15375,7 +14273,7 @@
 							"dependencies": {
 								"boxen": {
 									"version": "1.1.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz",
 									"integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI=",
 									"dev": true,
 									"requires": {
@@ -15390,7 +14288,7 @@
 									"dependencies": {
 										"ansi-align": {
 											"version": "2.0.0",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
 											"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
 											"dev": true,
 											"requires": {
@@ -15399,19 +14297,19 @@
 										},
 										"camelcase": {
 											"version": "4.1.0",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
 											"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
 											"dev": true
 										},
 										"cli-boxes": {
 											"version": "1.0.0",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
 											"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
 											"dev": true
 										},
 										"string-width": {
 											"version": "2.1.0",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
 											"integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
 											"dev": true,
 											"requires": {
@@ -15421,13 +14319,13 @@
 											"dependencies": {
 												"is-fullwidth-code-point": {
 													"version": "2.0.0",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 													"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 													"dev": true
 												},
 												"strip-ansi": {
 													"version": "4.0.0",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 													"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 													"dev": true,
 													"requires": {
@@ -15438,7 +14336,7 @@
 										},
 										"term-size": {
 											"version": "0.1.1",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
 											"integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
 											"dev": true,
 											"requires": {
@@ -15447,7 +14345,7 @@
 											"dependencies": {
 												"execa": {
 													"version": "0.4.0",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
 													"integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
 													"dev": true,
 													"requires": {
@@ -15461,7 +14359,7 @@
 													"dependencies": {
 														"cross-spawn-async": {
 															"version": "2.2.5",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
 															"integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
 															"dev": true,
 															"requires": {
@@ -15471,13 +14369,13 @@
 														},
 														"is-stream": {
 															"version": "1.1.0",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 															"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
 															"dev": true
 														},
 														"npm-run-path": {
 															"version": "1.0.0",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
 															"integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
 															"dev": true,
 															"requires": {
@@ -15486,19 +14384,19 @@
 														},
 														"object-assign": {
 															"version": "4.1.1",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 															"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 															"dev": true
 														},
 														"path-key": {
 															"version": "1.0.0",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
 															"integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
 															"dev": true
 														},
 														"strip-eof": {
 															"version": "1.0.0",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 															"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 															"dev": true
 														}
@@ -15508,7 +14406,7 @@
 										},
 										"widest-line": {
 											"version": "1.0.0",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
 											"integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
 											"dev": true,
 											"requires": {
@@ -15517,7 +14415,7 @@
 											"dependencies": {
 												"string-width": {
 													"version": "1.0.2",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 													"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 													"dev": true,
 													"requires": {
@@ -15528,13 +14426,13 @@
 													"dependencies": {
 														"code-point-at": {
 															"version": "1.1.0",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 															"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 															"dev": true
 														},
 														"is-fullwidth-code-point": {
 															"version": "1.0.0",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 															"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 															"dev": true,
 															"requires": {
@@ -15543,7 +14441,7 @@
 															"dependencies": {
 																"number-is-nan": {
 																	"version": "1.0.1",
-																	"resolved": false,
+																	"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 																	"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 																	"dev": true
 																}
@@ -15551,7 +14449,7 @@
 														},
 														"strip-ansi": {
 															"version": "3.0.1",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 															"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 															"dev": true,
 															"requires": {
@@ -15560,7 +14458,7 @@
 															"dependencies": {
 																"ansi-regex": {
 																	"version": "2.1.1",
-																	"resolved": false,
+																	"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 																	"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 																	"dev": true
 																}
@@ -15574,7 +14472,7 @@
 								},
 								"chalk": {
 									"version": "1.1.3",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 									"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 									"dev": true,
 									"requires": {
@@ -15587,19 +14485,19 @@
 									"dependencies": {
 										"ansi-styles": {
 											"version": "2.2.1",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
 											"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
 											"dev": true
 										},
 										"escape-string-regexp": {
 											"version": "1.0.5",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 											"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 											"dev": true
 										},
 										"has-ansi": {
 											"version": "2.0.0",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 											"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 											"dev": true,
 											"requires": {
@@ -15608,7 +14506,7 @@
 											"dependencies": {
 												"ansi-regex": {
 													"version": "2.1.1",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 													"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 													"dev": true
 												}
@@ -15616,7 +14514,7 @@
 										},
 										"strip-ansi": {
 											"version": "3.0.1",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 											"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 											"dev": true,
 											"requires": {
@@ -15625,7 +14523,7 @@
 											"dependencies": {
 												"ansi-regex": {
 													"version": "2.1.1",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 													"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 													"dev": true
 												}
@@ -15633,7 +14531,7 @@
 										},
 										"supports-color": {
 											"version": "2.0.0",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 											"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
 											"dev": true
 										}
@@ -15641,7 +14539,7 @@
 								},
 								"configstore": {
 									"version": "3.1.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz",
 									"integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE=",
 									"dev": true,
 									"requires": {
@@ -15655,7 +14553,7 @@
 									"dependencies": {
 										"dot-prop": {
 											"version": "4.1.1",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
 											"integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
 											"dev": true,
 											"requires": {
@@ -15664,7 +14562,7 @@
 											"dependencies": {
 												"is-obj": {
 													"version": "1.0.1",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 													"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 													"dev": true
 												}
@@ -15672,7 +14570,7 @@
 										},
 										"make-dir": {
 											"version": "1.0.0",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
 											"integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
 											"dev": true,
 											"requires": {
@@ -15681,7 +14579,7 @@
 											"dependencies": {
 												"pify": {
 													"version": "2.3.0",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 													"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 													"dev": true
 												}
@@ -15689,7 +14587,7 @@
 										},
 										"unique-string": {
 											"version": "1.0.0",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
 											"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
 											"dev": true,
 											"requires": {
@@ -15698,7 +14596,7 @@
 											"dependencies": {
 												"crypto-random-string": {
 													"version": "1.0.0",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
 													"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
 													"dev": true
 												}
@@ -15708,19 +14606,19 @@
 								},
 								"import-lazy": {
 									"version": "2.1.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
 									"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
 									"dev": true
 								},
 								"is-npm": {
 									"version": "1.0.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
 									"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
 									"dev": true
 								},
 								"latest-version": {
 									"version": "3.1.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
 									"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
 									"dev": true,
 									"requires": {
@@ -15729,7 +14627,7 @@
 									"dependencies": {
 										"package-json": {
 											"version": "4.0.1",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
 											"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
 											"dev": true,
 											"requires": {
@@ -15741,7 +14639,7 @@
 											"dependencies": {
 												"got": {
 													"version": "6.7.1",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
 													"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 													"dev": true,
 													"requires": {
@@ -15760,7 +14658,7 @@
 													"dependencies": {
 														"create-error-class": {
 															"version": "3.0.2",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
 															"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
 															"dev": true,
 															"requires": {
@@ -15769,7 +14667,7 @@
 															"dependencies": {
 																"capture-stack-trace": {
 																	"version": "1.0.0",
-																	"resolved": false,
+																	"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
 																	"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
 																	"dev": true
 																}
@@ -15777,55 +14675,55 @@
 														},
 														"duplexer3": {
 															"version": "0.1.4",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
 															"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
 															"dev": true
 														},
 														"get-stream": {
 															"version": "3.0.0",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 															"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 															"dev": true
 														},
 														"is-redirect": {
 															"version": "1.0.0",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
 															"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
 															"dev": true
 														},
 														"is-retry-allowed": {
 															"version": "1.1.0",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
 															"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
 															"dev": true
 														},
 														"is-stream": {
 															"version": "1.1.0",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 															"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
 															"dev": true
 														},
 														"lowercase-keys": {
 															"version": "1.0.0",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
 															"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
 															"dev": true
 														},
 														"timed-out": {
 															"version": "4.0.1",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
 															"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
 															"dev": true
 														},
 														"unzip-response": {
 															"version": "2.0.1",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
 															"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
 															"dev": true
 														},
 														"url-parse-lax": {
 															"version": "1.0.0",
-															"resolved": false,
+															"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
 															"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 															"dev": true,
 															"requires": {
@@ -15834,7 +14732,7 @@
 															"dependencies": {
 																"prepend-http": {
 																	"version": "1.0.4",
-																	"resolved": false,
+																	"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
 																	"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
 																	"dev": true
 																}
@@ -15844,51 +14742,17 @@
 												},
 												"registry-auth-token": {
 													"version": "3.3.1",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
 													"integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
 													"dev": true,
 													"requires": {
 														"rc": "^1.1.6",
 														"safe-buffer": "^5.0.1"
-													},
-													"dependencies": {
-														"rc": {
-															"version": "1.2.1",
-															"resolved": false,
-															"integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-															"dev": true,
-															"requires": {
-																"deep-extend": "~0.4.0",
-																"ini": "~1.3.0",
-																"minimist": "^1.2.0",
-																"strip-json-comments": "~2.0.1"
-															},
-															"dependencies": {
-																"deep-extend": {
-																	"version": "0.4.2",
-																	"resolved": false,
-																	"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-																	"dev": true
-																},
-																"minimist": {
-																	"version": "1.2.0",
-																	"resolved": false,
-																	"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-																	"dev": true
-																},
-																"strip-json-comments": {
-																	"version": "2.0.1",
-																	"resolved": false,
-																	"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-																	"dev": true
-																}
-															}
-														}
 													}
 												},
 												"registry-url": {
 													"version": "3.1.0",
-													"resolved": false,
+													"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 													"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
 													"dev": true,
 													"requires": {
@@ -15896,35 +14760,15 @@
 													},
 													"dependencies": {
 														"rc": {
-															"version": "1.2.1",
-															"resolved": false,
-															"integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+															"version": "1.2.8",
+															"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+															"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 															"dev": true,
 															"requires": {
-																"deep-extend": "~0.4.0",
+																"deep-extend": "^0.6.0",
 																"ini": "~1.3.0",
 																"minimist": "^1.2.0",
 																"strip-json-comments": "~2.0.1"
-															},
-															"dependencies": {
-																"deep-extend": {
-																	"version": "0.4.2",
-																	"resolved": false,
-																	"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-																	"dev": true
-																},
-																"minimist": {
-																	"version": "1.2.0",
-																	"resolved": false,
-																	"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-																	"dev": true
-																},
-																"strip-json-comments": {
-																	"version": "2.0.1",
-																	"resolved": false,
-																	"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-																	"dev": true
-																}
 															}
 														}
 													}
@@ -15935,7 +14779,7 @@
 								},
 								"semver-diff": {
 									"version": "2.1.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
 									"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
 									"dev": true,
 									"requires": {
@@ -15944,7 +14788,7 @@
 								},
 								"xdg-basedir": {
 									"version": "3.0.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
 									"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
 									"dev": true
 								}
@@ -15952,13 +14796,13 @@
 						},
 						"uuid": {
 							"version": "3.1.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
 							"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
 							"dev": true
 						},
 						"validate-npm-package-license": {
 							"version": "3.0.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
 							"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
 							"dev": true,
 							"requires": {
@@ -15968,7 +14812,7 @@
 							"dependencies": {
 								"spdx-correct": {
 									"version": "1.0.2",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
 									"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
 									"dev": true,
 									"requires": {
@@ -15977,7 +14821,7 @@
 									"dependencies": {
 										"spdx-license-ids": {
 											"version": "1.2.2",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
 											"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
 											"dev": true
 										}
@@ -15985,7 +14829,7 @@
 								},
 								"spdx-expression-parse": {
 									"version": "1.0.4",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
 									"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
 									"dev": true
 								}
@@ -15993,7 +14837,7 @@
 						},
 						"validate-npm-package-name": {
 							"version": "3.0.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
 							"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
 							"dev": true,
 							"requires": {
@@ -16002,7 +14846,7 @@
 							"dependencies": {
 								"builtins": {
 									"version": "1.0.3",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
 									"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
 									"dev": true
 								}
@@ -16010,7 +14854,7 @@
 						},
 						"which": {
 							"version": "1.2.14",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
 							"integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
 							"dev": true,
 							"requires": {
@@ -16019,7 +14863,7 @@
 							"dependencies": {
 								"isexe": {
 									"version": "2.0.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 									"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 									"dev": true
 								}
@@ -16027,7 +14871,7 @@
 						},
 						"worker-farm": {
 							"version": "1.3.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.1.tgz",
 							"integrity": "sha1-QzMRK7SbF6oFC4eJXKayys9A5f8=",
 							"dev": true,
 							"requires": {
@@ -16037,7 +14881,7 @@
 							"dependencies": {
 								"errno": {
 									"version": "0.1.4",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
 									"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
 									"dev": true,
 									"requires": {
@@ -16046,7 +14890,7 @@
 									"dependencies": {
 										"prr": {
 											"version": "0.0.0",
-											"resolved": false,
+											"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
 											"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
 											"dev": true
 										}
@@ -16054,7 +14898,7 @@
 								},
 								"xtend": {
 									"version": "4.0.1",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 									"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
 									"dev": true
 								}
@@ -16062,13 +14906,13 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 							"dev": true
 						},
 						"write-file-atomic": {
 							"version": "2.1.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
 							"integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
 							"dev": true,
 							"requires": {
@@ -16081,7 +14925,7 @@
 				},
 				"npm-package-arg": {
 					"version": "6.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
 					"integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
 					"dev": true,
 					"requires": {
@@ -16093,7 +14937,7 @@
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 					"dev": true,
 					"requires": {
@@ -16102,13 +14946,13 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 					"dev": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
 					"requires": {
@@ -16117,13 +14961,13 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"dev": true,
 					"requires": {
@@ -16134,13 +14978,13 @@
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"dev": true
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 					"dev": true,
 					"requires": {
@@ -16150,13 +14994,13 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
 					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
 					"dev": true
 				},
 				"p-limit": {
 					"version": "1.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
 					"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
 					"dev": true,
 					"requires": {
@@ -16165,7 +15009,7 @@
 				},
 				"p-locate": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"dev": true,
 					"requires": {
@@ -16174,13 +15018,13 @@
 				},
 				"p-try": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
 					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
 					"dev": true
 				},
 				"package-json": {
 					"version": "4.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
 					"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
 					"dev": true,
 					"requires": {
@@ -16192,49 +15036,71 @@
 				},
 				"path-exists": {
 					"version": "3.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
 					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
 					"dev": true
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 					"dev": true
 				},
 				"path-is-inside": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
 					"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
 					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
 					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+					"dev": true
+				},
+				"performance-now": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+					"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
 					"dev": true
 				},
 				"pify": {
 					"version": "3.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 					"dev": true
 				},
 				"prepend-http": {
 					"version": "1.0.4",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
 					"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
 					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
 					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+					"dev": true
+				},
+				"pump": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+					"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+					"dev": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				},
+				"qs": {
+					"version": "6.4.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+					"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
 					"dev": true
 				},
 				"rc": {
 					"version": "1.2.6",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
 					"integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
 					"dev": true,
 					"requires": {
@@ -16246,7 +15112,7 @@
 				},
 				"registry-auth-token": {
 					"version": "3.3.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
 					"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
 					"dev": true,
 					"requires": {
@@ -16256,28 +15122,58 @@
 				},
 				"registry-url": {
 					"version": "3.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 					"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
 					"dev": true,
 					"requires": {
 						"rc": "^1.0.1"
 					}
 				},
+				"request": {
+					"version": "2.81.0",
+					"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+					"dev": true,
+					"requires": {
+						"aws-sign2": "~0.6.0",
+						"aws4": "^1.2.1",
+						"caseless": "~0.12.0",
+						"combined-stream": "~1.0.5",
+						"extend": "~3.0.0",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.1.1",
+						"har-validator": "~4.2.1",
+						"hawk": "~3.1.3",
+						"http-signature": "~1.1.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.7",
+						"oauth-sign": "~0.8.1",
+						"performance-now": "^0.2.0",
+						"qs": "~6.4.0",
+						"safe-buffer": "^5.0.1",
+						"stringstream": "~0.0.4",
+						"tough-cookie": "~2.3.0",
+						"tunnel-agent": "^0.6.0",
+						"uuid": "^3.0.0"
+					}
+				},
 				"require-directory": {
 					"version": "2.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
 					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
 					"dev": true
 				},
 				"rimraf": {
 					"version": "2.6.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 					"dev": true,
 					"requires": {
@@ -16286,19 +15182,19 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
 					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
 					"dev": true
 				},
 				"semver": {
 					"version": "5.5.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
 					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
 					"dev": true
 				},
 				"semver-diff": {
 					"version": "2.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
 					"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
 					"dev": true,
 					"requires": {
@@ -16307,13 +15203,13 @@
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"dev": true
 				},
 				"shebang-command": {
 					"version": "1.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 					"dev": true,
 					"requires": {
@@ -16322,19 +15218,28 @@
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"dev": true
 				},
+				"ssri": {
+					"version": "4.1.6",
+					"resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
+					"integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "^5.1.0"
+					}
+				},
 				"string-width": {
 					"version": "2.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
@@ -16344,7 +15249,7 @@
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
@@ -16353,19 +15258,19 @@
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 					"dev": true
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "5.3.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
@@ -16374,7 +15279,7 @@
 				},
 				"term-size": {
 					"version": "1.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
 					"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
 					"dev": true,
 					"requires": {
@@ -16383,13 +15288,13 @@
 				},
 				"timed-out": {
 					"version": "4.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
 					"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
 					"dev": true
 				},
 				"unique-string": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
 					"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
 					"dev": true,
 					"requires": {
@@ -16398,13 +15303,13 @@
 				},
 				"unzip-response": {
 					"version": "2.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
 					"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
 					"dev": true
 				},
 				"update-notifier": {
 					"version": "2.4.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.4.0.tgz",
 					"integrity": "sha1-+bTHAPv9TsEsgRWHJYd31WPYyGY=",
 					"dev": true,
 					"requires": {
@@ -16422,7 +15327,7 @@
 				},
 				"url-parse-lax": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
 					"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 					"dev": true,
 					"requires": {
@@ -16431,7 +15336,7 @@
 				},
 				"validate-npm-package-name": {
 					"version": "3.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
 					"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
 					"dev": true,
 					"requires": {
@@ -16440,7 +15345,7 @@
 				},
 				"which": {
 					"version": "1.3.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 					"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
 					"dev": true,
 					"requires": {
@@ -16449,13 +15354,13 @@
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 					"dev": true
 				},
 				"widest-line": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
 					"integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
 					"dev": true,
 					"requires": {
@@ -16464,7 +15369,7 @@
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"dev": true,
 					"requires": {
@@ -16474,13 +15379,13 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "2.1.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 							"dev": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"dev": true,
 							"requires": {
@@ -16489,7 +15394,7 @@
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"requires": {
@@ -16500,7 +15405,7 @@
 						},
 						"strip-ansi": {
 							"version": "3.0.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 							"dev": true,
 							"requires": {
@@ -16511,13 +15416,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 					"dev": true
 				},
 				"write-file-atomic": {
 					"version": "2.3.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 					"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 					"dev": true,
 					"requires": {
@@ -16528,25 +15433,25 @@
 				},
 				"xdg-basedir": {
 					"version": "3.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
 					"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
 					"dev": true
 				},
 				"y18n": {
 					"version": "4.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
 					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
 					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
 					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
 					"dev": true
 				},
 				"yargs": {
 					"version": "11.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
 					"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
 					"dev": true,
 					"requires": {
@@ -16566,7 +15471,7 @@
 					"dependencies": {
 						"y18n": {
 							"version": "3.2.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
 							"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
 							"dev": true
 						}
@@ -16574,7 +15479,7 @@
 				},
 				"yargs-parser": {
 					"version": "9.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
 					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 					"dev": true,
 					"requires": {
@@ -16861,12 +15766,12 @@
 			}
 		},
 		"os-name": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
-			"integrity": "sha1-GzefZINa98Wn9JizV8uVIVwVnt8=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
+			"integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
 			"dev": true,
 			"requires": {
-				"osx-release": "^1.0.0",
+				"macos-release": "^1.0.0",
 				"win-release": "^1.0.0"
 			}
 		},
@@ -16892,23 +15797,6 @@
 				"os-tmpdir": "^1.0.0"
 			}
 		},
-		"osx-release": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
-			"integrity": "sha1-8heRGigTaUmvG/kwiyQeJzfTzWw=",
-			"dev": true,
-			"requires": {
-				"minimist": "^1.1.0"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
-			}
-		},
 		"p-any": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/p-any/-/p-any-1.1.0.tgz",
@@ -16920,7 +15808,7 @@
 		},
 		"p-cancelable": {
 			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+			"resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
 			"integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
 			"dev": true
 		},
@@ -17042,7 +15930,7 @@
 		},
 		"parse-asn1": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
 			"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
 			"dev": true,
 			"requires": {
@@ -17103,9 +15991,9 @@
 			}
 		},
 		"parse-help": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/parse-help/-/parse-help-0.1.1.tgz",
-			"integrity": "sha1-L035Qud6VYG7qZZ8DD9I5MZtfdo=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/parse-help/-/parse-help-1.0.0.tgz",
+			"integrity": "sha512-dlOrbBba6Rrw/nrJ+V7/vkGZdiimWJQzMHZZrYsUq03JE8AV3fAv6kOYX7dP/w2h67lIdmRf8ES8mU44xAgE/Q==",
 			"dev": true,
 			"requires": {
 				"execall": "^1.0.0"
@@ -17267,7 +16155,7 @@
 		},
 		"pause-stream": {
 			"version": "0.0.11",
-			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
 			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
 			"dev": true,
 			"requires": {
@@ -17286,6 +16174,12 @@
 				"safe-buffer": "^5.0.1",
 				"sha.js": "^2.4.8"
 			}
+		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
 		},
 		"pify": {
 			"version": "3.0.0",
@@ -17351,6 +16245,15 @@
 				"find-up": "^2.1.0"
 			}
 		},
+		"pkg-up": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+			"dev": true,
+			"requires": {
+				"find-up": "^2.1.0"
+			}
+		},
 		"plur": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
@@ -17386,7 +16289,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
@@ -17542,42 +16445,6 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				}
-			}
-		},
-		"postcss-html": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.18.0.tgz",
-			"integrity": "sha512-7llFZ5hlINmUu/8iUBIXCTZ4OMyGB+NBeb7jDadXrH9g+hpcUEBhZv3rjqesmOsHNC3bITqx1EkVz77RuHJygw==",
-			"dev": true,
-			"requires": {
-				"@babel/core": "^7.0.0-beta.42",
-				"@babel/traverse": "^7.0.0-beta.42",
-				"babylon": "^7.0.0-beta.42",
-				"htmlparser2": "^3.9.2",
-				"remark": "^9.0.0",
-				"unist-util-find-all-after": "^1.0.1"
-			},
-			"dependencies": {
-				"remark": {
-					"version": "9.0.0",
-					"resolved": "https://registry.npmjs.org/remark/-/remark-9.0.0.tgz",
-					"integrity": "sha512-amw8rGdD5lHbMEakiEsllmkdBP+/KpjW/PRK6NSGPZKCQowh0BT4IWXDAkRMyG3SB9dKPXWMviFjNusXzXNn3A==",
-					"dev": true,
-					"requires": {
-						"remark-parse": "^5.0.0",
-						"remark-stringify": "^5.0.0",
-						"unified": "^6.0.0"
-					}
-				}
-			}
-		},
-		"postcss-less": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-1.1.5.tgz",
-			"integrity": "sha512-QQIiIqgEjNnquc0d4b6HDOSFZxbFQoy4MPpli2lSLpKhMyBkKwwca2HFqu4xzxlKID/F2fxSOowwtKpgczhF7A==",
-			"dev": true,
-			"requires": {
-				"postcss": "^5.2.16"
 			}
 		},
 		"postcss-load-config": {
@@ -18049,37 +16916,6 @@
 				"postcss-value-parser": "^3.0.1"
 			}
 		},
-		"postcss-reporter": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-5.0.0.tgz",
-			"integrity": "sha512-rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.0.1",
-				"lodash": "^4.17.4",
-				"log-symbols": "^2.0.0",
-				"postcss": "^6.0.8"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.22",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-					"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
 		"postcss-resolve-nested-selector": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
@@ -18095,83 +16931,15 @@
 				"postcss": "^5.2.16"
 			}
 		},
-		"postcss-sass": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.3.1.tgz",
-			"integrity": "sha512-jyrOsP3MoLv57avdbi7GEITKrM23qeoFzZi8zmbXPjcPklRt83zzoxF/CEZ/cwRAJsHSkEwHc28Qhkm+8/OoUA==",
-			"dev": true,
-			"requires": {
-				"gonzales-pe": "4.2.3",
-				"postcss": "6.0.22"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.22",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-					"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
-		"postcss-scss": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.5.tgz",
-			"integrity": "sha512-gJB1tKYMkBy0MU+COt6WXA4ZiRctAKoWLa6qD7a6bbEbBMqrpa/BhfQdN80eYMV+JkKddZVEpZlOggnGShpvyg==",
-			"dev": true,
-			"requires": {
-				"postcss": "^6.0.21"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.22",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-					"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
 		"postcss-selector-parser": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-			"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
 			"dev": true,
 			"requires": {
-				"dot-prop": "^4.1.1",
+				"flatten": "^1.0.2",
 				"indexes-of": "^1.0.1",
 				"uniq": "^1.0.1"
-			},
-			"dependencies": {
-				"dot-prop": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-					"dev": true,
-					"requires": {
-						"is-obj": "^1.0.0"
-					}
-				}
 			}
 		},
 		"postcss-svgo": {
@@ -18259,6 +17027,17 @@
 				"postcss": "^5.2.5"
 			}
 		},
+		"primer-support": {
+			"version": "4.6.0",
+			"dev": true
+		},
+		"primer-utilities": {
+			"version": "4.12.0",
+			"dev": true,
+			"requires": {
+				"primer-support": "4.6.0"
+			}
+		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -18330,6 +17109,12 @@
 				"object-assign": "^4.1.1"
 			}
 		},
+		"proto-list": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+			"dev": true
+		},
 		"proxy-addr": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
@@ -18375,7 +17160,7 @@
 		},
 		"public-encrypt": {
 			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
+			"resolved": "http://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
 			"integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
 			"dev": true,
 			"requires": {
@@ -18420,9 +17205,9 @@
 			"dev": true
 		},
 		"qs": {
-			"version": "6.3.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-			"integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 			"dev": true
 		},
 		"query-string": {
@@ -18473,7 +17258,7 @@
 			"dependencies": {
 				"inline-style-prefixer": {
 					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz",
+					"resolved": "http://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz",
 					"integrity": "sha1-wVPH6I/YT+9cYC6VqBaLJ3BnH+c=",
 					"dev": true,
 					"requires": {
@@ -18609,7 +17394,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				}
@@ -18662,7 +17447,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
@@ -18999,7 +17784,7 @@
 		},
 		"readable-stream": {
 			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
@@ -19022,34 +17807,6 @@
 				"minimatch": "^3.0.2",
 				"readable-stream": "^2.0.2",
 				"set-immediate-shim": "^1.0.1"
-			}
-		},
-		"readline2": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-			"integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-			"dev": true,
-			"requires": {
-				"code-point-at": "^1.0.0",
-				"is-fullwidth-code-point": "^1.0.0",
-				"mute-stream": "0.0.5"
-			},
-			"dependencies": {
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"mute-stream": {
-					"version": "0.0.5",
-					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-					"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
-					"dev": true
-				}
 			}
 		},
 		"recast": {
@@ -19320,51 +18077,6 @@
 				}
 			}
 		},
-		"remark-parse": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
-			"integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
-			"dev": true,
-			"requires": {
-				"collapse-white-space": "^1.0.2",
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-whitespace-character": "^1.0.0",
-				"is-word-character": "^1.0.0",
-				"markdown-escapes": "^1.0.0",
-				"parse-entities": "^1.1.0",
-				"repeat-string": "^1.5.4",
-				"state-toggle": "^1.0.0",
-				"trim": "0.0.1",
-				"trim-trailing-lines": "^1.0.0",
-				"unherit": "^1.0.4",
-				"unist-util-remove-position": "^1.0.0",
-				"vfile-location": "^2.0.0",
-				"xtend": "^4.0.1"
-			}
-		},
-		"remark-stringify": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-5.0.0.tgz",
-			"integrity": "sha512-Ws5MdA69ftqQ/yhRF9XhVV29mhxbfGhbz0Rx5bQH+oJcNhhSM6nCu1EpLod+DjrFGrU0BMPs+czVmJZU7xiS7w==",
-			"dev": true,
-			"requires": {
-				"ccount": "^1.0.0",
-				"is-alphanumeric": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-whitespace-character": "^1.0.0",
-				"longest-streak": "^2.0.1",
-				"markdown-escapes": "^1.0.0",
-				"markdown-table": "^1.1.0",
-				"mdast-util-compact": "^1.0.0",
-				"parse-entities": "^1.0.2",
-				"repeat-string": "^1.5.4",
-				"state-toggle": "^1.0.0",
-				"stringify-entities": "^1.0.1",
-				"unherit": "^1.0.4",
-				"xtend": "^4.0.1"
-			}
-		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -19422,7 +18134,7 @@
 				},
 				"readable-stream": {
 					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"dev": true,
 					"requires": {
@@ -19474,39 +18186,31 @@
 			"dev": true
 		},
 		"request": {
-			"version": "2.79.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-			"integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+			"version": "2.87.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
 			"dev": true,
 			"requires": {
-				"aws-sign2": "~0.6.0",
-				"aws4": "^1.2.1",
-				"caseless": "~0.11.0",
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.6.0",
+				"caseless": "~0.12.0",
 				"combined-stream": "~1.0.5",
-				"extend": "~3.0.0",
+				"extend": "~3.0.1",
 				"forever-agent": "~0.6.1",
-				"form-data": "~2.1.1",
-				"har-validator": "~2.0.6",
-				"hawk": "~3.1.3",
-				"http-signature": "~1.1.0",
+				"form-data": "~2.3.1",
+				"har-validator": "~5.0.3",
+				"http-signature": "~1.2.0",
 				"is-typedarray": "~1.0.0",
 				"isstream": "~0.1.2",
 				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.7",
-				"oauth-sign": "~0.8.1",
-				"qs": "~6.3.0",
-				"stringstream": "~0.0.4",
-				"tough-cookie": "~2.3.0",
-				"tunnel-agent": "~0.4.1",
-				"uuid": "^3.0.0"
-			},
-			"dependencies": {
-				"uuid": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-					"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-					"dev": true
-				}
+				"mime-types": "~2.1.17",
+				"oauth-sign": "~0.8.2",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.1",
+				"safe-buffer": "^5.1.1",
+				"tough-cookie": "~2.3.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.1.0"
 			}
 		},
 		"require-directory": {
@@ -19574,12 +18278,6 @@
 				"expand-tilde": "^2.0.0",
 				"global-modules": "^1.0.0"
 			}
-		},
-		"resolve-from": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-			"dev": true
 		},
 		"resolve-url": {
 			"version": "0.2.1",
@@ -19713,6 +18411,15 @@
 				"rx-lite": "*"
 			}
 		},
+		"rxjs": {
+			"version": "6.3.2",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.2.tgz",
+			"integrity": "sha512-hV7criqbR0pe7EeL3O66UYVg92IR0XsA97+9y+BWTePK9SKmEI5Qd3Zj6uPnGkNzXsBywBQWTvujPl+1Kn9Zjw==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.9.0"
+			}
+		},
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -19774,7 +18481,7 @@
 				},
 				"os-locale": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+					"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"dev": true,
 					"requires": {
@@ -20031,7 +18738,7 @@
 		},
 		"sha.js": {
 			"version": "2.4.11",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"dev": true,
 			"requires": {
@@ -20319,24 +19026,13 @@
 			}
 		},
 		"sort-on": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/sort-on/-/sort-on-2.0.0.tgz",
-			"integrity": "sha1-DfQqZ5165K7Zwwui9VgH2XmRD8w=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/sort-on/-/sort-on-3.0.0.tgz",
+			"integrity": "sha512-e2RHeY1iM6dT9od3RoqeJSyz3O7naNFsGy34+EFEcwghjAncuOXC2/Xwq87S4FbypqLVp6PcizYEsGEGsGIDXA==",
 			"dev": true,
 			"requires": {
 				"arrify": "^1.0.0",
 				"dot-prop": "^4.1.1"
-			},
-			"dependencies": {
-				"dot-prop": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-					"dev": true,
-					"requires": {
-						"is-obj": "^1.0.0"
-					}
-				}
 			}
 		},
 		"source-list-map": {
@@ -20544,9 +19240,9 @@
 			"dev": true
 		},
 		"stdout-stream": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
-			"integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
+			"integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
 			"dev": true,
 			"requires": {
 				"readable-stream": "^2.0.1"
@@ -20564,7 +19260,7 @@
 		},
 		"stream-combiner": {
 			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+			"resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
 			"integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
 			"dev": true,
 			"requires": {
@@ -20608,12 +19304,30 @@
 			"dev": true
 		},
 		"string-length": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
-			"integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
 			"dev": true,
 			"requires": {
-				"strip-ansi": "^3.0.0"
+				"astral-regex": "^1.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"string-width": {
@@ -20687,9 +19401,9 @@
 			}
 		},
 		"stringstream": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+			"integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
 			"dev": true
 		},
 		"strip-ansi": {
@@ -20755,6 +19469,21 @@
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 			"dev": true
 		},
+		"strip-outer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+			"integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.2"
+			}
+		},
+		"strip-url-auth": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/strip-url-auth/-/strip-url-auth-1.0.1.tgz",
+			"integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=",
+			"dev": true
+		},
 		"strong-log-transformer": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-1.0.6.tgz",
@@ -20770,7 +19499,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
 					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
 					"dev": true
 				}
@@ -20848,7 +19577,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
@@ -20870,7 +19599,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
@@ -21095,7 +19824,7 @@
 					"dependencies": {
 						"chalk": {
 							"version": "1.1.3",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+							"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 							"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 							"dev": true,
 							"requires": {
@@ -21134,13 +19863,13 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
 				"os-locale": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+					"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"dev": true,
 					"requires": {
@@ -21185,7 +19914,7 @@
 					"dependencies": {
 						"chalk": {
 							"version": "1.1.3",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+							"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 							"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 							"dev": true,
 							"requires": {
@@ -21314,7 +20043,7 @@
 				},
 				"yargs": {
 					"version": "3.32.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+					"resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
 					"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
 					"dev": true,
 					"requires": {
@@ -21343,1973 +20072,13 @@
 			}
 		},
 		"stylelint-config-primer": {
-			"version": "2.2.8",
+			"version": "2.2.10",
 			"dev": true,
 			"requires": {
 				"stylelint-no-unsupported-browser-features": "^1.0.0",
 				"stylelint-order": "^0.4.4",
 				"stylelint-scss": "^1.4.1",
-				"stylelint-selector-no-utility": "1.8.8"
-			},
-			"dependencies": {
-				"stylelint-selector-no-utility": {
-					"version": "1.8.8",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"primer-utilities": "4.11.1",
-						"stylelint": "^7.13.0"
-					},
-					"dependencies": {
-						"JSONStream": {
-							"version": "0.8.4",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"jsonparse": "0.0.5",
-								"through": ">=2.2.7 <3"
-							}
-						},
-						"ajv": {
-							"version": "6.5.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"fast-deep-equal": "^2.0.1",
-								"fast-json-stable-stringify": "^2.0.0",
-								"json-schema-traverse": "^0.4.1",
-								"uri-js": "^4.2.1"
-							}
-						},
-						"ajv-keywords": {
-							"version": "3.2.0",
-							"bundled": true,
-							"dev": true
-						},
-						"amdefine": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true
-						},
-						"ansi-regex": {
-							"version": "2.1.1",
-							"bundled": true,
-							"dev": true
-						},
-						"ansi-styles": {
-							"version": "2.2.1",
-							"bundled": true,
-							"dev": true
-						},
-						"argparse": {
-							"version": "1.0.10",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"sprintf-js": "~1.0.2"
-							}
-						},
-						"arr-diff": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"arr-flatten": "^1.0.1"
-							}
-						},
-						"arr-flatten": {
-							"version": "1.1.0",
-							"bundled": true,
-							"dev": true
-						},
-						"array-differ": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"array-find-index": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true
-						},
-						"array-union": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"array-uniq": "^1.0.1"
-							}
-						},
-						"array-uniq": {
-							"version": "1.0.3",
-							"bundled": true,
-							"dev": true
-						},
-						"array-unique": {
-							"version": "0.2.1",
-							"bundled": true,
-							"dev": true
-						},
-						"arrify": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true
-						},
-						"autoprefixer": {
-							"version": "6.7.7",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"browserslist": "^1.7.6",
-								"caniuse-db": "^1.0.30000634",
-								"normalize-range": "^0.1.2",
-								"num2fraction": "^1.2.2",
-								"postcss": "^5.2.16",
-								"postcss-value-parser": "^3.2.3"
-							}
-						},
-						"balanced-match": {
-							"version": "0.4.2",
-							"bundled": true,
-							"dev": true
-						},
-						"brace-expansion": {
-							"version": "1.1.11",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"balanced-match": "^1.0.0",
-								"concat-map": "0.0.1"
-							},
-							"dependencies": {
-								"balanced-match": {
-									"version": "1.0.0",
-									"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-									"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-									"dev": true
-								}
-							}
-						},
-						"braces": {
-							"version": "1.8.5",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"expand-range": "^1.8.1",
-								"preserve": "^0.2.0",
-								"repeat-element": "^1.1.2"
-							}
-						},
-						"browserslist": {
-							"version": "1.7.7",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"caniuse-db": "^1.0.30000639",
-								"electron-to-chromium": "^1.2.7"
-							}
-						},
-						"builtin-modules": {
-							"version": "1.1.1",
-							"bundled": true,
-							"dev": true
-						},
-						"camelcase": {
-							"version": "2.1.1",
-							"bundled": true,
-							"dev": true
-						},
-						"camelcase-keys": {
-							"version": "2.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"camelcase": "^2.0.0",
-								"map-obj": "^1.0.0"
-							}
-						},
-						"caniuse-db": {
-							"version": "1.0.30000858",
-							"bundled": true,
-							"dev": true
-						},
-						"chalk": {
-							"version": "2.4.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^3.2.1",
-								"escape-string-regexp": "^1.0.5",
-								"supports-color": "^5.3.0"
-							},
-							"dependencies": {
-								"ansi-styles": {
-									"version": "3.2.1",
-									"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-									"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-									"dev": true,
-									"requires": {
-										"color-convert": "^1.9.0"
-									}
-								},
-								"has-flag": {
-									"version": "3.0.0",
-									"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-									"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-									"dev": true
-								},
-								"supports-color": {
-									"version": "5.4.0",
-									"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-									"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-									"dev": true,
-									"requires": {
-										"has-flag": "^3.0.0"
-									}
-								}
-							}
-						},
-						"circular-json": {
-							"version": "0.3.3",
-							"bundled": true,
-							"dev": true
-						},
-						"cliui": {
-							"version": "3.2.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"string-width": "^1.0.1",
-								"strip-ansi": "^3.0.1",
-								"wrap-ansi": "^2.0.0"
-							},
-							"dependencies": {
-								"string-width": {
-									"version": "1.0.2",
-									"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-									"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-									"dev": true,
-									"requires": {
-										"code-point-at": "^1.0.0",
-										"is-fullwidth-code-point": "^1.0.0",
-										"strip-ansi": "^3.0.0"
-									}
-								}
-							}
-						},
-						"clone-regexp": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-regexp": "^1.0.0",
-								"is-supported-regexp-flag": "^1.0.0"
-							}
-						},
-						"code-point-at": {
-							"version": "1.1.0",
-							"bundled": true,
-							"dev": true
-						},
-						"color-convert": {
-							"version": "1.9.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"color-name": "1.1.1"
-							}
-						},
-						"color-diff": {
-							"version": "0.1.7",
-							"bundled": true,
-							"dev": true
-						},
-						"color-name": {
-							"version": "1.1.1",
-							"bundled": true,
-							"dev": true
-						},
-						"colorguard": {
-							"version": "1.2.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"chalk": "^1.1.1",
-								"color-diff": "^0.1.3",
-								"log-symbols": "^1.0.2",
-								"object-assign": "^4.0.1",
-								"pipetteur": "^2.0.0",
-								"plur": "^2.0.0",
-								"postcss": "^5.0.4",
-								"postcss-reporter": "^1.2.1",
-								"text-table": "^0.2.0",
-								"yargs": "^1.2.6"
-							},
-							"dependencies": {
-								"chalk": {
-									"version": "1.1.3",
-									"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-									"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-									"dev": true,
-									"requires": {
-										"ansi-styles": "^2.2.1",
-										"escape-string-regexp": "^1.0.2",
-										"has-ansi": "^2.0.0",
-										"strip-ansi": "^3.0.0",
-										"supports-color": "^2.0.0"
-									}
-								},
-								"postcss-reporter": {
-									"version": "1.4.1",
-									"resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-1.4.1.tgz",
-									"integrity": "sha1-wTbwpbFhkV83ndN2XGEHX357mvI=",
-									"dev": true,
-									"requires": {
-										"chalk": "^1.0.0",
-										"lodash": "^4.1.0",
-										"log-symbols": "^1.0.2",
-										"postcss": "^5.0.0"
-									}
-								},
-								"supports-color": {
-									"version": "2.0.0",
-									"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-									"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-									"dev": true
-								}
-							}
-						},
-						"concat-map": {
-							"version": "0.0.1",
-							"bundled": true,
-							"dev": true
-						},
-						"core-util-is": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true
-						},
-						"cosmiconfig": {
-							"version": "2.2.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-directory": "^0.3.1",
-								"js-yaml": "^3.4.3",
-								"minimist": "^1.2.0",
-								"object-assign": "^4.1.0",
-								"os-homedir": "^1.0.1",
-								"parse-json": "^2.2.0",
-								"require-from-string": "^1.1.0"
-							}
-						},
-						"css-color-names": {
-							"version": "0.0.3",
-							"bundled": true,
-							"dev": true
-						},
-						"css-rule-stream": {
-							"version": "1.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"css-tokenize": "^1.0.1",
-								"duplexer2": "0.0.2",
-								"ldjson-stream": "^1.2.1",
-								"through2": "^0.6.3"
-							}
-						},
-						"css-tokenize": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"inherits": "^2.0.1",
-								"readable-stream": "^1.0.33"
-							}
-						},
-						"currently-unhandled": {
-							"version": "0.4.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"array-find-index": "^1.0.1"
-							}
-						},
-						"debug": {
-							"version": "2.6.9",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ms": "2.0.0"
-							}
-						},
-						"decamelize": {
-							"version": "1.2.0",
-							"bundled": true,
-							"dev": true
-						},
-						"del": {
-							"version": "2.2.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"globby": "^5.0.0",
-								"is-path-cwd": "^1.0.0",
-								"is-path-in-cwd": "^1.0.0",
-								"object-assign": "^4.0.1",
-								"pify": "^2.0.0",
-								"pinkie-promise": "^2.0.0",
-								"rimraf": "^2.2.8"
-							},
-							"dependencies": {
-								"globby": {
-									"version": "5.0.0",
-									"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-									"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-									"dev": true,
-									"requires": {
-										"array-union": "^1.0.1",
-										"arrify": "^1.0.0",
-										"glob": "^7.0.3",
-										"object-assign": "^4.0.1",
-										"pify": "^2.0.0",
-										"pinkie-promise": "^2.0.0"
-									}
-								}
-							}
-						},
-						"doiuse": {
-							"version": "2.6.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"browserslist": "^1.1.1",
-								"caniuse-db": "^1.0.30000187",
-								"css-rule-stream": "^1.1.0",
-								"duplexer2": "0.0.2",
-								"jsonfilter": "^1.1.2",
-								"ldjson-stream": "^1.2.1",
-								"lodash": "^4.0.0",
-								"multimatch": "^2.0.0",
-								"postcss": "^5.0.8",
-								"source-map": "^0.4.2",
-								"through2": "^0.6.3",
-								"yargs": "^3.5.4"
-							},
-							"dependencies": {
-								"source-map": {
-									"version": "0.4.4",
-									"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-									"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-									"dev": true,
-									"requires": {
-										"amdefine": ">=0.0.4"
-									}
-								},
-								"string-width": {
-									"version": "1.0.2",
-									"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-									"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-									"dev": true,
-									"requires": {
-										"code-point-at": "^1.0.0",
-										"is-fullwidth-code-point": "^1.0.0",
-										"strip-ansi": "^3.0.0"
-									}
-								},
-								"yargs": {
-									"version": "3.32.0",
-									"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-									"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-									"dev": true,
-									"requires": {
-										"camelcase": "^2.0.1",
-										"cliui": "^3.0.3",
-										"decamelize": "^1.1.1",
-										"os-locale": "^1.4.0",
-										"string-width": "^1.0.1",
-										"window-size": "^0.1.4",
-										"y18n": "^3.2.0"
-									}
-								}
-							}
-						},
-						"duplexer": {
-							"version": "0.1.1",
-							"bundled": true,
-							"dev": true
-						},
-						"duplexer2": {
-							"version": "0.0.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"readable-stream": "~1.1.9"
-							}
-						},
-						"electron-to-chromium": {
-							"version": "1.3.50",
-							"bundled": true,
-							"dev": true
-						},
-						"error-ex": {
-							"version": "1.3.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-arrayish": "^0.2.1"
-							}
-						},
-						"escape-string-regexp": {
-							"version": "1.0.5",
-							"bundled": true,
-							"dev": true
-						},
-						"esprima": {
-							"version": "4.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"execall": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"clone-regexp": "^1.0.0"
-							}
-						},
-						"expand-brackets": {
-							"version": "0.1.5",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-posix-bracket": "^0.1.0"
-							}
-						},
-						"expand-range": {
-							"version": "1.8.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"fill-range": "^2.1.0"
-							}
-						},
-						"extglob": {
-							"version": "0.3.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-extglob": "^1.0.0"
-							}
-						},
-						"fast-deep-equal": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true
-						},
-						"fast-json-stable-stringify": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"file-entry-cache": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"flat-cache": "^1.2.1",
-								"object-assign": "^4.0.1"
-							}
-						},
-						"filename-regex": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true
-						},
-						"fill-range": {
-							"version": "2.2.4",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-number": "^2.1.0",
-								"isobject": "^2.0.0",
-								"randomatic": "^3.0.0",
-								"repeat-element": "^1.1.2",
-								"repeat-string": "^1.5.2"
-							}
-						},
-						"find-up": {
-							"version": "1.1.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"path-exists": "^2.0.0",
-								"pinkie-promise": "^2.0.0"
-							}
-						},
-						"flat-cache": {
-							"version": "1.3.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"circular-json": "^0.3.1",
-								"del": "^2.0.2",
-								"graceful-fs": "^4.1.2",
-								"write": "^0.2.1"
-							}
-						},
-						"flatten": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true
-						},
-						"for-in": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true
-						},
-						"for-own": {
-							"version": "0.1.5",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"for-in": "^1.0.1"
-							}
-						},
-						"fs.realpath": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"gather-stream": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"get-stdin": {
-							"version": "5.0.1",
-							"bundled": true,
-							"dev": true
-						},
-						"glob": {
-							"version": "7.1.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"fs.realpath": "^1.0.0",
-								"inflight": "^1.0.4",
-								"inherits": "2",
-								"minimatch": "^3.0.4",
-								"once": "^1.3.0",
-								"path-is-absolute": "^1.0.0"
-							}
-						},
-						"glob-base": {
-							"version": "0.3.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"glob-parent": "^2.0.0",
-								"is-glob": "^2.0.0"
-							}
-						},
-						"glob-parent": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-glob": "^2.0.0"
-							}
-						},
-						"globby": {
-							"version": "6.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"array-union": "^1.0.1",
-								"glob": "^7.0.3",
-								"object-assign": "^4.0.1",
-								"pify": "^2.0.0",
-								"pinkie-promise": "^2.0.0"
-							}
-						},
-						"globjoin": {
-							"version": "0.1.4",
-							"bundled": true,
-							"dev": true
-						},
-						"graceful-fs": {
-							"version": "4.1.11",
-							"bundled": true,
-							"dev": true
-						},
-						"has-ansi": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^2.0.0"
-							}
-						},
-						"has-flag": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"hosted-git-info": {
-							"version": "2.6.1",
-							"bundled": true,
-							"dev": true
-						},
-						"html-tags": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"ignore": {
-							"version": "3.3.10",
-							"bundled": true,
-							"dev": true
-						},
-						"imurmurhash": {
-							"version": "0.1.4",
-							"bundled": true,
-							"dev": true
-						},
-						"indent-string": {
-							"version": "2.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"repeating": "^2.0.0"
-							}
-						},
-						"indexes-of": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true
-						},
-						"inflight": {
-							"version": "1.0.6",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"once": "^1.3.0",
-								"wrappy": "1"
-							}
-						},
-						"inherits": {
-							"version": "2.0.3",
-							"bundled": true,
-							"dev": true
-						},
-						"invert-kv": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"irregular-plurals": {
-							"version": "1.4.0",
-							"bundled": true,
-							"dev": true
-						},
-						"is-arrayish": {
-							"version": "0.2.1",
-							"bundled": true,
-							"dev": true
-						},
-						"is-buffer": {
-							"version": "1.1.6",
-							"bundled": true,
-							"dev": true
-						},
-						"is-builtin-module": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"builtin-modules": "^1.0.0"
-							}
-						},
-						"is-directory": {
-							"version": "0.3.1",
-							"bundled": true,
-							"dev": true
-						},
-						"is-dotfile": {
-							"version": "1.0.3",
-							"bundled": true,
-							"dev": true
-						},
-						"is-equal-shallow": {
-							"version": "0.1.3",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-primitive": "^2.0.0"
-							}
-						},
-						"is-extendable": {
-							"version": "0.1.1",
-							"bundled": true,
-							"dev": true
-						},
-						"is-extglob": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"is-finite": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"number-is-nan": "^1.0.0"
-							}
-						},
-						"is-fullwidth-code-point": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"number-is-nan": "^1.0.0"
-							}
-						},
-						"is-glob": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-extglob": "^1.0.0"
-							}
-						},
-						"is-number": {
-							"version": "2.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"kind-of": "^3.0.2"
-							}
-						},
-						"is-path-cwd": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"is-path-in-cwd": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-path-inside": "^1.0.0"
-							}
-						},
-						"is-path-inside": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"path-is-inside": "^1.0.1"
-							}
-						},
-						"is-posix-bracket": {
-							"version": "0.1.1",
-							"bundled": true,
-							"dev": true
-						},
-						"is-primitive": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"is-regexp": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"is-supported-regexp-flag": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true
-						},
-						"is-utf8": {
-							"version": "0.2.1",
-							"bundled": true,
-							"dev": true
-						},
-						"isarray": {
-							"version": "0.0.1",
-							"bundled": true,
-							"dev": true
-						},
-						"isobject": {
-							"version": "2.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"isarray": "1.0.0"
-							},
-							"dependencies": {
-								"isarray": {
-									"version": "1.0.0",
-									"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-									"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-									"dev": true
-								}
-							}
-						},
-						"js-base64": {
-							"version": "2.4.5",
-							"bundled": true,
-							"dev": true
-						},
-						"js-yaml": {
-							"version": "3.12.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"argparse": "^1.0.7",
-								"esprima": "^4.0.0"
-							}
-						},
-						"json-schema-traverse": {
-							"version": "0.4.1",
-							"bundled": true,
-							"dev": true
-						},
-						"jsonfilter": {
-							"version": "1.1.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"JSONStream": "^0.8.4",
-								"minimist": "^1.1.0",
-								"stream-combiner": "^0.2.1",
-								"through2": "^0.6.3"
-							}
-						},
-						"jsonparse": {
-							"version": "0.0.5",
-							"bundled": true,
-							"dev": true
-						},
-						"kind-of": {
-							"version": "3.2.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						},
-						"known-css-properties": {
-							"version": "0.2.0",
-							"bundled": true,
-							"dev": true
-						},
-						"lcid": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"invert-kv": "^1.0.0"
-							}
-						},
-						"ldjson-stream": {
-							"version": "1.2.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"split2": "^0.2.1",
-								"through2": "^0.6.1"
-							}
-						},
-						"load-json-file": {
-							"version": "1.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"graceful-fs": "^4.1.2",
-								"parse-json": "^2.2.0",
-								"pify": "^2.0.0",
-								"pinkie-promise": "^2.0.0",
-								"strip-bom": "^2.0.0"
-							}
-						},
-						"lodash": {
-							"version": "4.17.10",
-							"bundled": true,
-							"dev": true
-						},
-						"log-symbols": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"chalk": "^1.0.0"
-							},
-							"dependencies": {
-								"chalk": {
-									"version": "1.1.3",
-									"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-									"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-									"dev": true,
-									"requires": {
-										"ansi-styles": "^2.2.1",
-										"escape-string-regexp": "^1.0.2",
-										"has-ansi": "^2.0.0",
-										"strip-ansi": "^3.0.0",
-										"supports-color": "^2.0.0"
-									}
-								},
-								"supports-color": {
-									"version": "2.0.0",
-									"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-									"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-									"dev": true
-								}
-							}
-						},
-						"loud-rejection": {
-							"version": "1.6.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"currently-unhandled": "^0.4.1",
-								"signal-exit": "^3.0.0"
-							}
-						},
-						"map-obj": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true
-						},
-						"math-random": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true
-						},
-						"mathml-tag-names": {
-							"version": "2.1.0",
-							"bundled": true,
-							"dev": true
-						},
-						"meow": {
-							"version": "3.7.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"camelcase-keys": "^2.0.0",
-								"decamelize": "^1.1.2",
-								"loud-rejection": "^1.0.0",
-								"map-obj": "^1.0.1",
-								"minimist": "^1.1.3",
-								"normalize-package-data": "^2.3.4",
-								"object-assign": "^4.0.1",
-								"read-pkg-up": "^1.0.1",
-								"redent": "^1.0.0",
-								"trim-newlines": "^1.0.0"
-							}
-						},
-						"micromatch": {
-							"version": "2.3.11",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"arr-diff": "^2.0.0",
-								"array-unique": "^0.2.1",
-								"braces": "^1.8.2",
-								"expand-brackets": "^0.1.4",
-								"extglob": "^0.3.1",
-								"filename-regex": "^2.0.0",
-								"is-extglob": "^1.0.0",
-								"is-glob": "^2.0.1",
-								"kind-of": "^3.0.2",
-								"normalize-path": "^2.0.1",
-								"object.omit": "^2.0.0",
-								"parse-glob": "^3.0.4",
-								"regex-cache": "^0.4.2"
-							}
-						},
-						"minimatch": {
-							"version": "3.0.4",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"brace-expansion": "^1.1.7"
-							}
-						},
-						"minimist": {
-							"version": "1.2.0",
-							"bundled": true,
-							"dev": true
-						},
-						"mkdirp": {
-							"version": "0.5.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"minimist": "0.0.8"
-							},
-							"dependencies": {
-								"minimist": {
-									"version": "0.0.8",
-									"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-									"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-									"dev": true
-								}
-							}
-						},
-						"ms": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"multimatch": {
-							"version": "2.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"array-differ": "^1.0.0",
-								"array-union": "^1.0.1",
-								"arrify": "^1.0.0",
-								"minimatch": "^3.0.0"
-							}
-						},
-						"normalize-package-data": {
-							"version": "2.4.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"hosted-git-info": "^2.1.4",
-								"is-builtin-module": "^1.0.0",
-								"semver": "2 || 3 || 4 || 5",
-								"validate-npm-package-license": "^3.0.1"
-							}
-						},
-						"normalize-path": {
-							"version": "2.1.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"remove-trailing-separator": "^1.0.1"
-							}
-						},
-						"normalize-range": {
-							"version": "0.1.2",
-							"bundled": true,
-							"dev": true
-						},
-						"normalize-selector": {
-							"version": "0.2.0",
-							"bundled": true,
-							"dev": true
-						},
-						"num2fraction": {
-							"version": "1.2.2",
-							"bundled": true,
-							"dev": true
-						},
-						"number-is-nan": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true
-						},
-						"object-assign": {
-							"version": "4.1.1",
-							"bundled": true,
-							"dev": true
-						},
-						"object.omit": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"for-own": "^0.1.4",
-								"is-extendable": "^0.1.1"
-							}
-						},
-						"once": {
-							"version": "1.4.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"wrappy": "1"
-							}
-						},
-						"onecolor": {
-							"version": "3.0.5",
-							"bundled": true,
-							"dev": true
-						},
-						"os-homedir": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true
-						},
-						"os-locale": {
-							"version": "1.4.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"lcid": "^1.0.0"
-							}
-						},
-						"parse-glob": {
-							"version": "3.0.4",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"glob-base": "^0.3.0",
-								"is-dotfile": "^1.0.0",
-								"is-extglob": "^1.0.0",
-								"is-glob": "^2.0.0"
-							}
-						},
-						"parse-json": {
-							"version": "2.2.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"error-ex": "^1.2.0"
-							}
-						},
-						"path-exists": {
-							"version": "2.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"pinkie-promise": "^2.0.0"
-							}
-						},
-						"path-is-absolute": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true
-						},
-						"path-is-inside": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true
-						},
-						"path-type": {
-							"version": "1.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"graceful-fs": "^4.1.2",
-								"pify": "^2.0.0",
-								"pinkie-promise": "^2.0.0"
-							}
-						},
-						"pify": {
-							"version": "2.3.0",
-							"bundled": true,
-							"dev": true
-						},
-						"pinkie": {
-							"version": "2.0.4",
-							"bundled": true,
-							"dev": true
-						},
-						"pinkie-promise": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"pinkie": "^2.0.0"
-							}
-						},
-						"pipetteur": {
-							"version": "2.0.3",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"onecolor": "^3.0.4",
-								"synesthesia": "^1.0.1"
-							}
-						},
-						"plur": {
-							"version": "2.1.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"irregular-plurals": "^1.0.0"
-							}
-						},
-						"postcss": {
-							"version": "5.2.18",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"chalk": "^1.1.3",
-								"js-base64": "^2.1.9",
-								"source-map": "^0.5.6",
-								"supports-color": "^3.2.3"
-							},
-							"dependencies": {
-								"chalk": {
-									"version": "1.1.3",
-									"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-									"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-									"dev": true,
-									"requires": {
-										"ansi-styles": "^2.2.1",
-										"escape-string-regexp": "^1.0.2",
-										"has-ansi": "^2.0.0",
-										"strip-ansi": "^3.0.0",
-										"supports-color": "^2.0.0"
-									},
-									"dependencies": {
-										"supports-color": {
-											"version": "2.0.0",
-											"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-											"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-											"dev": true
-										}
-									}
-								}
-							}
-						},
-						"postcss-less": {
-							"version": "0.14.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"postcss": "^5.0.21"
-							}
-						},
-						"postcss-media-query-parser": {
-							"version": "0.2.3",
-							"bundled": true,
-							"dev": true
-						},
-						"postcss-reporter": {
-							"version": "3.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"chalk": "^1.0.0",
-								"lodash": "^4.1.0",
-								"log-symbols": "^1.0.2",
-								"postcss": "^5.0.0"
-							},
-							"dependencies": {
-								"chalk": {
-									"version": "1.1.3",
-									"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-									"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-									"dev": true,
-									"requires": {
-										"ansi-styles": "^2.2.1",
-										"escape-string-regexp": "^1.0.2",
-										"has-ansi": "^2.0.0",
-										"strip-ansi": "^3.0.0",
-										"supports-color": "^2.0.0"
-									}
-								},
-								"supports-color": {
-									"version": "2.0.0",
-									"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-									"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-									"dev": true
-								}
-							}
-						},
-						"postcss-resolve-nested-selector": {
-							"version": "0.1.1",
-							"bundled": true,
-							"dev": true
-						},
-						"postcss-scss": {
-							"version": "0.4.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"postcss": "^5.2.13"
-							}
-						},
-						"postcss-selector-parser": {
-							"version": "2.2.3",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"flatten": "^1.0.2",
-								"indexes-of": "^1.0.1",
-								"uniq": "^1.0.1"
-							}
-						},
-						"postcss-value-parser": {
-							"version": "3.3.0",
-							"bundled": true,
-							"dev": true
-						},
-						"preserve": {
-							"version": "0.2.0",
-							"bundled": true,
-							"dev": true
-						},
-						"primer-utilities": {
-							"version": "4.11.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"primer-support": "4.5.4"
-							},
-							"dependencies": {
-								"primer-support": {
-									"version": "4.5.4",
-									"bundled": true,
-									"dev": true
-								}
-							}
-						},
-						"punycode": {
-							"version": "2.1.1",
-							"bundled": true,
-							"dev": true
-						},
-						"randomatic": {
-							"version": "3.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-number": "^4.0.0",
-								"kind-of": "^6.0.0",
-								"math-random": "^1.0.1"
-							},
-							"dependencies": {
-								"is-number": {
-									"version": "4.0.0",
-									"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-									"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-									"dev": true
-								},
-								"kind-of": {
-									"version": "6.0.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-									"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-									"dev": true
-								}
-							}
-						},
-						"read-file-stdin": {
-							"version": "0.2.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"gather-stream": "^1.0.0"
-							}
-						},
-						"read-pkg": {
-							"version": "1.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"load-json-file": "^1.0.0",
-								"normalize-package-data": "^2.3.2",
-								"path-type": "^1.0.0"
-							}
-						},
-						"read-pkg-up": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"find-up": "^1.0.0",
-								"read-pkg": "^1.0.0"
-							}
-						},
-						"readable-stream": {
-							"version": "1.1.14",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.1",
-								"isarray": "0.0.1",
-								"string_decoder": "~0.10.x"
-							}
-						},
-						"redent": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"indent-string": "^2.1.0",
-								"strip-indent": "^1.0.1"
-							}
-						},
-						"regex-cache": {
-							"version": "0.4.4",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-equal-shallow": "^0.1.3"
-							}
-						},
-						"remove-trailing-separator": {
-							"version": "1.1.0",
-							"bundled": true,
-							"dev": true
-						},
-						"repeat-element": {
-							"version": "1.1.2",
-							"bundled": true,
-							"dev": true
-						},
-						"repeat-string": {
-							"version": "1.6.1",
-							"bundled": true,
-							"dev": true
-						},
-						"repeating": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-finite": "^1.0.0"
-							}
-						},
-						"require-from-string": {
-							"version": "1.2.1",
-							"bundled": true,
-							"dev": true
-						},
-						"resolve-from": {
-							"version": "3.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"rimraf": {
-							"version": "2.6.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"glob": "^7.0.5"
-							}
-						},
-						"semver": {
-							"version": "5.5.0",
-							"bundled": true,
-							"dev": true
-						},
-						"signal-exit": {
-							"version": "3.0.2",
-							"bundled": true,
-							"dev": true
-						},
-						"slice-ansi": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-fullwidth-code-point": "^2.0.0"
-							},
-							"dependencies": {
-								"is-fullwidth-code-point": {
-									"version": "2.0.0",
-									"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-									"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-									"dev": true
-								}
-							}
-						},
-						"source-map": {
-							"version": "0.5.7",
-							"bundled": true,
-							"dev": true
-						},
-						"spdx-correct": {
-							"version": "3.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"spdx-expression-parse": "^3.0.0",
-								"spdx-license-ids": "^3.0.0"
-							}
-						},
-						"spdx-exceptions": {
-							"version": "2.1.0",
-							"bundled": true,
-							"dev": true
-						},
-						"spdx-expression-parse": {
-							"version": "3.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"spdx-exceptions": "^2.1.0",
-								"spdx-license-ids": "^3.0.0"
-							}
-						},
-						"spdx-license-ids": {
-							"version": "3.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"specificity": {
-							"version": "0.3.2",
-							"bundled": true,
-							"dev": true
-						},
-						"split2": {
-							"version": "0.2.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"through2": "~0.6.1"
-							}
-						},
-						"sprintf-js": {
-							"version": "1.0.3",
-							"bundled": true,
-							"dev": true
-						},
-						"stream-combiner": {
-							"version": "0.2.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"duplexer": "~0.1.1",
-								"through": "~2.3.4"
-							}
-						},
-						"string-width": {
-							"version": "2.1.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-fullwidth-code-point": "^2.0.0",
-								"strip-ansi": "^4.0.0"
-							},
-							"dependencies": {
-								"ansi-regex": {
-									"version": "3.0.0",
-									"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-									"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-									"dev": true
-								},
-								"is-fullwidth-code-point": {
-									"version": "2.0.0",
-									"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-									"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-									"dev": true
-								},
-								"strip-ansi": {
-									"version": "4.0.0",
-									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-									"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-									"dev": true,
-									"requires": {
-										"ansi-regex": "^3.0.0"
-									}
-								}
-							}
-						},
-						"string_decoder": {
-							"version": "0.10.31",
-							"bundled": true,
-							"dev": true
-						},
-						"strip-ansi": {
-							"version": "3.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^2.0.0"
-							}
-						},
-						"strip-bom": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-utf8": "^0.2.0"
-							}
-						},
-						"strip-indent": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"get-stdin": "^4.0.1"
-							},
-							"dependencies": {
-								"get-stdin": {
-									"version": "4.0.1",
-									"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-									"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-									"dev": true
-								}
-							}
-						},
-						"style-search": {
-							"version": "0.1.0",
-							"bundled": true,
-							"dev": true
-						},
-						"stylehacks": {
-							"version": "2.3.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"browserslist": "^1.1.3",
-								"chalk": "^1.1.1",
-								"log-symbols": "^1.0.2",
-								"minimist": "^1.2.0",
-								"plur": "^2.1.2",
-								"postcss": "^5.0.18",
-								"postcss-reporter": "^1.3.3",
-								"postcss-selector-parser": "^2.0.0",
-								"read-file-stdin": "^0.2.1",
-								"text-table": "^0.2.0",
-								"write-file-stdout": "0.0.2"
-							},
-							"dependencies": {
-								"chalk": {
-									"version": "1.1.3",
-									"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-									"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-									"dev": true,
-									"requires": {
-										"ansi-styles": "^2.2.1",
-										"escape-string-regexp": "^1.0.2",
-										"has-ansi": "^2.0.0",
-										"strip-ansi": "^3.0.0",
-										"supports-color": "^2.0.0"
-									}
-								},
-								"postcss-reporter": {
-									"version": "1.4.1",
-									"resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-1.4.1.tgz",
-									"integrity": "sha1-wTbwpbFhkV83ndN2XGEHX357mvI=",
-									"dev": true,
-									"requires": {
-										"chalk": "^1.0.0",
-										"lodash": "^4.1.0",
-										"log-symbols": "^1.0.2",
-										"postcss": "^5.0.0"
-									}
-								},
-								"supports-color": {
-									"version": "2.0.0",
-									"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-									"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-									"dev": true
-								}
-							}
-						},
-						"stylelint": {
-							"version": "7.13.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"autoprefixer": "^6.0.0",
-								"balanced-match": "^0.4.0",
-								"chalk": "^2.0.1",
-								"colorguard": "^1.2.0",
-								"cosmiconfig": "^2.1.1",
-								"debug": "^2.6.0",
-								"doiuse": "^2.4.1",
-								"execall": "^1.0.0",
-								"file-entry-cache": "^2.0.0",
-								"get-stdin": "^5.0.0",
-								"globby": "^6.0.0",
-								"globjoin": "^0.1.4",
-								"html-tags": "^2.0.0",
-								"ignore": "^3.2.0",
-								"imurmurhash": "^0.1.4",
-								"known-css-properties": "^0.2.0",
-								"lodash": "^4.17.4",
-								"log-symbols": "^1.0.2",
-								"mathml-tag-names": "^2.0.0",
-								"meow": "^3.3.0",
-								"micromatch": "^2.3.11",
-								"normalize-selector": "^0.2.0",
-								"pify": "^2.3.0",
-								"postcss": "^5.0.20",
-								"postcss-less": "^0.14.0",
-								"postcss-media-query-parser": "^0.2.0",
-								"postcss-reporter": "^3.0.0",
-								"postcss-resolve-nested-selector": "^0.1.1",
-								"postcss-scss": "^0.4.0",
-								"postcss-selector-parser": "^2.1.1",
-								"postcss-value-parser": "^3.1.1",
-								"resolve-from": "^3.0.0",
-								"specificity": "^0.3.0",
-								"string-width": "^2.0.0",
-								"style-search": "^0.1.0",
-								"stylehacks": "^2.3.2",
-								"sugarss": "^0.2.0",
-								"svg-tags": "^1.0.0",
-								"table": "^4.0.1"
-							}
-						},
-						"sugarss": {
-							"version": "0.2.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"postcss": "^5.2.4"
-							}
-						},
-						"supports-color": {
-							"version": "3.2.3",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"has-flag": "^1.0.0"
-							}
-						},
-						"svg-tags": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"synesthesia": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"css-color-names": "0.0.3"
-							}
-						},
-						"table": {
-							"version": "4.0.3",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ajv": "^6.0.1",
-								"ajv-keywords": "^3.0.0",
-								"chalk": "^2.1.0",
-								"lodash": "^4.17.4",
-								"slice-ansi": "1.0.0",
-								"string-width": "^2.1.1"
-							}
-						},
-						"text-table": {
-							"version": "0.2.0",
-							"bundled": true,
-							"dev": true
-						},
-						"through": {
-							"version": "2.3.8",
-							"bundled": true,
-							"dev": true
-						},
-						"through2": {
-							"version": "0.6.5",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"readable-stream": ">=1.0.33-1 <1.1.0-0",
-								"xtend": ">=4.0.0 <4.1.0-0"
-							},
-							"dependencies": {
-								"readable-stream": {
-									"version": "1.0.34",
-									"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-									"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-									"dev": true,
-									"requires": {
-										"core-util-is": "~1.0.0",
-										"inherits": "~2.0.1",
-										"isarray": "0.0.1",
-										"string_decoder": "~0.10.x"
-									}
-								}
-							}
-						},
-						"trim-newlines": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"uniq": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true
-						},
-						"uri-js": {
-							"version": "4.2.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"punycode": "^2.1.0"
-							}
-						},
-						"validate-npm-package-license": {
-							"version": "3.0.3",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"spdx-correct": "^3.0.0",
-								"spdx-expression-parse": "^3.0.0"
-							}
-						},
-						"window-size": {
-							"version": "0.1.4",
-							"bundled": true,
-							"dev": true
-						},
-						"wrap-ansi": {
-							"version": "2.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"string-width": "^1.0.1",
-								"strip-ansi": "^3.0.1"
-							},
-							"dependencies": {
-								"string-width": {
-									"version": "1.0.2",
-									"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-									"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-									"dev": true,
-									"requires": {
-										"code-point-at": "^1.0.0",
-										"is-fullwidth-code-point": "^1.0.0",
-										"strip-ansi": "^3.0.0"
-									}
-								}
-							}
-						},
-						"wrappy": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true
-						},
-						"write": {
-							"version": "0.2.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"mkdirp": "^0.5.1"
-							}
-						},
-						"write-file-stdout": {
-							"version": "0.0.2",
-							"bundled": true,
-							"dev": true
-						},
-						"xtend": {
-							"version": "4.0.1",
-							"bundled": true,
-							"dev": true
-						},
-						"y18n": {
-							"version": "3.2.1",
-							"bundled": true,
-							"dev": true
-						},
-						"yargs": {
-							"version": "1.3.3",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				}
+				"stylelint-selector-no-utility": "1.8.10"
 			}
 		},
 		"stylelint-no-unsupported-browser-features": {
@@ -23324,90 +20093,10 @@
 				"stylelint": ">=5.0.0"
 			},
 			"dependencies": {
-				"autoprefixer": {
-					"version": "8.4.1",
-					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.4.1.tgz",
-					"integrity": "sha512-YqUclCBDXUT9Y7aQ8Xv+ja8yhTZYJoMsOD7WS++gZIJLCpCu+gPcKGDlhk6S3WxhLkTcNVdaMZAWys2nzZCH7g==",
-					"dev": true,
-					"requires": {
-						"browserslist": "^3.2.6",
-						"caniuse-lite": "^1.0.30000832",
-						"normalize-range": "^0.1.2",
-						"num2fraction": "^1.2.2",
-						"postcss": "^6.0.22",
-						"postcss-value-parser": "^3.2.3"
-					}
-				},
-				"browserslist": {
-					"version": "3.2.7",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.7.tgz",
-					"integrity": "sha512-oYVLxFVqpX9uMhOIQBLtZL+CX4uY8ZpWcjNTaxyWl5rO8yA9SSNikFnAfvk8J3P/7z3BZwNmEqFKaJoYltj3MQ==",
-					"dev": true,
-					"requires": {
-						"caniuse-lite": "^1.0.30000835",
-						"electron-to-chromium": "^1.3.45"
-					}
-				},
-				"get-stdin": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-					"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-					"dev": true
-				},
-				"globby": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
-					"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
-					"dev": true,
-					"requires": {
-						"array-union": "^1.0.1",
-						"dir-glob": "^2.0.0",
-						"fast-glob": "^2.0.2",
-						"glob": "^7.1.2",
-						"ignore": "^3.3.5",
-						"pify": "^3.0.0",
-						"slash": "^1.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
-					}
-				},
-				"meow": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
-					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-					"dev": true,
-					"requires": {
-						"camelcase-keys": "^4.0.0",
-						"decamelize-keys": "^1.0.0",
-						"loud-rejection": "^1.0.0",
-						"minimist": "^1.1.3",
-						"minimist-options": "^3.0.1",
-						"normalize-package-data": "^2.3.4",
-						"read-pkg-up": "^3.0.0",
-						"redent": "^2.0.0",
-						"trim-newlines": "^2.0.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				},
 				"postcss": {
-					"version": "6.0.22",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-					"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+					"version": "6.0.23",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
@@ -23415,90 +20104,11 @@
 						"supports-color": "^5.4.0"
 					}
 				},
-				"postcss-safe-parser": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-3.0.1.tgz",
-					"integrity": "sha1-t1Pv9sfArqXoN1++TN6L+QY/8UI=",
-					"dev": true,
-					"requires": {
-						"postcss": "^6.0.6"
-					}
-				},
-				"read-pkg": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^4.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
-					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^3.0.0"
-					}
-				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
-				},
-				"stylelint": {
-					"version": "9.2.0",
-					"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.2.0.tgz",
-					"integrity": "sha512-aBlnuLyTvyNfIVoc+reaqx88aW41Awc9Ccu7ZXrO2fnSvv0MVSQeyL3ci/nD1H1eYvH3X+MXTwMYC3Mf5+2Ckw==",
-					"dev": true,
-					"requires": {
-						"autoprefixer": "^8.0.0",
-						"balanced-match": "^1.0.0",
-						"chalk": "^2.0.1",
-						"cosmiconfig": "^4.0.0",
-						"debug": "^3.0.0",
-						"execall": "^1.0.0",
-						"file-entry-cache": "^2.0.0",
-						"get-stdin": "^6.0.0",
-						"globby": "^8.0.0",
-						"globjoin": "^0.1.4",
-						"html-tags": "^2.0.0",
-						"ignore": "^3.3.3",
-						"import-lazy": "^3.1.0",
-						"imurmurhash": "^0.1.4",
-						"known-css-properties": "^0.6.0",
-						"lodash": "^4.17.4",
-						"log-symbols": "^2.0.0",
-						"mathml-tag-names": "^2.0.1",
-						"meow": "^4.0.0",
-						"micromatch": "^2.3.11",
-						"normalize-selector": "^0.2.0",
-						"pify": "^3.0.0",
-						"postcss": "^6.0.16",
-						"postcss-html": "^0.18.0",
-						"postcss-less": "^1.1.5",
-						"postcss-media-query-parser": "^0.2.3",
-						"postcss-reporter": "^5.0.0",
-						"postcss-resolve-nested-selector": "^0.1.1",
-						"postcss-safe-parser": "^3.0.1",
-						"postcss-sass": "^0.3.0",
-						"postcss-scss": "^1.0.2",
-						"postcss-selector-parser": "^3.1.0",
-						"postcss-value-parser": "^3.3.0",
-						"resolve-from": "^4.0.0",
-						"signal-exit": "^3.0.2",
-						"specificity": "^0.3.1",
-						"string-width": "^2.1.0",
-						"style-search": "^0.1.0",
-						"sugarss": "^1.0.0",
-						"svg-tags": "^1.0.0",
-						"table": "^4.0.1"
-					}
 				}
 			}
 		},
@@ -23525,19 +20135,14 @@
 				"postcss-selector-parser": "^2.0.0",
 				"postcss-value-parser": "^3.3.0",
 				"stylelint": "^7.0.3"
-			},
-			"dependencies": {
-				"postcss-selector-parser": {
-					"version": "2.2.3",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-					"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-					"dev": true,
-					"requires": {
-						"flatten": "^1.0.2",
-						"indexes-of": "^1.0.1",
-						"uniq": "^1.0.1"
-					}
-				}
+			}
+		},
+		"stylelint-selector-no-utility": {
+			"version": "1.8.10",
+			"dev": true,
+			"requires": {
+				"primer-utilities": "4.12.0",
+				"stylelint": "^7.13.0"
 			}
 		},
 		"sudo-block": {
@@ -23559,7 +20164,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
@@ -23574,34 +20179,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				}
-			}
-		},
-		"sugarss": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/sugarss/-/sugarss-1.0.1.tgz",
-			"integrity": "sha512-3qgLZytikQQEVn1/FrhY7B68gPUUGY3R1Q1vTiD5xT+Ti1DP/8iZuwFet9ONs5+bmL8pZoDQ6JrQHVgrNlK6mA==",
-			"dev": true,
-			"requires": {
-				"postcss": "^6.0.14"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.22",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-					"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				}
 			}
@@ -23725,7 +20302,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
@@ -23756,7 +20333,7 @@
 				},
 				"external-editor": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+					"resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
 					"integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
 					"dev": true,
 					"requires": {
@@ -23821,7 +20398,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
@@ -23898,7 +20475,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				}
@@ -23939,14 +20516,6 @@
 				"pify": "^3.0.0",
 				"temp-dir": "^1.0.0",
 				"uuid": "^3.0.1"
-			},
-			"dependencies": {
-				"uuid": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-					"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-					"dev": true
-				}
 			}
 		},
 		"tempfile": {
@@ -23957,6 +20526,14 @@
 			"requires": {
 				"os-tmpdir": "^1.0.0",
 				"uuid": "^2.0.1"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "2.0.3",
+					"resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+					"dev": true
+				}
 			}
 		},
 		"term-size": {
@@ -23986,9 +20563,9 @@
 			}
 		},
 		"text-extensions": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
-			"integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
+			"integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
 			"dev": true
 		},
 		"text-table": {
@@ -23999,7 +20576,7 @@
 		},
 		"through": {
 			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},
@@ -24033,7 +20610,7 @@
 				},
 				"chalk": {
 					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
 					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
 					"dev": true,
 					"requires": {
@@ -24119,12 +20696,6 @@
 			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
 			"dev": true
 		},
-		"to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-			"dev": true
-		},
 		"to-object-path": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
@@ -24189,6 +20760,15 @@
 			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
 			"dev": true
 		},
+		"trim-repeated": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+			"integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.2"
+			}
+		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -24208,28 +20788,19 @@
 			"dev": true
 		},
 		"true-case-path": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
-			"integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
+			"integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
 			"dev": true,
 			"requires": {
-				"glob": "^6.0.4"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "6.0.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-					"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-					"dev": true,
-					"requires": {
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "2 || 3",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
+				"glob": "^7.1.2"
 			}
+		},
+		"tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"dev": true
 		},
 		"tty-browserify": {
 			"version": "0.0.0",
@@ -24238,16 +20809,19 @@
 			"dev": true
 		},
 		"tunnel": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-			"integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.5.tgz",
+			"integrity": "sha512-gj5sdqherx4VZKMcBA4vewER7zdK25Td+z1npBqpbDys4eJrLx+SlYjJvq1bDXs2irkuJM5pf8ktaEQVipkrbA==",
 			"dev": true
 		},
 		"tunnel-agent": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-			"integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-			"dev": true
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
 		},
 		"tweetnacl": {
 			"version": "0.14.5",
@@ -24257,11 +20831,12 @@
 			"optional": true
 		},
 		"twig": {
-			"version": "0.8.9",
-			"resolved": "https://registry.npmjs.org/twig/-/twig-0.8.9.tgz",
-			"integrity": "sha1-sVlPACtoTl8CnePlToe+xPCEtsI=",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/twig/-/twig-1.12.0.tgz",
+			"integrity": "sha512-zm5OQXb8bQDGQUPytFgjqMKHhqcz/s6pU6Nwsy+rKPhsoOOVwYeHnziiDGFzeTDiFd28M8EVkEO8we6ikcrGjQ==",
 			"dev": true,
 			"requires": {
+				"locutus": "^2.0.5",
 				"minimatch": "3.0.x",
 				"walk": "2.3.x"
 			}
@@ -24307,7 +20882,7 @@
 				},
 				"yargs": {
 					"version": "3.10.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+					"resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
 					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
 					"dev": true,
 					"requires": {
@@ -24508,15 +21083,6 @@
 				"uid2": "0.0.3"
 			}
 		},
-		"unist-util-find-all-after": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.2.tgz",
-			"integrity": "sha512-nDl79mKpffXojLpCimVXnxhlH/jjaTnDuScznU9J4jjsaUtBdDbxmlc109XtcqxY4SDO0SwzngsxxW8DIISt1w==",
-			"dev": true,
-			"requires": {
-				"unist-util-is": "^2.0.0"
-			}
-		},
 		"unist-util-find-before": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/unist-util-find-before/-/unist-util-find-before-2.0.2.tgz",
@@ -24649,9 +21215,9 @@
 			}
 		},
 		"untildify": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.2.tgz",
-			"integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E=",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
+			"integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==",
 			"dev": true
 		},
 		"unzip-response": {
@@ -24874,9 +21440,9 @@
 			"dev": true
 		},
 		"uuid": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-			"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
@@ -25031,9 +21597,9 @@
 			}
 		},
 		"walk": {
-			"version": "2.3.13",
-			"resolved": "https://registry.npmjs.org/walk/-/walk-2.3.13.tgz",
-			"integrity": "sha512-78SMe7To9U7kqVhSoGho3GfspA089ZDBIj2f8jElg2hi6lUCoagtDJ8sSMFNlpAh5Ib8Jt1gQ6Y7gh9mzHtFng==",
+			"version": "2.3.14",
+			"resolved": "https://registry.npmjs.org/walk/-/walk-2.3.14.tgz",
+			"integrity": "sha512-5skcWAUmySj6hkBdH6B6+3ddMjVQYH5Qy9QGbPmN8kVmLteXk+yVXg+yfk1nbX30EYakahLrr8iPcCxJQSCBeg==",
 			"dev": true,
 			"requires": {
 				"foreachasync": "^3.0.0"
@@ -25313,7 +21879,7 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {
@@ -25375,20 +21941,6 @@
 			"integrity": "sha1-wlLXx8WxtAKJdjDjRTx7/mkNnKE=",
 			"dev": true
 		},
-		"write-json-file": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
-			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
-			"dev": true,
-			"requires": {
-				"detect-indent": "^5.0.0",
-				"graceful-fs": "^4.1.2",
-				"make-dir": "^1.0.0",
-				"pify": "^3.0.0",
-				"sort-keys": "^2.0.0",
-				"write-file-atomic": "^2.0.0"
-			}
-		},
 		"write-pkg": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.1.0.tgz",
@@ -25397,6 +21949,22 @@
 			"requires": {
 				"sort-keys": "^2.0.0",
 				"write-json-file": "^2.2.0"
+			},
+			"dependencies": {
+				"write-json-file": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
+					"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
+					"dev": true,
+					"requires": {
+						"detect-indent": "^5.0.0",
+						"graceful-fs": "^4.1.2",
+						"make-dir": "^1.0.0",
+						"pify": "^3.0.0",
+						"sort-keys": "^2.0.0",
+						"write-file-atomic": "^2.0.0"
+					}
+				}
 			}
 		},
 		"x-is-string": {
@@ -25551,174 +22119,225 @@
 			}
 		},
 		"yeoman-doctor": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/yeoman-doctor/-/yeoman-doctor-2.1.0.tgz",
-			"integrity": "sha1-lKt4SJamT1Op+sRS1ekTPidQojY=",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/yeoman-doctor/-/yeoman-doctor-3.0.2.tgz",
+			"integrity": "sha512-/KbouQdKgnqxG6K3Tc8VBPAQLPbruQ7KkbinwR+ah507oOFobHnGs8kqj8oMfafY6rXInHdh7nC5YzicCR4Z0g==",
 			"dev": true,
 			"requires": {
-				"bin-version-check": "^2.1.0",
-				"chalk": "^1.0.0",
+				"ansi-styles": "^3.2.0",
+				"bin-version-check": "^3.0.0",
+				"chalk": "^2.3.0",
 				"each-async": "^1.1.1",
-				"log-symbols": "^1.0.1",
+				"latest-version": "^3.1.0",
+				"log-symbols": "^2.1.0",
 				"object-values": "^1.0.0",
 				"semver": "^5.0.3",
-				"twig": "^0.8.2",
+				"twig": "^1.10.5",
 				"user-home": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"log-symbols": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-					"dev": true,
-					"requires": {
-						"chalk": "^1.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				}
 			}
 		},
 		"yeoman-environment": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.0.6.tgz",
-			"integrity": "sha512-jzHBTTy8EPI4ImV8dpUMt+Q5zELkSU5xvGpndHcHudQ4tqN6YgIWaCGmRFl+HDchwRUkcgyjQ+n6/w5zlJBCPg==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.3.3.tgz",
+			"integrity": "sha512-HBpXdNw8V66EwqIFt01rNhSgX33BOzgVb9CxpIvESvCI4ELeOSniB6gV6RXwrBur8kmHZCIAkYQYpib7Qxx8FQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.1.0",
+				"chalk": "^2.4.1",
+				"cross-spawn": "^6.0.5",
 				"debug": "^3.1.0",
-				"diff": "^3.3.1",
+				"diff": "^3.5.0",
 				"escape-string-regexp": "^1.0.2",
-				"globby": "^6.1.0",
+				"globby": "^8.0.1",
 				"grouped-queue": "^0.3.3",
-				"inquirer": "^3.3.0",
+				"inquirer": "^6.0.0",
 				"is-scoped": "^1.0.0",
-				"lodash": "^4.17.4",
-				"log-symbols": "^2.1.0",
+				"lodash": "^4.17.10",
+				"log-symbols": "^2.2.0",
 				"mem-fs": "^1.1.0",
+				"strip-ansi": "^4.0.0",
 				"text-table": "^0.2.0",
-				"untildify": "^3.0.2"
+				"untildify": "^3.0.3"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"chardet": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+					"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+					"dev": true
+				},
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"external-editor": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+					"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+					"dev": true,
+					"requires": {
+						"chardet": "^0.7.0",
+						"iconv-lite": "^0.4.24",
+						"tmp": "^0.0.33"
+					}
+				},
+				"globby": {
+					"version": "8.0.1",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+					"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+					"dev": true,
+					"requires": {
+						"array-union": "^1.0.1",
+						"dir-glob": "^2.0.0",
+						"fast-glob": "^2.0.2",
+						"glob": "^7.1.2",
+						"ignore": "^3.3.5",
+						"pify": "^3.0.0",
+						"slash": "^1.0.0"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.24",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+					"dev": true,
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				},
+				"inquirer": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
+					"integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+					"dev": true,
+					"requires": {
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.0",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^3.0.0",
+						"figures": "^2.0.0",
+						"lodash": "^4.17.10",
+						"mute-stream": "0.0.7",
+						"run-async": "^2.2.0",
+						"rxjs": "^6.1.0",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^4.0.0",
+						"through": "^2.3.6"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"yo": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/yo/-/yo-2.0.2.tgz",
-			"integrity": "sha512-/mHx2YFH0xA/zR9OiycC0FTXDr8n59uYpM6rKWjWQutpMRUjbICt6H4OA26S3WRSLh0wuO+4iUMdo9erswnyRw==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/yo/-/yo-2.0.5.tgz",
+			"integrity": "sha512-PLyTNZSJjHkks/FIln+QE5PxV224MsekCzbROVhZEW0MvLyj/6ghWIVkdBmrwdAbapH8H9q21F1/pQ9Q0Lk9UA==",
 			"dev": true,
 			"requires": {
-				"async": "^2.1.4",
-				"chalk": "^1.0.0",
+				"async": "^2.6.1",
+				"chalk": "^2.4.1",
 				"cli-list": "^0.2.0",
-				"configstore": "^3.0.0",
-				"cross-spawn": "^5.0.1",
+				"configstore": "^3.1.2",
+				"cross-spawn": "^6.0.5",
 				"figures": "^2.0.0",
 				"fullname": "^3.2.0",
-				"global-tunnel-ng": "^2.1.1",
-				"got": "^8.0.3",
-				"humanize-string": "^1.0.0",
-				"inquirer": "^3.0.1",
-				"insight": "^0.8.4",
-				"lodash": "^4.17.4",
+				"global-tunnel-ng": "^2.5.3",
+				"got": "^8.3.2",
+				"humanize-string": "^1.0.2",
+				"inquirer": "^6.0.0",
+				"insight": "^0.10.1",
+				"lodash": "^4.17.10",
 				"meow": "^3.0.0",
 				"npm-keyword": "^5.0.0",
-				"opn": "^4.0.2",
-				"package-json": "^4.0.1",
-				"parse-help": "^0.1.1",
-				"read-pkg-up": "^2.0.0",
+				"opn": "^5.3.0",
+				"package-json": "^5.0.0",
+				"parse-help": "^1.0.0",
+				"read-pkg-up": "^4.0.0",
 				"root-check": "^1.0.0",
-				"sort-on": "^2.0.0",
-				"string-length": "^1.0.0",
+				"sort-on": "^3.0.0",
+				"string-length": "^2.0.0",
 				"tabtab": "^1.3.2",
-				"titleize": "^1.0.0",
-				"update-notifier": "^2.1.0",
+				"titleize": "^1.0.1",
+				"update-notifier": "^2.5.0",
 				"user-home": "^2.0.0",
 				"yeoman-character": "^1.0.0",
-				"yeoman-doctor": "^2.0.0",
-				"yeoman-environment": "^2.0.0",
-				"yosay": "^2.0.0"
+				"yeoman-doctor": "^3.0.1",
+				"yeoman-environment": "^2.3.0",
+				"yosay": "^2.0.2"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
 				},
-				"async": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-					"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-					"dev": true,
-					"requires": {
-						"lodash": "^4.14.0"
-					}
-				},
-				"camelcase": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+				"chardet": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+					"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 					"dev": true
 				},
-				"camelcase-keys": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"dev": true,
 					"requires": {
-						"camelcase": "^2.0.0",
-						"map-obj": "^1.0.0"
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+				"external-editor": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+					"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"chardet": "^0.7.0",
+						"iconv-lite": "^0.4.24",
+						"tmp": "^0.0.33"
 					}
 				},
 				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 					"dev": true,
 					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"locate-path": "^3.0.0"
 					}
 				},
 				"got": {
-					"version": "8.3.1",
-					"resolved": "https://registry.npmjs.org/got/-/got-8.3.1.tgz",
-					"integrity": "sha512-tiLX+bnYm5A56T5N/n9Xo89vMaO1mrS9qoDqj3u/anVooqGozvY/HbXzEpDfbNeKsHCBpK40gSbz8wGYSp3i1w==",
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
+					"integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
 					"dev": true,
 					"requires": {
 						"@sindresorhus/is": "^0.7.0",
@@ -25740,123 +22359,101 @@
 						"url-to-options": "^1.0.1"
 					}
 				},
-				"indent-string": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+				"iconv-lite": {
+					"version": "0.4.24",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 					"dev": true,
 					"requires": {
-						"repeating": "^2.0.0"
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				},
+				"inquirer": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
+					"integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+					"dev": true,
+					"requires": {
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.0",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^3.0.0",
+						"figures": "^2.0.0",
+						"lodash": "^4.17.10",
+						"mute-stream": "0.0.7",
+						"run-async": "^2.2.0",
+						"rxjs": "^6.1.0",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^4.0.0",
+						"through": "^2.3.6"
 					}
 				},
 				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
-					},
-					"dependencies": {
-						"pify": {
-							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-							"dev": true
-						}
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
-				"map-obj": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-					"dev": true
-				},
-				"meow": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 					"dev": true,
 					"requires": {
-						"camelcase-keys": "^2.0.0",
-						"decamelize": "^1.1.2",
-						"loud-rejection": "^1.0.0",
-						"map-obj": "^1.0.1",
-						"minimist": "^1.1.3",
-						"normalize-package-data": "^2.3.4",
-						"object-assign": "^4.0.1",
-						"read-pkg-up": "^1.0.1",
-						"redent": "^1.0.0",
-						"trim-newlines": "^1.0.0"
-					},
-					"dependencies": {
-						"read-pkg-up": {
-							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-							"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-							"dev": true,
-							"requires": {
-								"find-up": "^1.0.0",
-								"read-pkg": "^1.0.0"
-							}
-						}
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
 					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
 				},
 				"opn": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-					"integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+					"integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
 					"dev": true,
 					"requires": {
-						"object-assign": "^4.0.1",
-						"pinkie-promise": "^2.0.0"
+						"is-wsl": "^1.1.0"
 					}
 				},
-				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+				"p-limit": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+					"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.2.0"
+						"p-try": "^2.0.0"
 					}
 				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"p-limit": "^2.0.0"
 					}
 				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+				"p-try": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+					"dev": true
+				},
+				"package-json": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/package-json/-/package-json-5.0.0.tgz",
+					"integrity": "sha512-EeHQFFTlEmLrkIQoxbE9w0FuAWHoc1XpthDqnZ/i9keOt701cteyXwAxQFLpVqVjj3feh2TodkihjLaRUtIgLg==",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					},
-					"dependencies": {
-						"pify": {
-							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-							"dev": true
-						}
+						"got": "^8.3.1",
+						"registry-auth-token": "^3.3.2",
+						"registry-url": "^3.1.0",
+						"semver": "^5.5.0"
 					}
 				},
 				"prepend-http": {
@@ -25866,120 +22463,34 @@
 					"dev": true
 				},
 				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^1.0.0",
+						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
+						"path-type": "^3.0.0"
 					}
 				},
 				"read-pkg-up": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+					"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
 					"dev": true,
 					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^2.0.0"
-					},
-					"dependencies": {
-						"find-up": {
-							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-							"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-							"dev": true,
-							"requires": {
-								"locate-path": "^2.0.0"
-							}
-						},
-						"load-json-file": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-							"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-							"dev": true,
-							"requires": {
-								"graceful-fs": "^4.1.2",
-								"parse-json": "^2.2.0",
-								"pify": "^2.0.0",
-								"strip-bom": "^3.0.0"
-							}
-						},
-						"path-type": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-							"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-							"dev": true,
-							"requires": {
-								"pify": "^2.0.0"
-							}
-						},
-						"pify": {
-							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-							"dev": true
-						},
-						"read-pkg": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-							"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-							"dev": true,
-							"requires": {
-								"load-json-file": "^2.0.0",
-								"normalize-package-data": "^2.3.2",
-								"path-type": "^2.0.0"
-							}
-						},
-						"strip-bom": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-							"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-							"dev": true
-						}
+						"find-up": "^3.0.0",
+						"read-pkg": "^3.0.0"
 					}
 				},
-				"redent": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"indent-string": "^2.1.0",
-						"strip-indent": "^1.0.1"
+						"ansi-regex": "^3.0.0"
 					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
-				},
-				"strip-indent": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-					"dev": true,
-					"requires": {
-						"get-stdin": "^4.0.1"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				},
-				"trim-newlines": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-					"dev": true
 				},
 				"url-parse-lax": {
 					"version": "3.0.0",
@@ -26011,7 +22522,7 @@
 			"dependencies": {
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,12 @@
 		"@ava/babel-plugin-throws-helper": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-2.0.0.tgz",
-			"integrity": "sha1-L8H+PCEacQcaTsp7j3r1hCzRrnw=",
-			"dev": true
+			"integrity": "sha1-L8H+PCEacQcaTsp7j3r1hCzRrnw="
 		},
 		"@ava/babel-preset-stage-4": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-1.1.0.tgz",
 			"integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
-			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "^6.8.0",
 				"babel-plugin-syntax-trailing-function-commas": "^6.20.0",
@@ -32,7 +30,6 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
 					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-					"dev": true,
 					"requires": {
 						"md5-o-matic": "^0.1.1"
 					}
@@ -41,7 +38,6 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-1.2.0.tgz",
 					"integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
-					"dev": true,
 					"requires": {
 						"md5-hex": "^1.3.0"
 					}
@@ -52,7 +48,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-3.0.0.tgz",
 			"integrity": "sha1-ze0RlqjY2TgaUJJAq5LpGl7Aafc=",
-			"dev": true,
 			"requires": {
 				"@ava/babel-plugin-throws-helper": "^2.0.0",
 				"babel-plugin-espower": "^2.3.2"
@@ -62,7 +57,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@ava/write-file-atomic/-/write-file-atomic-2.2.0.tgz",
 			"integrity": "sha512-BTNB3nGbEfJT+69wuqXFr/bQH7Vr7ihx2xGOMNqPgDGhwspoZhiWumDDZNjBy7AScmqS5CELIOGtPVXESyrnDA==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"imurmurhash": "^0.1.4",
@@ -73,7 +67,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@concordance/react/-/react-1.0.0.tgz",
 			"integrity": "sha512-htrsRaQX8Iixlsek8zQU7tE8wcsTQJ5UhZkSPEA8slCDAisKpC/2VgU/ucPn32M5/LjGGXRaUEKvEw1Wiuu4zQ==",
-			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1"
 			}
@@ -82,7 +75,6 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
 			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
-			"dev": true,
 			"requires": {
 				"call-me-maybe": "^1.0.1",
 				"glob-to-regexp": "^0.3.0"
@@ -91,14 +83,28 @@
 		"@sindresorhus/is": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
-			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
-			"dev": true
+			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+		},
+		"@sinonjs/formatio": {
+			"version": "2.0.0",
+			"resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+			"integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+			"requires": {
+				"samsam": "1.3.0"
+			}
+		},
+		"@sinonjs/samsam": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
+			"integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
+			"requires": {
+				"array-from": "^2.1.1"
+			}
 		},
 		"@storybook/addon-actions": {
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.4.3.tgz",
 			"integrity": "sha512-1Du2SIXeJElOXor03Gc+n49sWv8R0OOKs4BvQPcmdw6uRL8ow917dXr5nQOAmZjXILPpZJOkpJE5BWPPqE+0LQ==",
-			"dev": true,
 			"requires": {
 				"@storybook/components": "3.4.3",
 				"babel-runtime": "^6.26.0",
@@ -115,8 +121,7 @@
 				"uuid": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-					"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-					"dev": true
+					"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
 				}
 			}
 		},
@@ -124,7 +129,6 @@
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.4.3.tgz",
 			"integrity": "sha512-TGOI4arJfYmqizSedx6WOGxtnZrYR1i4RUQJt6wdizQzelgZSyoXN2AyuFzX0RH5IlEmfdCyvnv2jw7mTDNMEg==",
-			"dev": true,
 			"requires": {
 				"@storybook/components": "3.4.3",
 				"babel-runtime": "^6.26.0",
@@ -136,7 +140,6 @@
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/@storybook/addon-options/-/addon-options-3.4.3.tgz",
 			"integrity": "sha512-FGNS0GjpxcokIXjpnL9v3UQf1rIQuGQX46FUvIt0dIjeNnjumonsOKcg3WGb8oNN5RS1e79Gccsk2s02EDgrGg==",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0"
 			}
@@ -144,14 +147,12 @@
 		"@storybook/addons": {
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.4.3.tgz",
-			"integrity": "sha512-vi2E2f+QFt1sp1mMJBdb0wdfmopE+Oprr1sLYEM9+E3eV9eh1stu/WBelk8Es3KsPh6vrJw8dy/rHIrIcUUSyQ==",
-			"dev": true
+			"integrity": "sha512-vi2E2f+QFt1sp1mMJBdb0wdfmopE+Oprr1sLYEM9+E3eV9eh1stu/WBelk8Es3KsPh6vrJw8dy/rHIrIcUUSyQ=="
 		},
 		"@storybook/channel-postmessage": {
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-3.4.3.tgz",
 			"integrity": "sha512-fWFCIEHtRk0inHuz6c91v5UlL+fB6RRZQZQkMrnFCZPCYpjtcJYBWp2mX+Pv1UFga57+d1NJKd/M0Jpy+xXLBA==",
-			"dev": true,
 			"requires": {
 				"@storybook/channels": "3.4.3",
 				"global": "^4.3.2",
@@ -161,20 +162,17 @@
 		"@storybook/channels": {
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-3.4.3.tgz",
-			"integrity": "sha512-x6ika4smvYOcmjoPGzZpitRpKiNfpHeovLPhnWdGGHm5IiC/Z0up9qvM4yxGfDuQvxCQ70nT+8f8Jo3SlqtTMw==",
-			"dev": true
+			"integrity": "sha512-x6ika4smvYOcmjoPGzZpitRpKiNfpHeovLPhnWdGGHm5IiC/Z0up9qvM4yxGfDuQvxCQ70nT+8f8Jo3SlqtTMw=="
 		},
 		"@storybook/client-logger": {
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-3.4.3.tgz",
-			"integrity": "sha512-QUD0/iJsPhtBYexo/MAwpkO8i+ChS/kKdlzoGOY9pC/XjQALk24BJDT4EVk0VbDdDqp2K0Pvc+ShIBtEm34AzA==",
-			"dev": true
+			"integrity": "sha512-QUD0/iJsPhtBYexo/MAwpkO8i+ChS/kKdlzoGOY9pC/XjQALk24BJDT4EVk0VbDdDqp2K0Pvc+ShIBtEm34AzA=="
 		},
 		"@storybook/components": {
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.4.3.tgz",
 			"integrity": "sha512-++sBqTD6V6nZ5EaY8ecW+rMtgLEQBP18d2b2OYAdMuDffIKL7olfcgmlW9bchm40zLecbV5TGTjZFGbXXJ4sWw==",
-			"dev": true,
 			"requires": {
 				"glamor": "^2.20.40",
 				"glamorous": "^4.12.1",
@@ -185,7 +183,6 @@
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/@storybook/core/-/core-3.4.3.tgz",
 			"integrity": "sha512-92mFUf+W2hac36x9N7r8VjuUJwKHL/c5k6Jbri0quJTcPRvrypIO3UmwAxon+9z+eNmWKi+bQGFayMxHlDEDkw==",
-			"dev": true,
 			"requires": {
 				"@storybook/addons": "3.4.3",
 				"@storybook/channel-postmessage": "3.4.3",
@@ -220,7 +217,6 @@
 					"version": "7.2.6",
 					"resolved": "http://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
 					"integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
-					"dev": true,
 					"requires": {
 						"browserslist": "^2.11.3",
 						"caniuse-lite": "^1.0.30000805",
@@ -234,7 +230,6 @@
 					"version": "2.11.3",
 					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
 					"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
-					"dev": true,
 					"requires": {
 						"caniuse-lite": "^1.0.30000792",
 						"electron-to-chromium": "^1.3.30"
@@ -244,7 +239,6 @@
 					"version": "6.0.22",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
 					"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
 						"source-map": "^0.6.1",
@@ -254,20 +248,17 @@
 				"qs": {
 					"version": "6.5.2",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-					"dev": true
+					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"style-loader": {
 					"version": "0.20.3",
 					"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.20.3.tgz",
 					"integrity": "sha512-2I7AVP73MvK33U7B9TKlYZAqdROyMXDYSMvHLX43qy3GCOaJNiV6i0v/sv9idWIaQ42Yn2dNv79Q5mKXbKhAZg==",
-					"dev": true,
 					"requires": {
 						"loader-utils": "^1.1.0",
 						"schema-utils": "^0.4.5"
@@ -279,7 +270,6 @@
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/@storybook/mantra-core/-/mantra-core-1.7.2.tgz",
 			"integrity": "sha512-GD4OYJ8GsayVhIg306sfgcKDk9j8YfuSKIAWvdB/g7IDlw0pDgueONALVEEE2XWJtCwcsUyDtCYzXFgCBWLEjA==",
-			"dev": true,
 			"requires": {
 				"@storybook/react-komposer": "^2.0.1",
 				"@storybook/react-simple-di": "^1.2.1",
@@ -290,7 +280,6 @@
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-3.4.3.tgz",
 			"integrity": "sha512-RpHpWoo+HpR2yGyhzbQN22x3aoeAtADz+G4e7kwC11q/yaFawdQSMIAhIMGOpQLl1G+ojx+uCLU5HWDHb864bA==",
-			"dev": true,
 			"requires": {
 				"npmlog": "^4.1.2"
 			}
@@ -299,7 +288,6 @@
 			"version": "1.2.3",
 			"resolved": "http://registry.npmjs.org/@storybook/podda/-/podda-1.2.3.tgz",
 			"integrity": "sha512-g7dsdsn50AhlGZ8iIDKdF8bi7Am++iFOq+QN+hNKz3FvgLuf8Dz+mpC/BFl90eE9bEYxXqXKeMf87399Ec5Qhw==",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.11.6",
 				"immutable": "^3.8.1"
@@ -309,7 +297,6 @@
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/@storybook/react/-/react-3.4.3.tgz",
 			"integrity": "sha512-vvhilLrBBSxZXUm8XApOnAscsci+XWQ5fXcZt1nYL4mjrD/vYngUuh42pTKVfZIYJcZ5jxWmxuSwCvLR0p6k6w==",
-			"dev": true,
 			"requires": {
 				"@storybook/addon-actions": "3.4.3",
 				"@storybook/addon-links": "3.4.3",
@@ -356,7 +343,6 @@
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.3.0.tgz",
 					"integrity": "sha512-+VV2GWEyak3eDOmzT1DDMuqHrw3VbE9nBNkx2LLVs4pH/Me32ND8DRpVDd8IRvk1xX5p75nygyRPtkMh6GIAbQ==",
-					"dev": true,
 					"requires": {
 						"babel-plugin-minify-builtins": "^0.3.0",
 						"babel-plugin-minify-constant-folding": "^0.3.0",
@@ -389,7 +375,6 @@
 			"version": "2.0.4",
 			"resolved": "http://registry.npmjs.org/@storybook/react-komposer/-/react-komposer-2.0.4.tgz",
 			"integrity": "sha1-wsDUp12bSpwMa0bxSrBQ9FitS7A=",
-			"dev": true,
 			"requires": {
 				"@storybook/react-stubber": "^1.0.0",
 				"babel-runtime": "^6.11.6",
@@ -402,7 +387,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@storybook/react-simple-di/-/react-simple-di-1.3.0.tgz",
 			"integrity": "sha512-RH6gPQaYMs/VzQX2dgbZU8DQMKFXVOv1ruohHjjNPys4q+YdqMFMDe5jOP1AUE3j9g01x0eW7bVjRawSpl++Ew==",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.x.x",
 				"create-react-class": "^15.6.2",
@@ -414,7 +398,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@storybook/react-stubber/-/react-stubber-1.0.1.tgz",
 			"integrity": "sha512-k+CHH+vA8bQfCmzBTtJsPkITFgD+C/w19KuByZ9WeEvNUFtnDaCqfP+Vp3/OR+3IAfAXYYOWolqPLxNPcEqEjw==",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.5.0"
 			}
@@ -423,7 +406,6 @@
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.4.3.tgz",
 			"integrity": "sha512-AZBsdw2rlm68X24jVmsTSlwOnqvYlTld+jeFKVpUTW6LdaTTF6xlqhYMiqBb3ykYeLP7/tyIcJkZJvZIGAoBZQ==",
-			"dev": true,
 			"requires": {
 				"@storybook/components": "3.4.3",
 				"@storybook/mantra-core": "^1.7.2",
@@ -451,8 +433,7 @@
 				"qs": {
 					"version": "6.5.2",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-					"dev": true
+					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 				}
 			}
 		},
@@ -460,7 +441,6 @@
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
 			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-			"dev": true,
 			"requires": {
 				"jsonparse": "^1.2.0",
 				"through": ">=2.2.7 <3"
@@ -469,14 +449,12 @@
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-			"dev": true
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
 		},
 		"accepts": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
 			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-			"dev": true,
 			"requires": {
 				"mime-types": "~2.1.18",
 				"negotiator": "0.6.1"
@@ -485,14 +463,12 @@
 		"acorn": {
 			"version": "5.5.3",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
-			"dev": true
+			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
 		},
 		"acorn-dynamic-import": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
 			"integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
-			"dev": true,
 			"requires": {
 				"acorn": "^4.0.3"
 			},
@@ -500,28 +476,39 @@
 				"acorn": {
 					"version": "4.0.13",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-					"dev": true
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+				}
+			}
+		},
+		"acorn-jsx": {
+			"version": "3.0.1",
+			"resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"requires": {
+				"acorn": "^3.0.4"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "3.3.0",
+					"resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
 				}
 			}
 		},
 		"add-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-			"integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
-			"dev": true
+			"integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo="
 		},
 		"address": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
-			"integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg==",
-			"dev": true
+			"integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
 		},
 		"agent-base": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
 			"integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
-			"dev": true,
 			"requires": {
 				"es6-promisify": "^5.0.0"
 			}
@@ -530,7 +517,6 @@
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.4.1.tgz",
 			"integrity": "sha512-MPIwsZU9PP9kOrZpyu2042kYA8Fdt/AedQYkYXucHgF9QoD9dXVp0ypuGnHXSR0hTstBxdt85Xkh4JolYfK5wg==",
-			"dev": true,
 			"requires": {
 				"humanize-ms": "^1.2.1"
 			}
@@ -539,7 +525,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-1.0.0.tgz",
 			"integrity": "sha1-iINE2tAiCnLjr1CQYRf0h3GSX6w=",
-			"dev": true,
 			"requires": {
 				"clean-stack": "^1.0.0",
 				"indent-string": "^3.0.0"
@@ -549,7 +534,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/airbnb-js-shims/-/airbnb-js-shims-1.4.1.tgz",
 			"integrity": "sha512-b7S3d+DPRMwaDAs0cgKQTMLO/JG/iSehIlzEGvt2FpxIztRDDABEjWI73AfTxkSiK3/OsraPRYxVNAX3yhSNLw==",
-			"dev": true,
 			"requires": {
 				"array-includes": "^3.0.3",
 				"array.prototype.flatmap": "^1.2.0",
@@ -569,7 +553,6 @@
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
 			"integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
-			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -580,14 +563,12 @@
 		"ajv-keywords": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-			"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
-			"dev": true
+			"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
 		},
 		"align-text": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2",
 				"longest": "^1.0.1",
@@ -597,26 +578,22 @@
 		"alphanum-sort": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
-			"integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
-			"dev": true
+			"integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
 		},
 		"amdefine": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-			"dev": true
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
 		},
 		"ansi": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-			"integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
-			"dev": true
+			"integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
 		},
 		"ansi-align": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
 			"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-			"dev": true,
 			"requires": {
 				"string-width": "^2.0.0"
 			}
@@ -624,26 +601,22 @@
 		"ansi-escapes": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-			"dev": true
+			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
 		},
 		"ansi-html": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-			"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
-			"dev": true
+			"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-			"dev": true
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
@@ -652,7 +625,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-			"dev": true,
 			"requires": {
 				"micromatch": "^3.1.4",
 				"normalize-path": "^2.1.1"
@@ -661,14 +633,12 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				},
 				"micromatch": {
 					"version": "3.1.10",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -696,7 +666,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
 			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-			"dev": true,
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
@@ -706,7 +675,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -714,74 +682,67 @@
 		"arity-n": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/arity-n/-/arity-n-1.0.4.tgz",
-			"integrity": "sha1-2edrEXM+CFacCEeuezmyhgswt0U=",
-			"dev": true
+			"integrity": "sha1-2edrEXM+CFacCEeuezmyhgswt0U="
 		},
 		"arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-			"dev": true
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 		},
 		"arr-exclude": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/arr-exclude/-/arr-exclude-1.0.0.tgz",
-			"integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE=",
-			"dev": true
+			"integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE="
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-			"dev": true
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
 		},
 		"arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-			"dev": true
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
 		},
 		"array-differ": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-			"dev": true
+			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
 		},
 		"array-filter": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
-			"dev": true
+			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
 		},
 		"array-find": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
-			"integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
-			"dev": true
+			"integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg="
 		},
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-			"dev": true
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
 		},
 		"array-flatten": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-			"dev": true
+			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+		},
+		"array-from": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+			"integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
 		},
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
-			"dev": true
+			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4="
 		},
 		"array-includes": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
 			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.7.0"
@@ -790,26 +751,22 @@
 		"array-iterate": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-1.1.2.tgz",
-			"integrity": "sha512-1hWSHTIlG/8wtYD+PPX5AOBtKWngpDFjrsrHgZpe+JdgNGz0udYu6ZIkAa/xuenIUEqFv7DvE2Yr60jxweJSrQ==",
-			"dev": true
+			"integrity": "sha512-1hWSHTIlG/8wtYD+PPX5AOBtKWngpDFjrsrHgZpe+JdgNGz0udYu6ZIkAa/xuenIUEqFv7DvE2Yr60jxweJSrQ=="
 		},
 		"array-map": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
-			"dev": true
+			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
 		},
 		"array-reduce": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
-			"dev": true
+			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
 		},
 		"array-union": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-			"dev": true,
 			"requires": {
 				"array-uniq": "^1.0.1"
 			}
@@ -817,20 +774,17 @@
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-			"dev": true
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
 		},
 		"array-unique": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-			"dev": true
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 		},
 		"array.prototype.flatmap": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.1.tgz",
 			"integrity": "sha512-i18e2APdsiezkcqDyZor78Pbfjfds3S94dG6dgIV2ZASJaUf1N0dz2tGdrmwrmlZuNUgxH+wz6Z0zYVH2c5xzQ==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.10.0",
@@ -841,7 +795,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/array.prototype.flatten/-/array.prototype.flatten-1.2.1.tgz",
 			"integrity": "sha512-3GhsA78XgK//wQKbhUe6L93kknekGlTRY0kvYcpuSi0aa9rVrMr/okeIIv/XSpN8fZ5iUM+bWifhf2/7CYKtIg==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.10.0",
@@ -851,26 +804,22 @@
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-			"dev": true
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
 		},
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-			"dev": true
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
 		"asn1": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-			"dev": true
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
 		},
 		"asn1.js": {
 			"version": "4.10.1",
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
 			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.0.0",
 				"inherits": "^2.0.1",
@@ -881,7 +830,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
 			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-			"dev": true,
 			"requires": {
 				"util": "0.10.3"
 			}
@@ -889,32 +837,27 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"dev": true
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-			"dev": true
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
 		},
 		"ast-types": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
-			"integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ==",
-			"dev": true
+			"integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
 		},
 		"astral-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-			"dev": true
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
 		},
 		"async": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
 			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-			"dev": true,
 			"requires": {
 				"lodash": "^4.17.10"
 			}
@@ -922,38 +865,32 @@
 		"async-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-			"dev": true
+			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
 		},
 		"async-foreach": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-			"integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
-			"dev": true
+			"integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
 		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-			"dev": true
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"atob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
-			"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
-			"dev": true
+			"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
 		},
 		"auto-bind": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-1.2.0.tgz",
-			"integrity": "sha512-Zw7pZp7tztvKnWWtoII4AmqH5a2PV3ZN5F0BPRTGcc1kpRm4b6QXQnPU7Znbl6BfPfqOVOV29g4JeMqZQaqqOA==",
-			"dev": true
+			"integrity": "sha512-Zw7pZp7tztvKnWWtoII4AmqH5a2PV3ZN5F0BPRTGcc1kpRm4b6QXQnPU7Znbl6BfPfqOVOV29g4JeMqZQaqqOA=="
 		},
 		"autoprefixer": {
 			"version": "6.7.7",
 			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
 			"integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
-			"dev": true,
 			"requires": {
 				"browserslist": "^1.7.6",
 				"caniuse-db": "^1.0.30000634",
@@ -967,7 +904,6 @@
 			"version": "0.23.0",
 			"resolved": "https://registry.npmjs.org/ava/-/ava-0.23.0.tgz",
 			"integrity": "sha512-ZsVwO8UENDoZHlYQOEBv6oSGuUiZ8AFqaa+OhTv/McwC+4Y2V9skip5uYwN3egT9I9c+mKzLWA9lXUv7D6g8ZA==",
-			"dev": true,
 			"requires": {
 				"@ava/babel-preset-stage-4": "^1.1.0",
 				"@ava/babel-preset-transform-test-files": "^3.0.0",
@@ -1054,20 +990,17 @@
 				"ansi-escapes": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
-					"integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
-					"dev": true
+					"integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs="
 				},
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"anymatch": {
 					"version": "1.3.2",
 					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 					"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-					"dev": true,
 					"requires": {
 						"micromatch": "^2.1.5",
 						"normalize-path": "^2.0.0"
@@ -1076,14 +1009,12 @@
 				"camelcase": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-					"dev": true
+					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
 				},
 				"camelcase-keys": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^2.0.0",
 						"map-obj": "^1.0.0"
@@ -1093,7 +1024,6 @@
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 					"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-					"dev": true,
 					"requires": {
 						"anymatch": "^1.3.0",
 						"async-each": "^1.0.0",
@@ -1110,7 +1040,6 @@
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
 					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-					"dev": true,
 					"requires": {
 						"is-obj": "^1.0.0"
 					}
@@ -1119,7 +1048,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-					"dev": true,
 					"requires": {
 						"is-glob": "^2.0.0"
 					}
@@ -1127,20 +1055,17 @@
 				"has-flag": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-					"dev": true
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
 				},
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -1148,14 +1073,12 @@
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-					"dev": true
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
 				},
 				"meow": {
 					"version": "3.7.0",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^2.0.0",
 						"decamelize": "^1.1.2",
@@ -1172,14 +1095,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"redent": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-					"dev": true,
 					"requires": {
 						"indent-string": "^2.1.0",
 						"strip-indent": "^1.0.1"
@@ -1189,7 +1110,6 @@
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 							"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-							"dev": true,
 							"requires": {
 								"repeating": "^2.0.0"
 							}
@@ -1200,7 +1120,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -1209,7 +1128,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-					"dev": true,
 					"requires": {
 						"get-stdin": "^4.0.1"
 					}
@@ -1218,7 +1136,6 @@
 					"version": "4.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-					"dev": true,
 					"requires": {
 						"has-flag": "^2.0.0"
 					}
@@ -1226,8 +1143,7 @@
 				"trim-newlines": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-					"dev": true
+					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
 				}
 			}
 		},
@@ -1235,7 +1151,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/ava-init/-/ava-init-0.2.1.tgz",
 			"integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
-			"dev": true,
 			"requires": {
 				"arr-exclude": "^1.0.0",
 				"execa": "^0.7.0",
@@ -1248,7 +1163,6 @@
 					"version": "0.7.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -1263,7 +1177,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
 					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^2.0.0"
@@ -1274,8 +1187,7 @@
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"dev": true
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
 			"version": "1.8.0",
@@ -1286,7 +1198,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3",
 				"esutils": "^2.0.2",
@@ -1296,14 +1207,12 @@
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -1315,8 +1224,7 @@
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -1324,7 +1232,6 @@
 			"version": "6.26.3",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
 			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"babel-generator": "^6.26.0",
@@ -1350,14 +1257,12 @@
 				"babylon": {
 					"version": "6.18.0",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-					"dev": true
+					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
 				},
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -1365,8 +1270,7 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -1374,7 +1278,6 @@
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-			"dev": true,
 			"requires": {
 				"babel-messages": "^6.23.0",
 				"babel-runtime": "^6.26.0",
@@ -1390,7 +1293,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 					"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-					"dev": true,
 					"requires": {
 						"repeating": "^2.0.0"
 					}
@@ -1398,14 +1300,12 @@
 				"jsesc": {
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-					"dev": true
+					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -1413,7 +1313,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
 			"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-traverse": "^6.24.1",
@@ -1424,7 +1323,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-			"dev": true,
 			"requires": {
 				"babel-helper-explode-assignable-expression": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1435,7 +1333,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
 			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"babel-types": "^6.26.0",
@@ -1446,7 +1343,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1458,7 +1354,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.26.0",
@@ -1469,14 +1364,12 @@
 		"babel-helper-evaluate-path": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.3.0.tgz",
-			"integrity": "sha512-dRFlMTqUJRGzx5a2smKxmptDdNCXKSkPcXWzKLwAV72hvIZumrd/0z9RcewHkr7PmAEq+ETtpD1GK6wZ6ZUXzw==",
-			"dev": true
+			"integrity": "sha512-dRFlMTqUJRGzx5a2smKxmptDdNCXKSkPcXWzKLwAV72hvIZumrd/0z9RcewHkr7PmAEq+ETtpD1GK6wZ6ZUXzw=="
 		},
 		"babel-helper-explode-assignable-expression": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-traverse": "^6.24.1",
@@ -1487,7 +1380,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
 			"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
-			"dev": true,
 			"requires": {
 				"babel-helper-bindify-decorators": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1498,14 +1390,12 @@
 		"babel-helper-flip-expressions": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.3.0.tgz",
-			"integrity": "sha512-kNGohWmtAG3b7tN1xocRQ5rsKkH/hpvZsMiGOJ1VwGJKhnwzR5KlB3rvKBaBPl5/IGHcopB2JN+r1SUEX1iMAw==",
-			"dev": true
+			"integrity": "sha512-kNGohWmtAG3b7tN1xocRQ5rsKkH/hpvZsMiGOJ1VwGJKhnwzR5KlB3rvKBaBPl5/IGHcopB2JN+r1SUEX1iMAw=="
 		},
 		"babel-helper-function-name": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-			"dev": true,
 			"requires": {
 				"babel-helper-get-function-arity": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1518,7 +1408,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -1528,7 +1417,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -1537,26 +1425,22 @@
 		"babel-helper-is-nodes-equiv": {
 			"version": "0.0.1",
 			"resolved": "http://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
-			"integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=",
-			"dev": true
+			"integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ="
 		},
 		"babel-helper-is-void-0": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.3.0.tgz",
-			"integrity": "sha512-JVqdX8y7Rf/x4NwbqtUI7mdQjL9HWoDnoAEQ8Gv8oxzjvbJv+n75f7l36m9Y8C7sCUltX3V5edndrp7Hp1oSXQ==",
-			"dev": true
+			"integrity": "sha512-JVqdX8y7Rf/x4NwbqtUI7mdQjL9HWoDnoAEQ8Gv8oxzjvbJv+n75f7l36m9Y8C7sCUltX3V5edndrp7Hp1oSXQ=="
 		},
 		"babel-helper-mark-eval-scopes": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.3.0.tgz",
-			"integrity": "sha512-nrho5Dg4vl0VUgURVpGpEGiwbst5JX7efIyDHFxmkCx/ocQFnrPt8ze9Kxl6TKjR29bJ7D/XKY1NMlSxOQJRbQ==",
-			"dev": true
+			"integrity": "sha512-nrho5Dg4vl0VUgURVpGpEGiwbst5JX7efIyDHFxmkCx/ocQFnrPt8ze9Kxl6TKjR29bJ7D/XKY1NMlSxOQJRbQ=="
 		},
 		"babel-helper-optimise-call-expression": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -1566,7 +1450,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"babel-types": "^6.26.0",
@@ -1577,7 +1460,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1589,14 +1471,12 @@
 		"babel-helper-remove-or-void": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.3.0.tgz",
-			"integrity": "sha512-D68W1M3ibCcbg0ysh3ww4/O0g10X1CXK720oOuR8kpfY7w0yP4tVcpK7zDmI1JecynycTQYAZ1rhLJo9aVtIKQ==",
-			"dev": true
+			"integrity": "sha512-D68W1M3ibCcbg0ysh3ww4/O0g10X1CXK720oOuR8kpfY7w0yP4tVcpK7zDmI1JecynycTQYAZ1rhLJo9aVtIKQ=="
 		},
 		"babel-helper-replace-supers": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-			"dev": true,
 			"requires": {
 				"babel-helper-optimise-call-expression": "^6.24.1",
 				"babel-messages": "^6.23.0",
@@ -1609,14 +1489,12 @@
 		"babel-helper-to-multiple-sequence-expressions": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.3.0.tgz",
-			"integrity": "sha512-1uCrBD+EAaMnAYh7hc944n8Ga19y3daEnoXWPYDvFVsxMCc1l8aDjksApaCEaNSSuewq8BEcff47Cy1PbLg2Gw==",
-			"dev": true
+			"integrity": "sha512-1uCrBD+EAaMnAYh7hc944n8Ga19y3daEnoXWPYDvFVsxMCc1l8aDjksApaCEaNSSuewq8BEcff47Cy1PbLg2Gw=="
 		},
 		"babel-helpers": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-template": "^6.24.1"
@@ -1626,7 +1504,6 @@
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.4.tgz",
 			"integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
-			"dev": true,
 			"requires": {
 				"find-cache-dir": "^1.0.0",
 				"loader-utils": "^1.0.2",
@@ -1637,7 +1514,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -1646,7 +1522,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -1655,7 +1530,6 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-2.4.0.tgz",
 			"integrity": "sha512-/+SRpy7pKgTI28oEHfn1wkuM5QFAdRq8WNsOOih1dVrdV6A/WbNbRZyl0eX5eyDgtb0lOE27PeDFuCX2j8OxVg==",
-			"dev": true,
 			"requires": {
 				"babel-generator": "^6.1.0",
 				"babylon": "^6.1.0",
@@ -1669,8 +1543,7 @@
 				"babylon": {
 					"version": "6.18.0",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-					"dev": true
+					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
 				}
 			}
 		},
@@ -1678,7 +1551,6 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.2.1.tgz",
 			"integrity": "sha512-DSLZpd6/LQFOJUr2pQK6pncxvAL87E6ReWgfaEfgOL1y/YTTIeqVfsrbdDgerdjtVzCIKajD32fxlvhEgvxMEw==",
-			"dev": true,
 			"requires": {
 				"cosmiconfig": "^4.0.0"
 			}
@@ -1687,7 +1559,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.3.0.tgz",
 			"integrity": "sha512-MqhSHlxkmgURqj3144qPksbZ/qof1JWdumcbucc4tysFcf3P3V3z3munTevQgKEFNMd8F5/ECGnwb63xogLjAg==",
-			"dev": true,
 			"requires": {
 				"babel-helper-evaluate-path": "^0.3.0"
 			}
@@ -1696,7 +1567,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.3.0.tgz",
 			"integrity": "sha512-1XeRpx+aY1BuNY6QU/cm6P+FtEi3ar3XceYbmC+4q4W+2Ewq5pL7V68oHg1hKXkBIE0Z4/FjSoHz6vosZLOe/A==",
-			"dev": true,
 			"requires": {
 				"babel-helper-evaluate-path": "^0.3.0"
 			}
@@ -1705,7 +1575,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.3.0.tgz",
 			"integrity": "sha512-SjM2Fzg85YZz+q/PNJ/HU4O3W98FKFOiP9K5z3sfonlamGOzvZw3Eup2OTiEBsbbqTeY8yzNCAv3qpJRYCgGmw==",
-			"dev": true,
 			"requires": {
 				"babel-helper-evaluate-path": "^0.3.0",
 				"babel-helper-mark-eval-scopes": "^0.3.0",
@@ -1717,7 +1586,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.3.0.tgz",
 			"integrity": "sha512-B8lK+ekcpSNVH7PZpWDe5nC5zxjRiiT4nTsa6h3QkF3Kk6y9qooIFLemdGlqBq6j0zALEnebvCpw8v7gAdpgnw==",
-			"dev": true,
 			"requires": {
 				"babel-helper-is-void-0": "^0.3.0"
 			}
@@ -1726,7 +1594,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.3.0.tgz",
 			"integrity": "sha512-O+6CvF5/Ttsth3LMg4/BhyvVZ82GImeKMXGdVRQGK/8jFiP15EjRpdgFlxv3cnqRjqdYxLCS6r28VfLpb9C/kA==",
-			"dev": true,
 			"requires": {
 				"babel-helper-flip-expressions": "^0.3.0"
 			}
@@ -1734,14 +1601,12 @@
 		"babel-plugin-minify-infinity": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.3.0.tgz",
-			"integrity": "sha512-Sj8ia3/w9158DWieUxU6/VvnYVy59geeFEkVgLZYBE8EBP+sN48tHtBM/jSgz0ejEdBlcfqJ6TnvPmVXTzR2BQ==",
-			"dev": true
+			"integrity": "sha512-Sj8ia3/w9158DWieUxU6/VvnYVy59geeFEkVgLZYBE8EBP+sN48tHtBM/jSgz0ejEdBlcfqJ6TnvPmVXTzR2BQ=="
 		},
 		"babel-plugin-minify-mangle-names": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.3.0.tgz",
 			"integrity": "sha512-PYTonhFWURsfAN8achDwvR5Xgy6EeTClLz+fSgGRqjAIXb0OyFm3/xfccbQviVi1qDXmlSnt6oJhBg8KE4Fn7Q==",
-			"dev": true,
 			"requires": {
 				"babel-helper-mark-eval-scopes": "^0.3.0"
 			}
@@ -1749,20 +1614,17 @@
 		"babel-plugin-minify-numeric-literals": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.3.0.tgz",
-			"integrity": "sha512-TgZj6ay8zDw74AS3yiIfoQ8vRSNJisYO/Du60S8nPV7EW7JM6fDMx5Sar6yVHlVuuwNgvDUBh191K33bVrAhpg==",
-			"dev": true
+			"integrity": "sha512-TgZj6ay8zDw74AS3yiIfoQ8vRSNJisYO/Du60S8nPV7EW7JM6fDMx5Sar6yVHlVuuwNgvDUBh191K33bVrAhpg=="
 		},
 		"babel-plugin-minify-replace": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.3.0.tgz",
-			"integrity": "sha512-VR6tTg2Lt0TicHIOw04fsUtpPw7RaRP8PC8YzSFwEixnzvguZjZJoL7TgG7ZyEWQD1cJ96UezswECmFNa815bg==",
-			"dev": true
+			"integrity": "sha512-VR6tTg2Lt0TicHIOw04fsUtpPw7RaRP8PC8YzSFwEixnzvguZjZJoL7TgG7ZyEWQD1cJ96UezswECmFNa815bg=="
 		},
 		"babel-plugin-minify-simplify": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.3.0.tgz",
 			"integrity": "sha512-2M16ytQOCqBi7bYMu4DCWn8e6KyFCA108F6+tVrBJxOmm5u2sOmTFEa8s94tR9RHRRNYmcUf+rgidfnzL3ik9Q==",
-			"dev": true,
 			"requires": {
 				"babel-helper-flip-expressions": "^0.3.0",
 				"babel-helper-is-nodes-equiv": "^0.0.1",
@@ -1773,7 +1635,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.3.0.tgz",
 			"integrity": "sha512-XRXpvsUCPeVw9YEUw+9vSiugcSZfow81oIJT0yR9s8H4W7yJ6FHbImi5DJHoL8KcDUjYnL9wYASXk/fOkbyR6Q==",
-			"dev": true,
 			"requires": {
 				"babel-helper-is-void-0": "^0.3.0"
 			}
@@ -1782,7 +1643,6 @@
 			"version": "1.9.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.9.0.tgz",
 			"integrity": "sha512-8lQ73p4BL+xcgba03NTiHrddl2X8J6PDMQHPpz73sesrRBf6JtAscQPLIjFWQR/abLokdv81HdshpjYGppOXgA==",
-			"dev": true,
 			"requires": {
 				"babel-types": "^6.24.1",
 				"lodash": "^4.17.0",
@@ -1792,92 +1652,77 @@
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-			"dev": true
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
 		},
 		"babel-plugin-syntax-async-generators": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
-			"dev": true
+			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
 		},
 		"babel-plugin-syntax-class-constructor-call": {
 			"version": "6.18.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
-			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY=",
-			"dev": true
+			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY="
 		},
 		"babel-plugin-syntax-class-properties": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
-			"dev": true
+			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
 		},
 		"babel-plugin-syntax-decorators": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
-			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
-			"dev": true
+			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs="
 		},
 		"babel-plugin-syntax-do-expressions": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz",
-			"integrity": "sha1-V0d1YTmqJtOQ0JQQsDdEugfkeW0=",
-			"dev": true
+			"integrity": "sha1-V0d1YTmqJtOQ0JQQsDdEugfkeW0="
 		},
 		"babel-plugin-syntax-dynamic-import": {
 			"version": "6.18.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
-			"dev": true
+			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-			"dev": true
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
 		},
 		"babel-plugin-syntax-export-extensions": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
-			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE=",
-			"dev": true
+			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE="
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
-			"dev": true
+			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
 		},
 		"babel-plugin-syntax-function-bind": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz",
-			"integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y=",
-			"dev": true
+			"integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y="
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-			"dev": true
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-			"dev": true
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-			"dev": true
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
 		},
 		"babel-plugin-transform-async-generator-functions": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
-			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "^6.24.1",
 				"babel-plugin-syntax-async-generators": "^6.5.0",
@@ -1888,7 +1733,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "^6.24.1",
 				"babel-plugin-syntax-async-functions": "^6.8.0",
@@ -1899,7 +1743,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
 			"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-class-constructor-call": "^6.18.0",
 				"babel-runtime": "^6.22.0",
@@ -1910,7 +1753,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
 			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
-			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-plugin-syntax-class-properties": "^6.8.0",
@@ -1922,7 +1764,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
 			"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
-			"dev": true,
 			"requires": {
 				"babel-helper-explode-class": "^6.24.1",
 				"babel-plugin-syntax-decorators": "^6.13.0",
@@ -1935,7 +1776,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.22.0.tgz",
 			"integrity": "sha1-KMyvkoEtlJws0SgfaQyP3EaK6bs=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-do-expressions": "^6.8.0",
 				"babel-runtime": "^6.22.0"
@@ -1945,7 +1785,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -1954,7 +1793,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -1963,7 +1801,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"babel-template": "^6.26.0",
@@ -1976,7 +1813,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-			"dev": true,
 			"requires": {
 				"babel-helper-define-map": "^6.24.1",
 				"babel-helper-function-name": "^6.24.1",
@@ -1993,7 +1829,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-template": "^6.24.1"
@@ -2003,7 +1838,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2012,7 +1846,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -2022,7 +1855,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2031,7 +1863,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2042,7 +1873,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2051,7 +1881,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2062,7 +1891,6 @@
 			"version": "6.26.2",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
 			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "^6.24.1",
 				"babel-runtime": "^6.26.0",
@@ -2074,7 +1902,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2085,7 +1912,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2096,7 +1922,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-			"dev": true,
 			"requires": {
 				"babel-helper-replace-supers": "^6.24.1",
 				"babel-runtime": "^6.22.0"
@@ -2106,7 +1931,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-			"dev": true,
 			"requires": {
 				"babel-helper-call-delegate": "^6.24.1",
 				"babel-helper-get-function-arity": "^6.24.1",
@@ -2120,7 +1944,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -2130,7 +1953,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2139,7 +1961,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-			"dev": true,
 			"requires": {
 				"babel-helper-regex": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2150,7 +1971,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2159,7 +1979,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2168,7 +1987,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-			"dev": true,
 			"requires": {
 				"babel-helper-regex": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2179,7 +1997,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 					"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-					"dev": true,
 					"requires": {
 						"regenerate": "^1.2.1",
 						"regjsgen": "^0.2.0",
@@ -2192,7 +2009,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-			"dev": true,
 			"requires": {
 				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
 				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
@@ -2203,7 +2019,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
 			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-export-extensions": "^6.8.0",
 				"babel-runtime": "^6.22.0"
@@ -2213,7 +2028,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-flow": "^6.18.0",
 				"babel-runtime": "^6.22.0"
@@ -2223,7 +2037,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz",
 			"integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-function-bind": "^6.8.0",
 				"babel-runtime": "^6.22.0"
@@ -2232,32 +2045,27 @@
 		"babel-plugin-transform-inline-consecutive-adds": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.3.0.tgz",
-			"integrity": "sha512-iZsYAIjYLLfLK0yN5WVT7Xf7Y3wQ9Z75j9A8q/0IglQSpUt2ppTdHlwl/GeaXnxdaSmsxBu861klbTBbv2n+RA==",
-			"dev": true
+			"integrity": "sha512-iZsYAIjYLLfLK0yN5WVT7Xf7Y3wQ9Z75j9A8q/0IglQSpUt2ppTdHlwl/GeaXnxdaSmsxBu861klbTBbv2n+RA=="
 		},
 		"babel-plugin-transform-member-expression-literals": {
 			"version": "6.9.2",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.2.tgz",
-			"integrity": "sha1-Hzl6uWGlw6QB8qdHrwbnIASvy3Y=",
-			"dev": true
+			"integrity": "sha1-Hzl6uWGlw6QB8qdHrwbnIASvy3Y="
 		},
 		"babel-plugin-transform-merge-sibling-variables": {
 			"version": "6.9.2",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.2.tgz",
-			"integrity": "sha1-mUqQBKecefDJHEluii28fptz97Q=",
-			"dev": true
+			"integrity": "sha1-mUqQBKecefDJHEluii28fptz97Q="
 		},
 		"babel-plugin-transform-minify-booleans": {
 			"version": "6.9.2",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.2.tgz",
-			"integrity": "sha1-z5lb4GegMDy1JlSfA9zZaCQZQw0=",
-			"dev": true
+			"integrity": "sha1-z5lb4GegMDy1JlSfA9zZaCQZQw0="
 		},
 		"babel-plugin-transform-object-rest-spread": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
 				"babel-runtime": "^6.26.0"
@@ -2267,7 +2075,6 @@
 			"version": "6.9.2",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.2.tgz",
 			"integrity": "sha1-pY0Jls8q2vIk986EitHN5M2M8nU=",
-			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2"
 			}
@@ -2276,7 +2083,6 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2285,7 +2091,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
-			"dev": true,
 			"requires": {
 				"babel-helper-builder-react-jsx": "^6.24.1",
 				"babel-plugin-syntax-jsx": "^6.8.0",
@@ -2296,7 +2101,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "^6.8.0",
 				"babel-runtime": "^6.22.0"
@@ -2306,7 +2110,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "^6.8.0",
 				"babel-runtime": "^6.22.0"
@@ -2316,7 +2119,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.10.0"
 			}
@@ -2324,26 +2126,22 @@
 		"babel-plugin-transform-regexp-constructors": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.3.0.tgz",
-			"integrity": "sha512-h92YHzyl042rb0naKO8frTHntpRFwRgKkfWD8602kFHoQingjJNtbvZzvxqHncJ6XmKVyYvfrBpDOSkCTDIIxw==",
-			"dev": true
+			"integrity": "sha512-h92YHzyl042rb0naKO8frTHntpRFwRgKkfWD8602kFHoQingjJNtbvZzvxqHncJ6XmKVyYvfrBpDOSkCTDIIxw=="
 		},
 		"babel-plugin-transform-remove-console": {
 			"version": "6.9.2",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.2.tgz",
-			"integrity": "sha1-6KDCfVbJUDyhbihPa2Tb1LldIek=",
-			"dev": true
+			"integrity": "sha1-6KDCfVbJUDyhbihPa2Tb1LldIek="
 		},
 		"babel-plugin-transform-remove-debugger": {
 			"version": "6.9.2",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.2.tgz",
-			"integrity": "sha1-U2yHvbYgDRRgyZbdldF5zzjCTuE=",
-			"dev": true
+			"integrity": "sha1-U2yHvbYgDRRgyZbdldF5zzjCTuE="
 		},
 		"babel-plugin-transform-remove-undefined": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.3.0.tgz",
 			"integrity": "sha512-TYGQucc8iP3LJwN3kDZLEz5aa/2KuFrqpT+s8f8NnHsBU1sAgR3y8Opns0xhC+smyDYWscqFCKM1gbkWQOhhnw==",
-			"dev": true,
 			"requires": {
 				"babel-helper-evaluate-path": "^0.3.0"
 			}
@@ -2352,7 +2150,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
 			"integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2360,14 +2157,12 @@
 		"babel-plugin-transform-simplify-comparison-operators": {
 			"version": "6.9.2",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.2.tgz",
-			"integrity": "sha1-DA6a+nMpJPA6qYL9Y8ktBAi9VlY=",
-			"dev": true
+			"integrity": "sha1-DA6a+nMpJPA6qYL9Y8ktBAi9VlY="
 		},
 		"babel-plugin-transform-strict-mode": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -2376,14 +2171,12 @@
 		"babel-plugin-transform-undefined-to-void": {
 			"version": "6.9.2",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.2.tgz",
-			"integrity": "sha1-Fl/eczkydr6gKnOWWIeNzO0Lnrs=",
-			"dev": true
+			"integrity": "sha1-Fl/eczkydr6gKnOWWIeNzO0Lnrs="
 		},
 		"babel-preset-env": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
 			"integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
-			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "^6.22.0",
 				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
@@ -2421,7 +2214,6 @@
 					"version": "3.2.7",
 					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.7.tgz",
 					"integrity": "sha512-oYVLxFVqpX9uMhOIQBLtZL+CX4uY8ZpWcjNTaxyWl5rO8yA9SSNikFnAfvk8J3P/7z3BZwNmEqFKaJoYltj3MQ==",
-					"dev": true,
 					"requires": {
 						"caniuse-lite": "^1.0.30000835",
 						"electron-to-chromium": "^1.3.45"
@@ -2433,7 +2225,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-flow-strip-types": "^6.22.0"
 			}
@@ -2442,7 +2233,6 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.2.0.tgz",
 			"integrity": "sha512-mR8Q44RmMzm18bM2Lqd9uiPopzk5GDCtVuquNbLFmX6lOKnqWoenaNBxnWW0UhBFC75lEHTIgNGCbnsRI0pJVw==",
-			"dev": true,
 			"requires": {
 				"babel-plugin-minify-builtins": "^0.2.0",
 				"babel-plugin-minify-constant-folding": "^0.2.0",
@@ -2472,44 +2262,37 @@
 				"babel-helper-evaluate-path": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.2.0.tgz",
-					"integrity": "sha512-0EK9TUKMxHL549hWDPkQoS7R0Ozg1CDLheVBHYds2B2qoAvmr9ejY3zOXFsrICK73TN7bPhU14PBeKc8jcBTwg==",
-					"dev": true
+					"integrity": "sha512-0EK9TUKMxHL549hWDPkQoS7R0Ozg1CDLheVBHYds2B2qoAvmr9ejY3zOXFsrICK73TN7bPhU14PBeKc8jcBTwg=="
 				},
 				"babel-helper-flip-expressions": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.2.0.tgz",
-					"integrity": "sha512-rAsPA1pWBc7e2E6HepkP2e1sXugT+Oq/VCqhyuHJ8aJ2d/ifwnJfd4Qxjm21qlW43AN8tqaeByagKK6wECFMSw==",
-					"dev": true
+					"integrity": "sha512-rAsPA1pWBc7e2E6HepkP2e1sXugT+Oq/VCqhyuHJ8aJ2d/ifwnJfd4Qxjm21qlW43AN8tqaeByagKK6wECFMSw=="
 				},
 				"babel-helper-is-void-0": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.2.0.tgz",
-					"integrity": "sha512-Axj1AYuD0E3Dl7nT3KxROP7VekEofz3XtEljzURf3fABalLpr8PamtgLFt+zuxtaCxRf9iuZmbAMMYWri5Bazw==",
-					"dev": true
+					"integrity": "sha512-Axj1AYuD0E3Dl7nT3KxROP7VekEofz3XtEljzURf3fABalLpr8PamtgLFt+zuxtaCxRf9iuZmbAMMYWri5Bazw=="
 				},
 				"babel-helper-mark-eval-scopes": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.2.0.tgz",
-					"integrity": "sha512-KJuwrOUcHbvbh6he4xRXZFLaivK9DF9o3CrvpWnK1Wp0B+1ANYABXBMgwrnNFIDK/AvicxQ9CNr8wsgivlp4Aw==",
-					"dev": true
+					"integrity": "sha512-KJuwrOUcHbvbh6he4xRXZFLaivK9DF9o3CrvpWnK1Wp0B+1ANYABXBMgwrnNFIDK/AvicxQ9CNr8wsgivlp4Aw=="
 				},
 				"babel-helper-remove-or-void": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.2.0.tgz",
-					"integrity": "sha512-1Z41upf/XR+PwY7Nd+F15Jo5BiQi5205ZXUuKed3yoyQgDkMyoM7vAdjEJS/T+M6jy32sXjskMUgms4zeiVtRA==",
-					"dev": true
+					"integrity": "sha512-1Z41upf/XR+PwY7Nd+F15Jo5BiQi5205ZXUuKed3yoyQgDkMyoM7vAdjEJS/T+M6jy32sXjskMUgms4zeiVtRA=="
 				},
 				"babel-helper-to-multiple-sequence-expressions": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.2.0.tgz",
-					"integrity": "sha512-ij9lpfdP3+Zc/7kNwa+NXbTrUlsYEWPwt/ugmQO0qflzLrveTIkbfOqQztvitk81aG5NblYDQXDlRohzu3oa8Q==",
-					"dev": true
+					"integrity": "sha512-ij9lpfdP3+Zc/7kNwa+NXbTrUlsYEWPwt/ugmQO0qflzLrveTIkbfOqQztvitk81aG5NblYDQXDlRohzu3oa8Q=="
 				},
 				"babel-plugin-minify-builtins": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.2.0.tgz",
 					"integrity": "sha512-4i+8ntaS8gwVUcOz5y+zE+55OVOl2nTbmHV51D4wAIiKcRI8U5K//ip1GHfhsgk/NJrrHK7h97Oy5jpqt0Iixg==",
-					"dev": true,
 					"requires": {
 						"babel-helper-evaluate-path": "^0.2.0"
 					}
@@ -2518,7 +2301,6 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.2.0.tgz",
 					"integrity": "sha512-B3ffQBEUQ8ydlIkYv2MkZtTCbV7FAkWAV7NkyhcXlGpD10PaCxNGQ/B9oguXGowR1m16Q5nGhvNn8Pkn1MO6Hw==",
-					"dev": true,
 					"requires": {
 						"babel-helper-evaluate-path": "^0.2.0"
 					}
@@ -2527,7 +2309,6 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.2.0.tgz",
 					"integrity": "sha512-zE7y3pRyzA4zK5nBou0kTcwUTSQ/AiFrynt1cIEYN7vcO2gS9ZFZoI0aO9JYLUdct5fsC1vfB35408yrzTyVfg==",
-					"dev": true,
 					"requires": {
 						"babel-helper-evaluate-path": "^0.2.0",
 						"babel-helper-mark-eval-scopes": "^0.2.0",
@@ -2539,7 +2320,6 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.2.0.tgz",
 					"integrity": "sha512-QOqXSEmD/LhT3LpM1WCyzAGcQZYYKJF7oOHvS6QbpomHenydrV53DMdPX2mK01icBExKZcJAHF209wvDBa+CSg==",
-					"dev": true,
 					"requires": {
 						"babel-helper-is-void-0": "^0.2.0"
 					}
@@ -2548,7 +2328,6 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.2.0.tgz",
 					"integrity": "sha512-5+NSPdRQ9mnrHaA+zFj+D5OzmSiv90EX5zGH6cWQgR/OUqmCHSDqgTRPFvOctgpo8MJyO7Rt7ajs2UfLnlAwYg==",
-					"dev": true,
 					"requires": {
 						"babel-helper-flip-expressions": "^0.2.0"
 					}
@@ -2556,14 +2335,12 @@
 				"babel-plugin-minify-infinity": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.2.0.tgz",
-					"integrity": "sha512-U694vrla1lN6vDHWGrR832t3a/A2eh+kyl019LxEE2+sS4VTydyOPRsAOIYAdJegWRA4cMX1lm9azAN0cLIr8g==",
-					"dev": true
+					"integrity": "sha512-U694vrla1lN6vDHWGrR832t3a/A2eh+kyl019LxEE2+sS4VTydyOPRsAOIYAdJegWRA4cMX1lm9azAN0cLIr8g=="
 				},
 				"babel-plugin-minify-mangle-names": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.2.0.tgz",
 					"integrity": "sha512-Gixuak1/CO7VCdjn15/8Bxe/QsAtDG4zPbnsNoe1mIJGCIH/kcmSjFhMlGJtXDQZd6EKzeMfA5WmX9+jvGRefw==",
-					"dev": true,
 					"requires": {
 						"babel-helper-mark-eval-scopes": "^0.2.0"
 					}
@@ -2571,20 +2348,17 @@
 				"babel-plugin-minify-numeric-literals": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.2.0.tgz",
-					"integrity": "sha512-VcLpb+r1YS7+RIOXdRsFVLLqoh22177USpHf+JM/g1nZbzdqENmfd5v534MLAbRErhbz6SyK+NQViVzVtBxu8g==",
-					"dev": true
+					"integrity": "sha512-VcLpb+r1YS7+RIOXdRsFVLLqoh22177USpHf+JM/g1nZbzdqENmfd5v534MLAbRErhbz6SyK+NQViVzVtBxu8g=="
 				},
 				"babel-plugin-minify-replace": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.2.0.tgz",
-					"integrity": "sha512-SEW6zoSVxh3OH6E1LCgyhhTWMnCv+JIRu5h5IlJDA11tU4ZeSF7uPQcO4vN/o52+FssRB26dmzJ/8D+z0QPg5Q==",
-					"dev": true
+					"integrity": "sha512-SEW6zoSVxh3OH6E1LCgyhhTWMnCv+JIRu5h5IlJDA11tU4ZeSF7uPQcO4vN/o52+FssRB26dmzJ/8D+z0QPg5Q=="
 				},
 				"babel-plugin-minify-simplify": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.2.0.tgz",
 					"integrity": "sha512-Mj3Mwy2zVosMfXDWXZrQH5/uMAyfJdmDQ1NVqit+ArbHC3LlXVzptuyC1JxTyai/wgFvjLaichm/7vSUshkWqw==",
-					"dev": true,
 					"requires": {
 						"babel-helper-flip-expressions": "^0.2.0",
 						"babel-helper-is-nodes-equiv": "^0.0.1",
@@ -2595,7 +2369,6 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.2.0.tgz",
 					"integrity": "sha512-NiOvvA9Pq6bki6nP4BayXwT5GZadw7DJFDDzHmkpnOQpENWe8RtHtKZM44MG1R6EQ5XxgbLdsdhswIzTkFlO5g==",
-					"dev": true,
 					"requires": {
 						"babel-helper-is-void-0": "^0.2.0"
 					}
@@ -2603,20 +2376,17 @@
 				"babel-plugin-transform-inline-consecutive-adds": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.2.0.tgz",
-					"integrity": "sha512-GlhOuLOQ28ua9prg0hT33HslCrEmz9xWXy9ZNZSACppCyRxxRW+haYtRgm7uYXCcd0q8ggCWD2pfWEJp5iiZfQ==",
-					"dev": true
+					"integrity": "sha512-GlhOuLOQ28ua9prg0hT33HslCrEmz9xWXy9ZNZSACppCyRxxRW+haYtRgm7uYXCcd0q8ggCWD2pfWEJp5iiZfQ=="
 				},
 				"babel-plugin-transform-regexp-constructors": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.2.0.tgz",
-					"integrity": "sha512-7IsQ6aQx6LAaOqy97/PthTf+5Nx9grZww3r6E62IdWe76Yr8KsuwVjxzqSPQvESJqTE3EMADQ9S0RtwWDGNG9Q==",
-					"dev": true
+					"integrity": "sha512-7IsQ6aQx6LAaOqy97/PthTf+5Nx9grZww3r6E62IdWe76Yr8KsuwVjxzqSPQvESJqTE3EMADQ9S0RtwWDGNG9Q=="
 				},
 				"babel-plugin-transform-remove-undefined": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.2.0.tgz",
 					"integrity": "sha512-O8v57tPMHkp89kA4ZfQEYds/pzgvz/QYerBJjIuL5/Jc7RnvMVRA5gJY9zFKP7WayW8WOSBV4vh8Y8FJRio+ow==",
-					"dev": true,
 					"requires": {
 						"babel-helper-evaluate-path": "^0.2.0"
 					}
@@ -2627,7 +2397,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "^6.3.13",
 				"babel-plugin-transform-react-display-name": "^6.23.0",
@@ -2641,7 +2410,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz",
 			"integrity": "sha1-VkLRUEL5E4TX5a+LyIsduVsDnmo=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-do-expressions": "^6.22.0",
 				"babel-plugin-transform-function-bind": "^6.22.0",
@@ -2652,7 +2420,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
 			"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-class-constructor-call": "^6.24.1",
 				"babel-plugin-transform-export-extensions": "^6.22.0",
@@ -2663,7 +2430,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
 			"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-dynamic-import": "^6.18.0",
 				"babel-plugin-transform-class-properties": "^6.24.1",
@@ -2675,7 +2441,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
 				"babel-plugin-transform-async-generator-functions": "^6.24.1",
@@ -2688,7 +2453,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-			"dev": true,
 			"requires": {
 				"babel-core": "^6.26.0",
 				"babel-runtime": "^6.26.0",
@@ -2703,7 +2467,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"dev": true,
 			"requires": {
 				"core-js": "^2.4.0",
 				"regenerator-runtime": "^0.11.0"
@@ -2713,7 +2476,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"babel-traverse": "^6.26.0",
@@ -2725,8 +2487,7 @@
 				"babylon": {
 					"version": "6.18.0",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-					"dev": true
+					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
 				}
 			}
 		},
@@ -2734,7 +2495,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"babel-messages": "^6.23.0",
@@ -2750,14 +2510,12 @@
 				"babylon": {
 					"version": "6.18.0",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-					"dev": true
+					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
 				},
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -2765,8 +2523,7 @@
 				"globals": {
 					"version": "9.18.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-					"dev": true
+					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
 				}
 			}
 		},
@@ -2774,7 +2531,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"esutils": "^2.0.2",
@@ -2785,16 +2541,14 @@
 				"to-fast-properties": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-					"dev": true
+					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
 				}
 			}
 		},
 		"bail": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
-			"integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg==",
-			"dev": true
+			"integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -2805,7 +2559,6 @@
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-			"dev": true,
 			"requires": {
 				"cache-base": "^1.0.1",
 				"class-utils": "^0.3.5",
@@ -2820,7 +2573,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -2829,7 +2581,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -2838,7 +2589,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -2847,7 +2597,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -2857,22 +2606,19 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
 		"base64-js": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-			"dev": true
+			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
@@ -2881,14 +2627,12 @@
 		"big.js": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-			"dev": true
+			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
 		},
 		"bin-version": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/bin-version/-/bin-version-2.0.0.tgz",
 			"integrity": "sha1-LMldg7Uive8umZeOdq61SRyBFP8=",
-			"dev": true,
 			"requires": {
 				"execa": "^0.1.1",
 				"find-versions": "^2.0.0"
@@ -2898,7 +2642,6 @@
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.1.1.tgz",
 					"integrity": "sha1-sJwqkwm8DvBQFHlHLbMYD41MPt0=",
-					"dev": true,
 					"requires": {
 						"cross-spawn-async": "^2.1.1",
 						"object-assign": "^4.0.1",
@@ -2911,7 +2654,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-3.0.0.tgz",
 			"integrity": "sha1-4k6/prY8sDh8X8F0+G5cyBLKfMk=",
-			"dev": true,
 			"requires": {
 				"bin-version": "^2.0.0",
 				"semver": "^5.1.0",
@@ -2921,14 +2663,17 @@
 		"binary-extensions": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
-			"dev": true
+			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+		},
+		"binaryextensions": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.1.tgz",
+			"integrity": "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA=="
 		},
 		"block-stream": {
 			"version": "0.0.9",
 			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
 			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-			"dev": true,
 			"requires": {
 				"inherits": "~2.0.0"
 			}
@@ -2941,14 +2686,12 @@
 		"bn.js": {
 			"version": "4.11.8",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-			"dev": true
+			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
 		},
 		"body-parser": {
 			"version": "1.18.2",
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
 			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
-			"dev": true,
 			"requires": {
 				"bytes": "3.0.0",
 				"content-type": "~1.0.4",
@@ -2965,14 +2708,12 @@
 				"bytes": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-					"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-					"dev": true
+					"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
 				},
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -2980,28 +2721,24 @@
 				"iconv-lite": {
 					"version": "0.4.19",
 					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-					"dev": true
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
 				},
 				"qs": {
 					"version": "6.5.1",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-					"dev": true
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
 				}
 			}
 		},
 		"boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-			"dev": true
+			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
 		},
 		"boom": {
 			"version": "2.10.1",
 			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
 			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-			"dev": true,
 			"requires": {
 				"hoek": "2.x.x"
 			}
@@ -3009,14 +2746,12 @@
 		"bowser": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.3.tgz",
-			"integrity": "sha512-/gp96UlcFw5DbV2KQPCqTqi0Mb9gZRyDAHiDsGEH+4B/KOQjeoE5lM1PxlVX8DQDvfEfitmC1rW2Oy8fk/XBDg==",
-			"dev": true
+			"integrity": "sha512-/gp96UlcFw5DbV2KQPCqTqi0Mb9gZRyDAHiDsGEH+4B/KOQjeoE5lM1PxlVX8DQDvfEfitmC1rW2Oy8fk/XBDg=="
 		},
 		"boxen": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
 			"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-			"dev": true,
 			"requires": {
 				"ansi-align": "^2.0.0",
 				"camelcase": "^4.0.0",
@@ -3030,8 +2765,7 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				}
 			}
 		},
@@ -3048,7 +2782,6 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-			"dev": true,
 			"requires": {
 				"arr-flatten": "^1.1.0",
 				"array-unique": "^0.3.2",
@@ -3066,7 +2799,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -3076,20 +2808,17 @@
 		"brcast": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.1.tgz",
-			"integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg==",
-			"dev": true
+			"integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg=="
 		},
 		"brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-			"dev": true
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
 			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-			"dev": true,
 			"requires": {
 				"buffer-xor": "^1.0.3",
 				"cipher-base": "^1.0.0",
@@ -3103,7 +2832,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
 			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
-			"dev": true,
 			"requires": {
 				"browserify-aes": "^1.0.4",
 				"browserify-des": "^1.0.0",
@@ -3114,7 +2842,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
 			"integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
-			"dev": true,
 			"requires": {
 				"cipher-base": "^1.0.1",
 				"des.js": "^1.0.0",
@@ -3125,7 +2852,6 @@
 			"version": "4.0.1",
 			"resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"randombytes": "^2.0.1"
@@ -3135,7 +2861,6 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.1",
 				"browserify-rsa": "^4.0.0",
@@ -3150,7 +2875,6 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
 			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-			"dev": true,
 			"requires": {
 				"pako": "~1.0.5"
 			}
@@ -3159,7 +2883,6 @@
 			"version": "1.7.7",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
 			"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-			"dev": true,
 			"requires": {
 				"caniuse-db": "^1.0.30000639",
 				"electron-to-chromium": "^1.2.7"
@@ -3168,19 +2891,36 @@
 		"buf-compare": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
-			"integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o=",
-			"dev": true
+			"integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o="
 		},
 		"buffer": {
 			"version": "4.9.1",
 			"resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-			"dev": true,
 			"requires": {
 				"base64-js": "^1.0.2",
 				"ieee754": "^1.1.4",
 				"isarray": "^1.0.0"
 			}
+		},
+		"buffer-alloc": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+			"requires": {
+				"buffer-alloc-unsafe": "^1.1.0",
+				"buffer-fill": "^1.0.0"
+			}
+		},
+		"buffer-alloc-unsafe": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+		},
+		"buffer-fill": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
 		},
 		"buffer-from": {
 			"version": "1.0.0",
@@ -3190,38 +2930,32 @@
 		"buffer-xor": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
-			"dev": true
+			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-			"dev": true
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
 		},
 		"builtin-status-codes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
-			"dev": true
+			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
 		},
 		"byline": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
-			"dev": true
+			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
 		},
 		"bytes": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz",
-			"integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo=",
-			"dev": true
+			"integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo="
 		},
 		"cacache": {
 			"version": "10.0.4",
 			"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
 			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
-			"dev": true,
 			"requires": {
 				"bluebird": "^3.5.1",
 				"chownr": "^1.0.1",
@@ -3241,8 +2975,7 @@
 				"y18n": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-					"dev": true
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 				}
 			}
 		},
@@ -3250,7 +2983,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-			"dev": true,
 			"requires": {
 				"collection-visit": "^1.0.0",
 				"component-emitter": "^1.2.1",
@@ -3267,7 +2999,6 @@
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
 			"integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
-			"dev": true,
 			"requires": {
 				"clone-response": "1.0.2",
 				"get-stream": "3.0.0",
@@ -3281,14 +3012,12 @@
 				"lowercase-keys": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-					"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-					"dev": true
+					"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
 				},
 				"normalize-url": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
 					"integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
-					"dev": true,
 					"requires": {
 						"prepend-http": "^2.0.0",
 						"query-string": "^5.0.1",
@@ -3298,14 +3027,12 @@
 				"prepend-http": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-					"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-					"dev": true
+					"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
 				},
 				"query-string": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
 					"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-					"dev": true,
 					"requires": {
 						"decode-uri-component": "^0.2.0",
 						"object-assign": "^4.1.0",
@@ -3318,7 +3045,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
 			"integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
-			"dev": true,
 			"requires": {
 				"md5-hex": "^1.2.0",
 				"mkdirp": "^0.5.1",
@@ -3329,7 +3055,6 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
 					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-					"dev": true,
 					"requires": {
 						"md5-o-matic": "^0.1.1"
 					}
@@ -3338,7 +3063,6 @@
 					"version": "1.3.4",
 					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
 					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
 						"imurmurhash": "^0.1.4",
@@ -3351,7 +3075,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.0.1.tgz",
 			"integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
-			"dev": true,
 			"requires": {
 				"core-js": "^2.0.0",
 				"deep-equal": "^1.0.0",
@@ -3362,20 +3085,30 @@
 		"call-me-maybe": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
-			"dev": true
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
 		},
 		"call-signature": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
-			"integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
-			"dev": true
+			"integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY="
+		},
+		"caller-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"requires": {
+				"callsites": "^0.2.0"
+			}
+		},
+		"callsites": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
 		},
 		"camel-case": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
 			"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-			"dev": true,
 			"requires": {
 				"no-case": "^2.2.0",
 				"upper-case": "^1.1.1"
@@ -3384,14 +3117,12 @@
 		"camelcase": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-			"dev": true
+			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
 		},
 		"camelcase-keys": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 			"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-			"dev": true,
 			"requires": {
 				"camelcase": "^4.1.0",
 				"map-obj": "^2.0.0",
@@ -3401,8 +3132,7 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				}
 			}
 		},
@@ -3410,7 +3140,6 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
 			"integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
-			"dev": true,
 			"requires": {
 				"browserslist": "^1.3.6",
 				"caniuse-db": "^1.0.30000529",
@@ -3421,26 +3150,22 @@
 		"caniuse-db": {
 			"version": "1.0.30000839",
 			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000839.tgz",
-			"integrity": "sha1-VahuQCx0rhcUlwe+o+o5lSIjNJc=",
-			"dev": true
+			"integrity": "sha1-VahuQCx0rhcUlwe+o+o5lSIjNJc="
 		},
 		"caniuse-lite": {
 			"version": "1.0.30000839",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000839.tgz",
-			"integrity": "sha512-gJZIfmkuy84agOeAZc7WJOexZhisZaBSFk96gkGM6TkH7+1mBfr/MSPnXC8lO0g7guh/ucbswYjruvDbzc6i0g==",
-			"dev": true
+			"integrity": "sha512-gJZIfmkuy84agOeAZc7WJOexZhisZaBSFk96gkGM6TkH7+1mBfr/MSPnXC8lO0g7guh/ucbswYjruvDbzc6i0g=="
 		},
 		"capture-stack-trace": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-			"dev": true
+			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
 		},
 		"case-sensitive-paths-webpack-plugin": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.2.tgz",
-			"integrity": "sha512-oEZgAFfEvKtjSRCu6VgYkuGxwrWXMnQzyBmlLPP7r6PWQVtHxP5Z5N6XsuJvtoVax78am/r7lr46bwo3IVEBOg==",
-			"dev": true
+			"integrity": "sha512-oEZgAFfEvKtjSRCu6VgYkuGxwrWXMnQzyBmlLPP7r6PWQVtHxP5Z5N6XsuJvtoVax78am/r7lr46bwo3IVEBOg=="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -3450,14 +3175,12 @@
 		"ccount": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
-			"integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==",
-			"dev": true
+			"integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw=="
 		},
 		"center-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-			"dev": true,
 			"requires": {
 				"align-text": "^0.1.3",
 				"lazy-cache": "^1.0.3"
@@ -3467,7 +3190,6 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -3477,44 +3199,37 @@
 		"character-entities": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
-			"integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ==",
-			"dev": true
+			"integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ=="
 		},
 		"character-entities-html4": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.2.tgz",
-			"integrity": "sha512-sIrXwyna2+5b0eB9W149izTPJk/KkJTg6mEzDGibwBUkyH1SbDa+nf515Ppdi3MaH35lW0JFJDWeq9Luzes1Iw==",
-			"dev": true
+			"integrity": "sha512-sIrXwyna2+5b0eB9W149izTPJk/KkJTg6mEzDGibwBUkyH1SbDa+nf515Ppdi3MaH35lW0JFJDWeq9Luzes1Iw=="
 		},
 		"character-entities-legacy": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz",
-			"integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA==",
-			"dev": true
+			"integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA=="
 		},
 		"character-reference-invalid": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
-			"integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ==",
-			"dev": true
+			"integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ=="
 		},
 		"chardet": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-			"dev": true
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
 		},
 		"chickencurry": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/chickencurry/-/chickencurry-1.1.1.tgz",
-			"integrity": "sha1-AmVfKyazvC7hrh5TFoht4463lzg=",
-			"dev": true
+			"integrity": "sha1-AmVfKyazvC7hrh5TFoht4463lzg="
 		},
 		"chokidar": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
 			"integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
-			"dev": true,
 			"requires": {
 				"anymatch": "^2.0.0",
 				"async-each": "^1.0.0",
@@ -3534,7 +3249,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.1"
 					}
@@ -3549,14 +3263,12 @@
 		"ci-info": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-			"integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
-			"dev": true
+			"integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg=="
 		},
 		"cipher-base": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -3565,14 +3277,12 @@
 		"circular-json": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-			"dev": true
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
 		},
 		"clap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
 			"integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
-			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3"
 			},
@@ -3580,14 +3290,12 @@
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -3599,8 +3307,22 @@
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
+			}
+		},
+		"class-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/class-extend/-/class-extend-0.1.2.tgz",
+			"integrity": "sha1-gFeoKwD1P4Kl1ixQ74z/3sb6vDQ=",
+			"requires": {
+				"object-assign": "^2.0.0"
+			},
+			"dependencies": {
+				"object-assign": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+					"integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
 				}
 			}
 		},
@@ -3608,7 +3330,6 @@
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"define-property": "^0.2.5",
@@ -3620,7 +3341,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -3630,14 +3350,12 @@
 		"classnames": {
 			"version": "2.2.5",
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
-			"integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0=",
-			"dev": true
+			"integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
 		},
 		"clean-css": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
 			"integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
-			"dev": true,
 			"requires": {
 				"source-map": "0.5.x"
 			},
@@ -3645,34 +3363,29 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
 		"clean-stack": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
-			"integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE=",
-			"dev": true
+			"integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE="
 		},
 		"clean-yaml-object": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
-			"integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
-			"dev": true
+			"integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g="
 		},
 		"cli-boxes": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-			"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
-			"dev": true
+			"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
 		},
 		"cli-cursor": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-			"dev": true,
 			"requires": {
 				"restore-cursor": "^2.0.0"
 			}
@@ -3680,20 +3393,32 @@
 		"cli-list": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/cli-list/-/cli-list-0.2.0.tgz",
-			"integrity": "sha1-fmc+4N05phGkhkduU/PGs5QctYI=",
-			"dev": true
+			"integrity": "sha1-fmc+4N05phGkhkduU/PGs5QctYI="
 		},
 		"cli-spinners": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
-			"integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==",
-			"dev": true
+			"integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg=="
+		},
+		"cli-table": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+			"integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+			"requires": {
+				"colors": "1.0.3"
+			},
+			"dependencies": {
+				"colors": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+				}
+			}
 		},
 		"cli-truncate": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
 			"integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
-			"dev": true,
 			"requires": {
 				"slice-ansi": "^1.0.0",
 				"string-width": "^2.0.0"
@@ -3702,14 +3427,12 @@
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-			"dev": true
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
 		},
 		"cliui": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
 			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-			"dev": true,
 			"requires": {
 				"center-align": "^0.1.1",
 				"right-align": "^0.1.1",
@@ -3719,22 +3442,24 @@
 				"wordwrap": {
 					"version": "0.0.2",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-					"dev": true
+					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
 				}
 			}
 		},
 		"clone": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-			"dev": true
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+		},
+		"clone-buffer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
 		},
 		"clone-deep": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-2.0.2.tgz",
 			"integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
-			"dev": true,
 			"requires": {
 				"for-own": "^1.0.0",
 				"is-plain-object": "^2.0.4",
@@ -3746,7 +3471,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
 					"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-					"dev": true,
 					"requires": {
 						"for-in": "^1.0.1"
 					}
@@ -3754,8 +3478,7 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -3763,7 +3486,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
 			"integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
-			"dev": true,
 			"requires": {
 				"is-regexp": "^1.0.0",
 				"is-supported-regexp-flag": "^1.0.0"
@@ -3773,7 +3495,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
 			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-			"dev": true,
 			"requires": {
 				"mimic-response": "^1.0.0"
 			}
@@ -3781,14 +3502,22 @@
 		"clone-stats": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-			"dev": true
+			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+		},
+		"cloneable-readable": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
+			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
+			"requires": {
+				"inherits": "^2.0.1",
+				"process-nextick-args": "^2.0.0",
+				"readable-stream": "^2.3.5"
+			}
 		},
 		"cmd-shim": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
 			"integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"mkdirp": "~0.5.0"
@@ -3797,14 +3526,12 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-			"dev": true
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
 		},
 		"co-with-promise": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co-with-promise/-/co-with-promise-4.6.0.tgz",
 			"integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
-			"dev": true,
 			"requires": {
 				"pinkie-promise": "^1.0.0"
 			},
@@ -3812,14 +3539,12 @@
 				"pinkie": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-					"integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
-					"dev": true
+					"integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q="
 				},
 				"pinkie-promise": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
 					"integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
-					"dev": true,
 					"requires": {
 						"pinkie": "^1.0.0"
 					}
@@ -3830,7 +3555,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
 			"integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
-			"dev": true,
 			"requires": {
 				"q": "^1.1.2"
 			}
@@ -3839,7 +3563,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.1.tgz",
 			"integrity": "sha512-tJLhH3EpFm/1x7heIW0hemXJTUU5EWl2V0EIX558jp05Mt1U6DVryCgkp3l37cxqs+DNbNgxG43SkwJXpQ14Jw==",
-			"dev": true,
 			"requires": {
 				"convert-to-spaces": "^1.0.1"
 			}
@@ -3847,20 +3570,17 @@
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"dev": true
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"collapse-white-space": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.4.tgz",
-			"integrity": "sha512-YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw==",
-			"dev": true
+			"integrity": "sha512-YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw=="
 		},
 		"collection-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-			"dev": true,
 			"requires": {
 				"map-visit": "^1.0.0",
 				"object-visit": "^1.0.0"
@@ -3870,7 +3590,6 @@
 			"version": "0.11.4",
 			"resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
 			"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-			"dev": true,
 			"requires": {
 				"clone": "^1.0.2",
 				"color-convert": "^1.3.0",
@@ -3881,7 +3600,6 @@
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-			"dev": true,
 			"requires": {
 				"color-name": "^1.1.1"
 			}
@@ -3889,20 +3607,17 @@
 		"color-diff": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/color-diff/-/color-diff-0.1.7.tgz",
-			"integrity": "sha1-bbeM2UgqjkWdQIIer0tQMoPcuOI=",
-			"dev": true
+			"integrity": "sha1-bbeM2UgqjkWdQIIer0tQMoPcuOI="
 		},
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"color-string": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
 			"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-			"dev": true,
 			"requires": {
 				"color-name": "^1.0.0"
 			}
@@ -3911,7 +3626,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/colorguard/-/colorguard-1.2.1.tgz",
 			"integrity": "sha512-qYVKTg626qpDg4/eBnPXidEPXn5+krbYqHVfyyEFBWV5z3IF4p44HKY/eE2t1ohlcrlIkDgHmFJMfQ8qMLnSFw==",
-			"dev": true,
 			"requires": {
 				"chalk": "^1.1.1",
 				"color-diff": "^0.1.3",
@@ -3928,14 +3642,12 @@
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -3948,7 +3660,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-					"dev": true,
 					"requires": {
 						"chalk": "^1.0.0"
 					}
@@ -3957,7 +3668,6 @@
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-1.4.1.tgz",
 					"integrity": "sha1-wTbwpbFhkV83ndN2XGEHX357mvI=",
-					"dev": true,
 					"requires": {
 						"chalk": "^1.0.0",
 						"lodash": "^4.1.0",
@@ -3968,14 +3678,12 @@
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				},
 				"yargs": {
 					"version": "1.3.3",
 					"resolved": "http://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz",
-					"integrity": "sha1-BU3oth8i7v23IHBZ6u+da4P7kxo=",
-					"dev": true
+					"integrity": "sha1-BU3oth8i7v23IHBZ6u+da4P7kxo="
 				}
 			}
 		},
@@ -3983,7 +3691,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
 			"integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
-			"dev": true,
 			"requires": {
 				"color": "^0.11.0",
 				"css-color-names": "0.0.4",
@@ -3993,22 +3700,19 @@
 				"css-color-names": {
 					"version": "0.0.4",
 					"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
-					"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
-					"dev": true
+					"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
 				}
 			}
 		},
 		"colors": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-			"dev": true
+			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
 		},
 		"columnify": {
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
 			"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
-			"dev": true,
 			"requires": {
 				"strip-ansi": "^3.0.0",
 				"wcwidth": "^1.0.0"
@@ -4025,20 +3729,17 @@
 		"command-join": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/command-join/-/command-join-2.0.0.tgz",
-			"integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8=",
-			"dev": true
+			"integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8="
 		},
 		"commander": {
 			"version": "2.15.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-			"dev": true
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
 		},
 		"commit-status": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/commit-status/-/commit-status-4.3.0.tgz",
 			"integrity": "sha1-fuSHfDpsdhXJWH9o2ahm2y2BU7A=",
-			"dev": true,
 			"requires": {
 				"octokat": "^0.4.11"
 			}
@@ -4046,14 +3747,12 @@
 		"common-path-prefix": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-1.0.0.tgz",
-			"integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA=",
-			"dev": true
+			"integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA="
 		},
 		"common-tags": {
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.7.2.tgz",
 			"integrity": "sha512-joj9ZlUOjCrwdbmiLqafeUSgkUM74NqhLsZtSqDmhKudaIY197zTrb8JMl31fMnCUuxwFT23eC/oWvrZzDLRJQ==",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0"
 			}
@@ -4061,14 +3760,12 @@
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-			"dev": true
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
 		},
 		"compare-func": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
 			"integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
-			"dev": true,
 			"requires": {
 				"array-ify": "^1.0.0",
 				"dot-prop": "^3.0.0"
@@ -4078,7 +3775,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
 					"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-					"dev": true,
 					"requires": {
 						"is-obj": "^1.0.0"
 					}
@@ -4088,14 +3784,12 @@
 		"component-emitter": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-			"dev": true
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 		},
 		"compose-function": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/compose-function/-/compose-function-2.0.0.tgz",
 			"integrity": "sha1-5kL6fh2iFSlyADFHZ3b8JGkawLA=",
-			"dev": true,
 			"requires": {
 				"arity-n": "^1.0.4"
 			}
@@ -4120,7 +3814,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/concordance/-/concordance-3.0.0.tgz",
 			"integrity": "sha512-CZBzJ3/l5QJjlZM20WY7+5GP5pMTw+1UEbThcpMw8/rojsi5sBCiD8ZbBLtD+jYpRGAkwuKuqk108c154V9eyQ==",
-			"dev": true,
 			"requires": {
 				"date-time": "^2.1.0",
 				"esutils": "^2.0.2",
@@ -4139,7 +3832,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/conf/-/conf-1.4.0.tgz",
 			"integrity": "sha512-bzlVWS2THbMetHqXKB8ypsXN4DQ/1qopGwNJi1eYbpwesJcd86FBjFciCQX/YwAhp9bM7NVnPFqZ5LpV7gP0Dg==",
-			"dev": true,
 			"requires": {
 				"dot-prop": "^4.1.0",
 				"env-paths": "^1.0.0",
@@ -4152,7 +3844,6 @@
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
 			"integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
-			"dev": true,
 			"requires": {
 				"ini": "^1.3.4",
 				"proto-list": "~1.2.1"
@@ -4162,7 +3853,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
 			"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
-			"dev": true,
 			"requires": {
 				"dot-prop": "^4.1.0",
 				"graceful-fs": "^4.1.2",
@@ -4176,7 +3866,6 @@
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
 					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-					"dev": true,
 					"requires": {
 						"is-obj": "^1.0.0"
 					}
@@ -4187,7 +3876,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-			"dev": true,
 			"requires": {
 				"date-now": "^0.1.4"
 			}
@@ -4195,32 +3883,32 @@
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"dev": true
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
-			"dev": true
+			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
+		},
+		"contains-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
 		},
 		"content-disposition": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-			"dev": true
+			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
 		},
 		"content-type": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-			"dev": true
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
 		},
 		"conventional-changelog": {
 			"version": "1.1.24",
 			"resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.24.tgz",
 			"integrity": "sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==",
-			"dev": true,
 			"requires": {
 				"conventional-changelog-angular": "^1.6.6",
 				"conventional-changelog-atom": "^0.2.8",
@@ -4239,7 +3927,6 @@
 			"version": "1.6.6",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
 			"integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
-			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"q": "^1.5.1"
@@ -4249,7 +3936,6 @@
 			"version": "0.2.8",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.8.tgz",
 			"integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -4258,7 +3944,6 @@
 			"version": "1.3.22",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-1.3.22.tgz",
 			"integrity": "sha512-pnjdIJbxjkZ5VdAX/H1wndr1G10CY8MuZgnXuJhIHglOXfIrXygb7KZC836GW9uo1u8PjEIvIw/bKX0lOmOzZg==",
-			"dev": true,
 			"requires": {
 				"add-stream": "^1.0.0",
 				"conventional-changelog": "^1.1.24",
@@ -4271,7 +3956,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -4283,7 +3967,6 @@
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -4299,14 +3982,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -4317,7 +3998,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -4329,7 +4009,6 @@
 			"version": "0.3.8",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.8.tgz",
 			"integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -4338,7 +4017,6 @@
 			"version": "2.0.11",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.11.tgz",
 			"integrity": "sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==",
-			"dev": true,
 			"requires": {
 				"conventional-changelog-writer": "^3.0.9",
 				"conventional-commits-parser": "^2.1.7",
@@ -4359,7 +4037,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
@@ -4372,7 +4049,6 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
@@ -4381,7 +4057,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"pify": "^2.0.0",
@@ -4391,14 +4066,12 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^1.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -4409,7 +4082,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -4420,7 +4092,6 @@
 			"version": "0.3.12",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.12.tgz",
 			"integrity": "sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -4429,7 +4100,6 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.9.tgz",
 			"integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -4438,7 +4108,6 @@
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.6.tgz",
 			"integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -4447,7 +4116,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
 			"integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
-			"dev": true,
 			"requires": {
 				"q": "^1.4.1"
 			}
@@ -4456,7 +4124,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
 			"integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
-			"dev": true,
 			"requires": {
 				"q": "^1.4.1"
 			}
@@ -4465,7 +4132,6 @@
 			"version": "0.3.8",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.8.tgz",
 			"integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
-			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"q": "^1.5.1"
@@ -4474,14 +4140,12 @@
 		"conventional-changelog-preset-loader": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.8.tgz",
-			"integrity": "sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw==",
-			"dev": true
+			"integrity": "sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw=="
 		},
 		"conventional-changelog-writer": {
 			"version": "3.0.9",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.9.tgz",
 			"integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
-			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"conventional-commits-filter": "^1.1.6",
@@ -4499,7 +4163,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -4511,7 +4174,6 @@
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -4527,14 +4189,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -4545,7 +4205,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -4557,7 +4216,6 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz",
 			"integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
-			"dev": true,
 			"requires": {
 				"is-subset": "^0.1.1",
 				"modify-values": "^1.0.0"
@@ -4567,7 +4225,6 @@
 			"version": "2.1.7",
 			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
 			"integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
-			"dev": true,
 			"requires": {
 				"JSONStream": "^1.0.4",
 				"is-text-path": "^1.0.0",
@@ -4582,7 +4239,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -4594,7 +4250,6 @@
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -4610,14 +4265,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -4628,7 +4281,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -4640,7 +4292,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.2.1.tgz",
 			"integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
-			"dev": true,
 			"requires": {
 				"concat-stream": "^1.4.10",
 				"conventional-commits-filter": "^1.1.1",
@@ -4654,26 +4305,22 @@
 		"convert-source-map": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-			"dev": true
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
 		},
 		"convert-to-spaces": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
-			"integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU=",
-			"dev": true
+			"integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU="
 		},
 		"cookie": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-			"dev": true
+			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
 		},
 		"cookie-signature": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-			"dev": true
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
 		},
 		"copy-concurrently": {
 			"version": "1.0.5",
@@ -4691,14 +4338,12 @@
 		"copy-descriptor": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-			"dev": true
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"core-assert": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
 			"integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
-			"dev": true,
 			"requires": {
 				"buf-compare": "^1.0.0",
 				"is-error": "^2.2.0"
@@ -4707,8 +4352,7 @@
 		"core-js": {
 			"version": "2.5.6",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
-			"integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
-			"dev": true
+			"integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -4719,7 +4363,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
 			"integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
-			"dev": true,
 			"requires": {
 				"is-directory": "^0.3.1",
 				"js-yaml": "^3.9.0",
@@ -4731,7 +4374,6 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
 			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"elliptic": "^6.0.0"
@@ -4741,7 +4383,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
 			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-			"dev": true,
 			"requires": {
 				"capture-stack-trace": "^1.0.0"
 			}
@@ -4750,7 +4391,6 @@
 			"version": "1.2.0",
 			"resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-			"dev": true,
 			"requires": {
 				"cipher-base": "^1.0.1",
 				"inherits": "^2.0.1",
@@ -4763,7 +4403,6 @@
 			"version": "1.1.7",
 			"resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-			"dev": true,
 			"requires": {
 				"cipher-base": "^1.0.3",
 				"create-hash": "^1.1.0",
@@ -4777,7 +4416,6 @@
 			"version": "15.6.3",
 			"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
 			"integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
-			"dev": true,
 			"requires": {
 				"fbjs": "^0.8.9",
 				"loose-envify": "^1.3.1",
@@ -4788,7 +4426,6 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-			"dev": true,
 			"requires": {
 				"lru-cache": "^4.0.1",
 				"shebang-command": "^1.2.0",
@@ -4799,7 +4436,6 @@
 			"version": "2.2.5",
 			"resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
 			"integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
-			"dev": true,
 			"requires": {
 				"lru-cache": "^4.0.0",
 				"which": "^1.2.8"
@@ -4809,7 +4445,6 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
 			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-			"dev": true,
 			"requires": {
 				"boom": "2.x.x"
 			}
@@ -4818,7 +4453,6 @@
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
 			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
-			"dev": true,
 			"requires": {
 				"browserify-cipher": "^1.0.0",
 				"browserify-sign": "^4.0.0",
@@ -4836,20 +4470,17 @@
 		"crypto-random-string": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-			"dev": true
+			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
 		},
 		"css-color-names": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.1.tgz",
-			"integrity": "sha1-XQVI+iVkVu3kqaDCrHqxnT6xrYE=",
-			"dev": true
+			"integrity": "sha1-XQVI+iVkVu3kqaDCrHqxnT6xrYE="
 		},
 		"css-in-js-utils": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
 			"integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
-			"dev": true,
 			"requires": {
 				"hyphenate-style-name": "^1.0.2",
 				"isobject": "^3.0.1"
@@ -4859,7 +4490,6 @@
 			"version": "0.28.11",
 			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.11.tgz",
 			"integrity": "sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==",
-			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"css-selector-tokenizer": "^0.7.0",
@@ -4881,7 +4511,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/css-rule-stream/-/css-rule-stream-1.1.0.tgz",
 			"integrity": "sha1-N4bnGYmD2WWibjGVfgkHjLt3BaI=",
-			"dev": true,
 			"requires": {
 				"css-tokenize": "^1.0.1",
 				"duplexer2": "0.0.2",
@@ -4892,14 +4521,12 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"readable-stream": {
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -4910,14 +4537,12 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				},
 				"through2": {
 					"version": "0.6.5",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
 					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-					"dev": true,
 					"requires": {
 						"readable-stream": ">=1.0.33-1 <1.1.0-0",
 						"xtend": ">=4.0.0 <4.1.0-0"
@@ -4929,7 +4554,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
 			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-			"dev": true,
 			"requires": {
 				"boolbase": "~1.0.0",
 				"css-what": "2.1",
@@ -4941,7 +4565,6 @@
 					"version": "1.5.1",
 					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
 					"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-					"dev": true,
 					"requires": {
 						"dom-serializer": "0",
 						"domelementtype": "1"
@@ -4952,14 +4575,12 @@
 		"css-selector-parser": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.3.0.tgz",
-			"integrity": "sha1-XxrUPi2O77/cME/NOaUhZklD4+s=",
-			"dev": true
+			"integrity": "sha1-XxrUPi2O77/cME/NOaUhZklD4+s="
 		},
 		"css-selector-tokenizer": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
 			"integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
-			"dev": true,
 			"requires": {
 				"cssesc": "^0.1.0",
 				"fastparse": "^1.1.1",
@@ -4970,7 +4591,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/css-shorthand-expand/-/css-shorthand-expand-1.2.0.tgz",
 			"integrity": "sha512-L3RS1VNYuXgMOfVGX4WzP9AFK6KL0JuioSoO8661egEac2eHX9/s4yFO8mgK6QEtm8UmU8IvuKzPgdQpU0DhpQ==",
-			"dev": true,
 			"requires": {
 				"css-color-names": "0.0.1",
 				"css-url-regex": "0.0.1",
@@ -4987,22 +4607,19 @@
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-					"dev": true
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
 				}
 			}
 		},
 		"css-shorthand-properties": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.1.0.tgz",
-			"integrity": "sha512-0Pg/e2U0NgT6Chw1TUe3D2ZTOOO3JFzlDV+bN3hxR8T0RDjnwzmx5WhuYUA0GHYWlPYAYi2/Ac0e8oqgerHDQw==",
-			"dev": true
+			"integrity": "sha512-0Pg/e2U0NgT6Chw1TUe3D2ZTOOO3JFzlDV+bN3hxR8T0RDjnwzmx5WhuYUA0GHYWlPYAYi2/Ac0e8oqgerHDQw=="
 		},
 		"css-tokenize": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/css-tokenize/-/css-tokenize-1.0.1.tgz",
 			"integrity": "sha1-RiXLHtohwUOFi3+B1oA8HSb8FL4=",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^1.0.33"
@@ -5011,14 +4628,12 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"readable-stream": {
 					"version": "1.1.14",
 					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -5029,34 +4644,29 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
 		},
 		"css-url-regex": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-0.0.1.tgz",
-			"integrity": "sha1-4Fr4xsKQ1FHvFjK0VepcgbSxOVw=",
-			"dev": true
+			"integrity": "sha1-4Fr4xsKQ1FHvFjK0VepcgbSxOVw="
 		},
 		"css-what": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-			"integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
-			"dev": true
+			"integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
 		},
 		"cssesc": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
-			"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
-			"dev": true
+			"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q="
 		},
 		"cssnano": {
 			"version": "3.10.0",
 			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
 			"integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
-			"dev": true,
 			"requires": {
 				"autoprefixer": "^6.3.1",
 				"decamelize": "^1.1.2",
@@ -5096,7 +4706,6 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
 			"integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
-			"dev": true,
 			"requires": {
 				"clap": "^1.0.9",
 				"source-map": "^0.5.3"
@@ -5105,8 +4714,7 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -5114,7 +4722,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/cssstats/-/cssstats-3.2.0.tgz",
 			"integrity": "sha1-m0sU6I7b1vltayRgzcyeNLNhkAY=",
-			"dev": true,
 			"requires": {
 				"bytes": "^2.4.0",
 				"css-selector-tokenizer": "^0.7.0",
@@ -5138,14 +4745,12 @@
 		"csstype": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.0.tgz",
-			"integrity": "sha512-KyGTo7/Y1lIK+JIfZ4LNEFdjN5lYwmJPpiP2fJbZF9LL95sY4CvUibobzzyXVsiuiD/oKcCzGZfT7WWZxHvkCw==",
-			"dev": true
+			"integrity": "sha512-KyGTo7/Y1lIK+JIfZ4LNEFdjN5lYwmJPpiP2fJbZF9LL95sY4CvUibobzzyXVsiuiD/oKcCzGZfT7WWZxHvkCw=="
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-			"dev": true,
 			"requires": {
 				"array-find-index": "^1.0.1"
 			}
@@ -5159,7 +4764,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-			"dev": true,
 			"requires": {
 				"es5-ext": "^0.10.9"
 			}
@@ -5168,7 +4772,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
 			"integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -5177,7 +4780,6 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			},
@@ -5185,22 +4787,19 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
 			}
 		},
 		"date-now": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
-			"dev": true
+			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
 		},
 		"date-time": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
 			"integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
-			"dev": true,
 			"requires": {
 				"time-zone": "^1.0.0"
 			}
@@ -5208,14 +4807,12 @@
 		"dateformat": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-			"dev": true
+			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
 		},
 		"debug": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -5223,14 +4820,12 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"decamelize-keys": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
 			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
-			"dev": true,
 			"requires": {
 				"decamelize": "^1.1.0",
 				"map-obj": "^1.0.0"
@@ -5239,22 +4834,19 @@
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-					"dev": true
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
 				}
 			}
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-			"dev": true
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
 		},
 		"decompress-response": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
 			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-			"dev": true,
 			"requires": {
 				"mimic-response": "^1.0.0"
 			}
@@ -5262,32 +4854,32 @@
 		"dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
-			"dev": true
+			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
 		},
 		"deep-equal": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-			"dev": true
+			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
 		},
 		"deep-extend": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-			"integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
-			"dev": true
+			"integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
 		"default-uid": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/default-uid/-/default-uid-1.0.0.tgz",
-			"integrity": "sha1-/O+p359axAyJFtkS3R/hFGqjxZ4=",
-			"dev": true
+			"integrity": "sha1-/O+p359axAyJFtkS3R/hFGqjxZ4="
 		},
 		"defaults": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
 			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-			"dev": true,
 			"requires": {
 				"clone": "^1.0.2"
 			}
@@ -5296,7 +4888,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-			"dev": true,
 			"requires": {
 				"foreach": "^2.0.5",
 				"object-keys": "^1.0.8"
@@ -5306,7 +4897,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-			"dev": true,
 			"requires": {
 				"is-descriptor": "^1.0.2",
 				"isobject": "^3.0.1"
@@ -5316,7 +4906,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -5325,7 +4914,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -5334,7 +4922,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -5344,22 +4931,19 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
 		"defined": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-			"dev": true
+			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
 		},
 		"del": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-			"dev": true,
 			"requires": {
 				"globby": "^5.0.0",
 				"is-path-cwd": "^1.0.0",
@@ -5374,7 +4958,6 @@
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
 					"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-					"dev": true,
 					"requires": {
 						"array-union": "^1.0.1",
 						"arrify": "^1.0.0",
@@ -5387,8 +4970,7 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
 		},
@@ -5400,20 +4982,17 @@
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"dev": true
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
 		},
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-			"dev": true
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
 		},
 		"des.js": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"minimalistic-assert": "^1.0.0"
@@ -5422,20 +5001,22 @@
 		"destroy": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-			"dev": true
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+		},
+		"detect-conflict": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.1.tgz",
+			"integrity": "sha1-CIZXpmqWHAUBnbfEIwiDsca0F24="
 		},
 		"detect-indent": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-			"dev": true
+			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
 		},
 		"detect-port-alt": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
 			"integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
-			"dev": true,
 			"requires": {
 				"address": "^1.0.1",
 				"debug": "^2.6.0"
@@ -5445,7 +5026,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -5455,14 +5035,12 @@
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-			"dev": true
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
 			"resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"miller-rabin": "^4.0.0",
@@ -5473,7 +5051,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
 			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
-			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
 				"path-type": "^3.0.0"
@@ -5483,7 +5060,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2"
 			}
@@ -5492,7 +5068,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/doiuse/-/doiuse-4.1.0.tgz",
 			"integrity": "sha512-QBvDs4nH6uJwSNwONQkBpt7SdCfjFEuQqoSkpyoUXqX7gYd9elCTVhIiIEaAFNiykwCrjIjHVcBcx1csa6EsQg==",
-			"dev": true,
 			"requires": {
 				"browserslist": "^3.2.1",
 				"caniuse-lite": "^1.0.30000819",
@@ -5512,7 +5087,6 @@
 					"version": "3.2.8",
 					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
 					"integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
-					"dev": true,
 					"requires": {
 						"caniuse-lite": "^1.0.30000844",
 						"electron-to-chromium": "^1.3.47"
@@ -5521,28 +5095,24 @@
 						"caniuse-lite": {
 							"version": "1.0.30000885",
 							"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000885.tgz",
-							"integrity": "sha512-cXKbYwpxBLd7qHyej16JazPoUacqoVuDhvR61U7Fr5vSxMUiodzcYa1rQYRYfZ5GexV03vGZHd722vNPLjPJGQ==",
-							"dev": true
+							"integrity": "sha512-cXKbYwpxBLd7qHyej16JazPoUacqoVuDhvR61U7Fr5vSxMUiodzcYa1rQYRYfZ5GexV03vGZHd722vNPLjPJGQ=="
 						}
 					}
 				},
 				"electron-to-chromium": {
 					"version": "1.3.66",
 					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.66.tgz",
-					"integrity": "sha512-EXfLtc9JxX2AZxISZ10o6hXEXTtnLtj7il5eye5YMgmDf4HbBbg+QDXpUEspsFrUcUugJZd5QJ4iIkRrmQQqIg==",
-					"dev": true
+					"integrity": "sha512-EXfLtc9JxX2AZxISZ10o6hXEXTtnLtj7il5eye5YMgmDf4HbBbg+QDXpUEspsFrUcUugJZd5QJ4iIkRrmQQqIg=="
 				},
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"postcss": {
 					"version": "6.0.23",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
 					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
 						"source-map": "^0.6.1",
@@ -5552,8 +5122,7 @@
 						"source-map": {
 							"version": "0.6.1",
 							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-							"dev": true
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 						}
 					}
 				},
@@ -5561,7 +5130,6 @@
 					"version": "1.0.34",
 					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -5572,20 +5140,17 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				},
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				},
 				"through2": {
 					"version": "0.6.5",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
 					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-					"dev": true,
 					"requires": {
 						"readable-stream": ">=1.0.33-1 <1.1.0-0",
 						"xtend": ">=4.0.0 <4.1.0-0"
@@ -5597,7 +5162,6 @@
 			"version": "0.1.4",
 			"resolved": "http://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
 			"integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
-			"dev": true,
 			"requires": {
 				"utila": "~0.3"
 			},
@@ -5605,22 +5169,19 @@
 				"utila": {
 					"version": "0.3.3",
 					"resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
-					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY=",
-					"dev": true
+					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY="
 				}
 			}
 		},
 		"dom-helpers": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
-			"integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg==",
-			"dev": true
+			"integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
 		},
 		"dom-serializer": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
 			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
-			"dev": true,
 			"requires": {
 				"domelementtype": "~1.1.1",
 				"entities": "~1.1.1"
@@ -5629,34 +5190,29 @@
 				"domelementtype": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-					"dev": true
+					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
 				}
 			}
 		},
 		"dom-walk": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
-			"dev": true
+			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
 		},
 		"domain-browser": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
-			"dev": true
+			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
 		},
 		"domelementtype": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
-			"dev": true
+			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
 		},
 		"domhandler": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
 			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-			"dev": true,
 			"requires": {
 				"domelementtype": "1"
 			}
@@ -5665,7 +5221,6 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
 			"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-			"dev": true,
 			"requires": {
 				"dom-serializer": "0",
 				"domelementtype": "1"
@@ -5675,7 +5230,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
 			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-			"dev": true,
 			"requires": {
 				"is-obj": "^1.0.0"
 			}
@@ -5683,14 +5237,12 @@
 		"dotenv": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
-			"integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
-			"dev": true
+			"integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
 		},
 		"dotenv-webpack": {
 			"version": "1.5.5",
 			"resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-1.5.5.tgz",
 			"integrity": "sha1-NEEJTwTTBLYRnmtyUk5i+zJS9fI=",
-			"dev": true,
 			"requires": {
 				"dotenv": "^5.0.1"
 			}
@@ -5699,7 +5251,6 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/downgrade-root/-/downgrade-root-1.2.2.tgz",
 			"integrity": "sha1-UxMZcVsOgf/MIusoR4uidkPhLGw=",
-			"dev": true,
 			"requires": {
 				"default-uid": "^1.0.0",
 				"is-root": "^1.0.0"
@@ -5708,14 +5259,12 @@
 		"duplexer": {
 			"version": "0.1.1",
 			"resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-			"dev": true
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
 		},
 		"duplexer2": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
 			"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "~1.1.9"
 			},
@@ -5723,14 +5272,12 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"readable-stream": {
 					"version": "1.1.14",
 					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -5741,16 +5288,14 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
 		},
 		"duplexer3": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-			"dev": true
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
 		},
 		"duplexify": {
 			"version": "3.6.0",
@@ -5767,7 +5312,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
 			"integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
-			"dev": true,
 			"requires": {
 				"onetime": "^1.0.0",
 				"set-immediate-shim": "^1.0.0"
@@ -5776,8 +5320,7 @@
 				"onetime": {
 					"version": "1.1.0",
 					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-					"dev": true
+					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
 				}
 			}
 		},
@@ -5785,29 +5328,35 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"jsbn": "~0.1.0"
 			}
 		},
+		"editions": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+			"integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-			"dev": true
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+		},
+		"ejs": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
+			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
 		},
 		"electron-to-chromium": {
 			"version": "1.3.45",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.45.tgz",
-			"integrity": "sha1-RYrBscXHYM6IEaFtK/vZfsMLr7g=",
-			"dev": true
+			"integrity": "sha1-RYrBscXHYM6IEaFtK/vZfsMLr7g="
 		},
 		"elliptic": {
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
 			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -5821,14 +5370,12 @@
 		"emojis-list": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-			"dev": true
+			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
 		},
 		"empower-core": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
 			"integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
-			"dev": true,
 			"requires": {
 				"call-signature": "0.0.2",
 				"core-js": "^2.0.0"
@@ -5837,14 +5384,12 @@
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-			"dev": true
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
 		},
 		"encoding": {
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"dev": true,
 			"requires": {
 				"iconv-lite": "~0.4.13"
 			}
@@ -5861,7 +5406,6 @@
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
 			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"memory-fs": "^0.4.0",
@@ -5872,41 +5416,44 @@
 		"entities": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-			"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
-			"dev": true
+			"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
 		},
 		"env-paths": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
-			"integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=",
-			"dev": true
+			"integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA="
 		},
 		"equal-length": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/equal-length/-/equal-length-1.0.1.tgz",
-			"integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w=",
-			"dev": true
+			"integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w="
 		},
 		"err-code": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-			"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
-			"dev": true
+			"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
 		},
 		"errno": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
 			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-			"dev": true,
 			"requires": {
 				"prr": "~1.0.1"
+			}
+		},
+		"error": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
+			"integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
+			"requires": {
+				"string-template": "~0.2.1",
+				"xtend": "~4.0.0"
 			}
 		},
 		"error-ex": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
 			}
@@ -5915,7 +5462,6 @@
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
 			"integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
-			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.1.1",
 				"function-bind": "^1.1.1",
@@ -5928,7 +5474,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-			"dev": true,
 			"requires": {
 				"is-callable": "^1.1.1",
 				"is-date-object": "^1.0.1",
@@ -5939,7 +5484,6 @@
 			"version": "0.10.42",
 			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
 			"integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
-			"dev": true,
 			"requires": {
 				"es6-iterator": "~2.0.3",
 				"es6-symbol": "~3.1.1",
@@ -5949,20 +5493,17 @@
 		"es5-shim": {
 			"version": "4.5.10",
 			"resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.10.tgz",
-			"integrity": "sha512-vmryBdqKRO8Ei9LJ4yyEk/EOmAOGIagcHDYPpTAi6pot4IMHS1AC2q5cTKPmydpijg2iX8DVmCuqgrNxIWj8Yg==",
-			"dev": true
+			"integrity": "sha512-vmryBdqKRO8Ei9LJ4yyEk/EOmAOGIagcHDYPpTAi6pot4IMHS1AC2q5cTKPmydpijg2iX8DVmCuqgrNxIWj8Yg=="
 		},
 		"es6-error": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-			"dev": true
+			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
 		},
 		"es6-iterator": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
 			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-			"dev": true,
 			"requires": {
 				"d": "1",
 				"es5-ext": "^0.10.35",
@@ -5973,7 +5514,6 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
 			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-			"dev": true,
 			"requires": {
 				"d": "1",
 				"es5-ext": "~0.10.14",
@@ -5986,14 +5526,12 @@
 		"es6-promise": {
 			"version": "3.0.2",
 			"resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
-			"integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
-			"dev": true
+			"integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
 		},
 		"es6-promisify": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-			"dev": true,
 			"requires": {
 				"es6-promise": "^4.0.3"
 			},
@@ -6001,8 +5539,7 @@
 				"es6-promise": {
 					"version": "4.2.4",
 					"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-					"integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
-					"dev": true
+					"integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
 				}
 			}
 		},
@@ -6010,7 +5547,6 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
 			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-			"dev": true,
 			"requires": {
 				"d": "1",
 				"es5-ext": "~0.10.14",
@@ -6022,14 +5558,12 @@
 		"es6-shim": {
 			"version": "0.35.3",
 			"resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.3.tgz",
-			"integrity": "sha1-m/tzY/7//4emzbbNk+QF7DxLbyY=",
-			"dev": true
+			"integrity": "sha1-m/tzY/7//4emzbbNk+QF7DxLbyY="
 		},
 		"es6-symbol": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
 			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-			"dev": true,
 			"requires": {
 				"d": "1",
 				"es5-ext": "~0.10.14"
@@ -6039,7 +5573,6 @@
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
 			"integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
-			"dev": true,
 			"requires": {
 				"recast": "~0.11.12",
 				"through": "~2.3.6"
@@ -6048,20 +5581,17 @@
 				"ast-types": {
 					"version": "0.9.6",
 					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-					"integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
-					"dev": true
+					"integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
 				},
 				"esprima": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-					"dev": true
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
 				},
 				"recast": {
 					"version": "0.11.23",
 					"resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
 					"integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-					"dev": true,
 					"requires": {
 						"ast-types": "0.9.6",
 						"esprima": "~3.1.0",
@@ -6072,8 +5602,7 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -6081,7 +5610,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
 			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-			"dev": true,
 			"requires": {
 				"d": "1",
 				"es5-ext": "^0.10.14",
@@ -6092,20 +5620,17 @@
 		"escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-			"dev": true
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escope": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
 			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-			"dev": true,
 			"requires": {
 				"es6-map": "^0.1.3",
 				"es6-weak-map": "^2.0.1",
@@ -6113,11 +5638,368 @@
 				"estraverse": "^4.1.1"
 			}
 		},
+		"eslint": {
+			"version": "3.19.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+			"integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+			"requires": {
+				"babel-code-frame": "^6.16.0",
+				"chalk": "^1.1.3",
+				"concat-stream": "^1.5.2",
+				"debug": "^2.1.1",
+				"doctrine": "^2.0.0",
+				"escope": "^3.6.0",
+				"espree": "^3.4.0",
+				"esquery": "^1.0.0",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"file-entry-cache": "^2.0.0",
+				"glob": "^7.0.3",
+				"globals": "^9.14.0",
+				"ignore": "^3.2.0",
+				"imurmurhash": "^0.1.4",
+				"inquirer": "^0.12.0",
+				"is-my-json-valid": "^2.10.0",
+				"is-resolvable": "^1.0.0",
+				"js-yaml": "^3.5.1",
+				"json-stable-stringify": "^1.0.0",
+				"levn": "^0.3.0",
+				"lodash": "^4.0.0",
+				"mkdirp": "^0.5.0",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.8.2",
+				"path-is-inside": "^1.0.1",
+				"pluralize": "^1.2.1",
+				"progress": "^1.1.8",
+				"require-uncached": "^1.0.2",
+				"shelljs": "^0.7.5",
+				"strip-bom": "^3.0.0",
+				"strip-json-comments": "~2.0.1",
+				"table": "^3.7.8",
+				"text-table": "~0.2.0",
+				"user-home": "^2.0.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "4.11.8",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+					"requires": {
+						"co": "^4.6.0",
+						"json-stable-stringify": "^1.0.1"
+					}
+				},
+				"ajv-keywords": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+					"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
+				},
+				"ansi-escapes": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"cli-cursor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+					"requires": {
+						"restore-cursor": "^1.0.1"
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"figures": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+					"requires": {
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
+					}
+				},
+				"inquirer": {
+					"version": "0.12.0",
+					"resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+					"integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+					"requires": {
+						"ansi-escapes": "^1.1.0",
+						"ansi-regex": "^2.0.0",
+						"chalk": "^1.0.0",
+						"cli-cursor": "^1.0.1",
+						"cli-width": "^2.0.0",
+						"figures": "^1.3.5",
+						"lodash": "^4.3.0",
+						"readline2": "^1.0.1",
+						"run-async": "^0.1.0",
+						"rx-lite": "^3.1.2",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.0",
+						"through": "^2.3.6"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"onetime": {
+					"version": "1.1.0",
+					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+				},
+				"restore-cursor": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+					"requires": {
+						"exit-hook": "^1.0.0",
+						"onetime": "^1.0.0"
+					}
+				},
+				"run-async": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+					"integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+					"requires": {
+						"once": "^1.3.0"
+					}
+				},
+				"rx-lite": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+					"integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
+				},
+				"shelljs": {
+					"version": "0.7.8",
+					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+					"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+					"requires": {
+						"glob": "^7.0.0",
+						"interpret": "^1.0.0",
+						"rechoir": "^0.6.2"
+					}
+				},
+				"slice-ansi": {
+					"version": "0.0.4",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+					"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				},
+				"table": {
+					"version": "3.8.3",
+					"resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
+					"integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+					"requires": {
+						"ajv": "^4.7.0",
+						"ajv-keywords": "^1.0.0",
+						"chalk": "^1.1.1",
+						"lodash": "^4.0.0",
+						"slice-ansi": "0.0.4",
+						"string-width": "^2.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+						},
+						"string-width": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+							"requires": {
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^4.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				}
+			}
+		},
+		"eslint-import-resolver-node": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+			"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+			"requires": {
+				"debug": "^2.6.9",
+				"resolve": "^1.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"eslint-module-utils": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
+			"integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
+			"requires": {
+				"debug": "^2.6.8",
+				"pkg-dir": "^1.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"requires": {
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"requires": {
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"pkg-dir": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+					"requires": {
+						"find-up": "^1.0.0"
+					}
+				}
+			}
+		},
+		"eslint-plugin-github": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-0.12.0.tgz",
+			"integrity": "sha1-qWFCtlz2XBPAlyC+Uwjke1Z9O78="
+		},
+		"eslint-plugin-import": {
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
+			"integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+			"requires": {
+				"contains-path": "^0.1.0",
+				"debug": "^2.6.8",
+				"doctrine": "1.5.0",
+				"eslint-import-resolver-node": "^0.3.1",
+				"eslint-module-utils": "^2.2.0",
+				"has": "^1.0.1",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.3",
+				"read-pkg-up": "^2.0.0",
+				"resolve": "^1.6.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"doctrine": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"requires": {
+						"esutils": "^2.0.2",
+						"isarray": "^1.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"requires": {
+						"find-up": "^2.0.0",
+						"read-pkg": "^2.0.0"
+					}
+				},
+				"resolve": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+					"requires": {
+						"path-parse": "^1.0.5"
+					}
+				}
+			}
+		},
+		"eslint-rule-documentation": {
+			"version": "1.0.21",
+			"resolved": "https://registry.npmjs.org/eslint-rule-documentation/-/eslint-rule-documentation-1.0.21.tgz",
+			"integrity": "sha512-XW/SKOQnvyg6SJQ7BcM4R5vJ6N5ivA6Jqbh4GPPjBwee4Jj1Bne9R1JM5duMObtNiYfeQt/yYIAsHCDttFbTsA=="
+		},
 		"espower-location-detector": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/espower-location-detector/-/espower-location-detector-1.0.0.tgz",
 			"integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
-			"dev": true,
 			"requires": {
 				"is-url": "^1.2.1",
 				"path-is-absolute": "^1.0.0",
@@ -6128,31 +6010,44 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
+			}
+		},
+		"espree": {
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+			"requires": {
+				"acorn": "^5.5.0",
+				"acorn-jsx": "^3.0.0"
 			}
 		},
 		"esprima": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-			"dev": true
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
 		},
 		"espurify": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.0.tgz",
 			"integrity": "sha512-jdkJG9jswjKCCDmEridNUuIQei9algr+o66ZZ19610ZoBsiWLRsQGNYS4HGez3Z/DsR0lhANGAqiwBUclPuNag==",
-			"dev": true,
 			"requires": {
 				"core-js": "^2.0.0"
+			}
+		},
+		"esquery": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+			"requires": {
+				"estraverse": "^4.0.0"
 			}
 		},
 		"esrecurse": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-			"dev": true,
 			"requires": {
 				"estraverse": "^4.1.0"
 			}
@@ -6160,26 +6055,22 @@
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-			"dev": true
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-			"dev": true
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
 		"etag": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-			"dev": true
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
 		},
 		"event-emitter": {
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
 			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-			"dev": true,
 			"requires": {
 				"d": "1",
 				"es5-ext": "~0.10.14"
@@ -6189,7 +6080,6 @@
 			"version": "3.3.4",
 			"resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
 			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-			"dev": true,
 			"requires": {
 				"duplexer": "~0.1.1",
 				"from": "~0",
@@ -6204,7 +6094,6 @@
 					"version": "0.3.3",
 					"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
 					"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-					"dev": true,
 					"requires": {
 						"through": "2"
 					}
@@ -6213,7 +6102,6 @@
 					"version": "0.0.4",
 					"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
 					"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-					"dev": true,
 					"requires": {
 						"duplexer": "~0.1.1"
 					}
@@ -6223,14 +6111,12 @@
 		"events": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-2.0.0.tgz",
-			"integrity": "sha512-r/M5YkNg9zwI8QbSf7tsDWWJvO3PGwZXyG7GpFAxtMASnHL2eblFd7iHiGPtyGKKFPZ59S63NeX10Ws6WqGDcg==",
-			"dev": true
+			"integrity": "sha512-r/M5YkNg9zwI8QbSf7tsDWWJvO3PGwZXyG7GpFAxtMASnHL2eblFd7iHiGPtyGKKFPZ59S63NeX10Ws6WqGDcg=="
 		},
 		"eventsource": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
 			"integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
-			"dev": true,
 			"requires": {
 				"original": ">=0.0.5"
 			}
@@ -6239,7 +6125,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-			"dev": true,
 			"requires": {
 				"md5.js": "^1.3.4",
 				"safe-buffer": "^5.1.1"
@@ -6249,7 +6134,6 @@
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
 			"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-			"dev": true,
 			"requires": {
 				"cross-spawn": "^6.0.0",
 				"get-stream": "^3.0.0",
@@ -6264,7 +6148,6 @@
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
 						"path-key": "^2.0.1",
@@ -6279,7 +6162,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
 			"integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
-			"dev": true,
 			"requires": {
 				"clone-regexp": "^1.0.0"
 			}
@@ -6287,20 +6169,17 @@
 		"exenv": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-			"integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=",
-			"dev": true
+			"integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
 		},
 		"exit-hook": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-			"dev": true
+			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
 		},
 		"expand-brackets": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-			"dev": true,
 			"requires": {
 				"debug": "^2.3.3",
 				"define-property": "^0.2.5",
@@ -6315,7 +6194,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -6324,7 +6202,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -6333,7 +6210,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -6344,7 +6220,6 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"dev": true,
 			"requires": {
 				"fill-range": "^2.1.0"
 			},
@@ -6353,7 +6228,6 @@
 					"version": "2.2.4",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
 					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-					"dev": true,
 					"requires": {
 						"is-number": "^2.1.0",
 						"isobject": "^2.0.0",
@@ -6366,7 +6240,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -6375,7 +6248,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-					"dev": true,
 					"requires": {
 						"isarray": "1.0.0"
 					}
@@ -6386,7 +6258,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
 			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-			"dev": true,
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
 			}
@@ -6395,7 +6266,6 @@
 			"version": "4.16.3",
 			"resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
 			"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
-			"dev": true,
 			"requires": {
 				"accepts": "~1.3.5",
 				"array-flatten": "1.1.1",
@@ -6433,7 +6303,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -6441,14 +6310,12 @@
 				"qs": {
 					"version": "6.5.1",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-					"dev": true
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-					"dev": true
+					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
 				}
 			}
 		},
@@ -6461,7 +6328,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-			"dev": true,
 			"requires": {
 				"assign-symbols": "^1.0.0",
 				"is-extendable": "^1.0.1"
@@ -6471,7 +6337,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -6482,7 +6347,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-			"dev": true,
 			"requires": {
 				"chardet": "^0.4.0",
 				"iconv-lite": "^0.4.17",
@@ -6493,7 +6357,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-			"dev": true,
 			"requires": {
 				"array-unique": "^0.3.2",
 				"define-property": "^1.0.0",
@@ -6509,7 +6372,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -6518,7 +6380,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -6527,7 +6388,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -6536,7 +6396,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -6545,7 +6404,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -6555,34 +6413,29 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fast-deep-equal": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-			"dev": true
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
 		},
 		"fast-diff": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-			"integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
-			"dev": true
+			"integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
 		},
 		"fast-glob": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.1.tgz",
 			"integrity": "sha512-wSyW1TBK3ia5V+te0rGPXudeMHoUQW6O5Y9oATiaGhpENmEifPDlOdhpsnlj5HoG6ttIvGiY1DdCmI9X2xGMhg==",
-			"dev": true,
 			"requires": {
 				"@mrmlnc/readdir-enhanced": "^2.2.1",
 				"glob-parent": "^3.1.0",
@@ -6595,7 +6448,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.1"
 					}
@@ -6603,14 +6455,12 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				},
 				"micromatch": {
 					"version": "3.1.10",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -6632,26 +6482,27 @@
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-			"dev": true
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
 		"fast-memoize": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.3.2.tgz",
-			"integrity": "sha512-h2avnhux4p3tXTA9xR7ntnQSFQdY4hAkyNj8wDXlVT2Die38JxVCInnrieuktdxzRevRWa3dBjN+SbQe1os0GQ==",
-			"dev": true
+			"integrity": "sha512-h2avnhux4p3tXTA9xR7ntnQSFQdY4hAkyNj8wDXlVT2Die38JxVCInnrieuktdxzRevRWa3dBjN+SbQe1os0GQ=="
 		},
 		"fastparse": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
-			"integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
-			"dev": true
+			"integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
 		},
 		"faye-websocket": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
 			"integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
-			"dev": true,
 			"requires": {
 				"websocket-driver": ">=0.5.1"
 			}
@@ -6660,7 +6511,6 @@
 			"version": "0.8.16",
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
 			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
-			"dev": true,
 			"requires": {
 				"core-js": "^1.0.0",
 				"isomorphic-fetch": "^2.1.1",
@@ -6674,8 +6524,7 @@
 				"core-js": {
 					"version": "1.2.7",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-					"dev": true
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
 				}
 			}
 		},
@@ -6683,7 +6532,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
 			}
@@ -6692,7 +6540,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-			"dev": true,
 			"requires": {
 				"flat-cache": "^1.2.1",
 				"object-assign": "^4.0.1"
@@ -6702,7 +6549,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
 			"integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
-			"dev": true,
 			"requires": {
 				"loader-utils": "^1.0.2",
 				"schema-utils": "^0.4.5"
@@ -6711,20 +6557,17 @@
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-			"dev": true
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
 		},
 		"filename-reserved-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
-			"integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
-			"dev": true
+			"integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q="
 		},
 		"filenamify": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
 			"integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
-			"dev": true,
 			"requires": {
 				"filename-reserved-regex": "^1.0.0",
 				"strip-outer": "^1.0.0",
@@ -6735,7 +6578,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-1.0.0.tgz",
 			"integrity": "sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=",
-			"dev": true,
 			"requires": {
 				"filenamify": "^1.0.0",
 				"humanize-url": "^1.0.0"
@@ -6744,14 +6586,12 @@
 		"filesize": {
 			"version": "3.5.11",
 			"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.11.tgz",
-			"integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g==",
-			"dev": true
+			"integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g=="
 		},
 		"fill-range": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-number": "^3.0.0",
@@ -6763,7 +6603,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -6773,14 +6612,12 @@
 		"filter-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-			"integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
-			"dev": true
+			"integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
 		},
 		"finalhandler": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
 			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
-			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
 				"encodeurl": "~1.0.2",
@@ -6795,7 +6632,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -6806,7 +6642,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
 			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-			"dev": true,
 			"requires": {
 				"commondir": "^1.0.1",
 				"make-dir": "^1.0.0",
@@ -6817,7 +6652,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-			"dev": true,
 			"requires": {
 				"locate-path": "^2.0.0"
 			}
@@ -6826,7 +6660,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-2.0.0.tgz",
 			"integrity": "sha1-KtkNSQ9oKMGqQCks9wmsMxghDDw=",
-			"dev": true,
 			"requires": {
 				"array-uniq": "^1.0.0",
 				"semver-regex": "^1.0.0"
@@ -6836,7 +6669,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
 			"integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "^2.0.2"
 			}
@@ -6845,7 +6677,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
-			"dev": true,
 			"requires": {
 				"circular-json": "^0.3.1",
 				"del": "^2.0.2",
@@ -6856,8 +6687,7 @@
 		"flatten": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
-			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
-			"dev": true
+			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
 		},
 		"flush-write-stream": {
 			"version": "1.0.3",
@@ -6871,20 +6701,25 @@
 		"fn-name": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-			"integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
-			"dev": true
+			"integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc="
+		},
+		"for-each": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+			"requires": {
+				"is-callable": "^1.1.3"
+			}
 		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-			"dev": true
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"dev": true,
 			"requires": {
 				"for-in": "^1.0.1"
 			}
@@ -6892,14 +6727,12 @@
 		"foreach": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-			"dev": true
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
 		},
 		"foreachasync": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
-			"integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY=",
-			"dev": true
+			"integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY="
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -6910,7 +6743,6 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "1.0.6",
@@ -6920,14 +6752,12 @@
 		"forwarded": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-			"dev": true
+			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-			"dev": true,
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
@@ -6935,14 +6765,12 @@
 		"fresh": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-			"dev": true
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
 		"from": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-			"dev": true
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
 		},
 		"from2": {
 			"version": "2.3.0",
@@ -6957,7 +6785,6 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
 			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"jsonfile": "^4.0.0",
@@ -6984,7 +6811,6 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
 			"integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"nan": "^2.9.2",
@@ -6995,27 +6821,23 @@
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
 					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"aproba": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
 					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
 					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"delegates": "^1.0.0",
@@ -7025,14 +6847,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-					"dev": true
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -7042,39 +6862,33 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
 					"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-					"dev": true
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-					"dev": true
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-					"dev": true
+					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 				},
 				"core-util-is": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-					"dev": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -7084,28 +6898,24 @@
 					"version": "0.6.0",
 					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
 					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-					"dev": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
 					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
 					"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -7115,14 +6925,12 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
 					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"aproba": "^1.0.3",
@@ -7139,7 +6947,6 @@
 					"version": "7.1.2",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -7154,14 +6961,12 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.21",
 					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
 					"integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"safer-buffer": "^2.1.0"
@@ -7171,7 +6976,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
 					"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"minimatch": "^3.0.4"
@@ -7181,7 +6985,6 @@
 					"version": "1.0.6",
 					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"once": "^1.3.0",
@@ -7191,14 +6994,12 @@
 				"inherits": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"dev": true
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -7207,14 +7008,12 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -7222,14 +7021,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
 					"integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -7239,7 +7036,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
 					"integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -7249,7 +7045,6 @@
 					"version": "0.5.1",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -7258,14 +7053,12 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
 					"integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "^2.1.2",
@@ -7275,9 +7068,8 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.9.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-8RwHUW3ZL4cZnbx+GDjqt81WyeA=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
@@ -7296,7 +7088,6 @@
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1",
@@ -7307,14 +7098,12 @@
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
 					"integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
-					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.1.10",
 					"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
 					"integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"ignore-walk": "^3.0.1",
@@ -7325,7 +7114,6 @@
 					"version": "4.1.2",
 					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
@@ -7337,21 +7125,18 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-					"dev": true
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 				},
 				"object-assign": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-					"dev": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -7360,21 +7145,18 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "^1.0.0",
@@ -7385,21 +7167,18 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
 					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.8",
 					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 					"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "^0.6.0",
@@ -7412,7 +7191,6 @@
 							"version": "1.2.0",
 							"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-							"dev": true,
 							"optional": true
 						}
 					}
@@ -7421,7 +7199,6 @@
 					"version": "2.3.6",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -7437,7 +7214,6 @@
 					"version": "2.6.2",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"glob": "^7.0.5"
@@ -7446,49 +7222,42 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-					"dev": true
+					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
 					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-					"dev": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
 					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -7499,7 +7268,6 @@
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
@@ -7509,7 +7277,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -7518,7 +7285,6 @@
 					"version": "4.4.1",
 					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
 					"integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"chownr": "^1.0.1",
@@ -7534,14 +7300,12 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
 					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"string-width": "^1.0.2"
@@ -7550,14 +7314,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-					"dev": true
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-					"dev": true
+					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
 				}
 			}
 		},
@@ -7565,7 +7327,6 @@
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
 			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"inherits": "~2.0.0",
@@ -7577,7 +7338,6 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/fullname/-/fullname-3.3.0.tgz",
 			"integrity": "sha1-oIdH1pISKWELgXi3YU/OEMsYX1o=",
-			"dev": true,
 			"requires": {
 				"execa": "^0.6.0",
 				"filter-obj": "^1.1.0",
@@ -7592,7 +7352,6 @@
 					"version": "0.6.3",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.6.3.tgz",
 					"integrity": "sha1-V7aaWU8IF1nGnlNw8NF7nLEWWP4=",
-					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -7608,20 +7367,17 @@
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"function-name-support": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/function-name-support/-/function-name-support-0.2.0.tgz",
-			"integrity": "sha1-VdO/qm6v1QWlD5vIH99XVkoLsHE=",
-			"dev": true
+			"integrity": "sha1-VdO/qm6v1QWlD5vIH99XVkoLsHE="
 		},
 		"function.prototype.name": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
 			"integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"function-bind": "^1.1.1",
@@ -7631,20 +7387,17 @@
 		"fuse.js": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.2.0.tgz",
-			"integrity": "sha1-8ESOgGmFW/Kj5oPNwdMg5+KgfvQ=",
-			"dev": true
+			"integrity": "sha1-8ESOgGmFW/Kj5oPNwdMg5+KgfvQ="
 		},
 		"gather-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gather-stream/-/gather-stream-1.0.0.tgz",
-			"integrity": "sha1-szmUr0V6gRVwDUEPMXczy+egkEs=",
-			"dev": true
+			"integrity": "sha1-szmUr0V6gRVwDUEPMXczy+egkEs="
 		},
 		"gauge": {
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.0.3",
 				"console-control-strings": "^1.0.0",
@@ -7660,7 +7413,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -7669,7 +7421,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -7682,22 +7433,35 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
 			"integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
-			"dev": true,
 			"requires": {
 				"globule": "^1.0.0"
+			}
+		},
+		"generate-function": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+			"integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+			"requires": {
+				"is-property": "^1.0.2"
+			}
+		},
+		"generate-object-property": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+			"requires": {
+				"is-property": "^1.0.0"
 			}
 		},
 		"get-caller-file": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-			"dev": true
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
 		},
 		"get-pkg-repo": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
 			"integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
-			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
 				"meow": "^3.3.0",
@@ -7709,32 +7473,27 @@
 		"get-port": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
-			"dev": true
+			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
 		},
 		"get-stdin": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-			"dev": true
+			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
 		},
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-			"dev": true
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 		},
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-			"dev": true
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			},
@@ -7742,16 +7501,23 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
+			}
+		},
+		"gh-got": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz",
+			"integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
+			"requires": {
+				"got": "^6.2.0",
+				"is-plain-obj": "^1.1.0"
 			}
 		},
 		"gh-pages": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-1.2.0.tgz",
 			"integrity": "sha512-cGLYAvxtlQ1iTwAS4g7FreZPXoE/g62Fsxln2mmR19mgs4zZI+XJ+wVVUhBFCF/0+Nmvbq+abyTWue1m1BSnmg==",
-			"dev": true,
 			"requires": {
 				"async": "2.6.1",
 				"commander": "2.15.1",
@@ -7766,7 +7532,6 @@
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
 					"integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"jsonfile": "^4.0.0",
@@ -7779,7 +7544,6 @@
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
 			"integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
-			"dev": true,
 			"requires": {
 				"dargs": "^4.0.1",
 				"lodash.template": "^4.0.2",
@@ -7792,7 +7556,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -7804,7 +7567,6 @@
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -7820,14 +7582,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -7838,7 +7598,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -7850,7 +7609,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
 			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
-			"dev": true,
 			"requires": {
 				"gitconfiglocal": "^1.0.0",
 				"pify": "^2.3.0"
@@ -7859,8 +7617,7 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
 		},
@@ -7868,7 +7625,6 @@
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.6.tgz",
 			"integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
-			"dev": true,
 			"requires": {
 				"meow": "^4.0.0",
 				"semver": "^5.5.0"
@@ -7878,7 +7634,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -7890,7 +7645,6 @@
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -7906,14 +7660,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -7924,7 +7676,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -7936,16 +7687,22 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
 			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
-			"dev": true,
 			"requires": {
 				"ini": "^1.3.2"
+			}
+		},
+		"github-username": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz",
+			"integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
+			"requires": {
+				"gh-got": "^5.0.0"
 			}
 		},
 		"glamor": {
 			"version": "2.20.40",
 			"resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.40.tgz",
 			"integrity": "sha512-DNXCd+c14N9QF8aAKrfl4xakPk5FdcFwmH7sD0qnC0Pr7xoZ5W9yovhUrY/dJc3psfGGXC58vqQyRtuskyUJxA==",
-			"dev": true,
 			"requires": {
 				"fbjs": "^0.8.12",
 				"inline-style-prefixer": "^3.0.6",
@@ -7958,7 +7715,6 @@
 			"version": "4.13.0",
 			"resolved": "https://registry.npmjs.org/glamorous/-/glamorous-4.13.0.tgz",
 			"integrity": "sha512-lJ+ET2Cz5+ZIsxrFNruN7Ye30PSe+jSN8jbma2+AAmNoJZOozqtjfjB5EVi16J9G3CjjXQtENsv4shwR1YYtaQ==",
-			"dev": true,
 			"requires": {
 				"brcast": "^3.0.0",
 				"csstype": "^2.2.0",
@@ -7987,7 +7743,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"dev": true,
 			"requires": {
 				"glob-parent": "^2.0.0",
 				"is-glob": "^2.0.0"
@@ -7997,7 +7752,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-					"dev": true,
 					"requires": {
 						"is-glob": "^2.0.0"
 					}
@@ -8005,14 +7759,12 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -8023,7 +7775,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-			"dev": true,
 			"requires": {
 				"is-glob": "^3.1.0",
 				"path-dirname": "^1.0.0"
@@ -8032,14 +7783,12 @@
 		"glob-to-regexp": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
-			"dev": true
+			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
 		},
 		"global": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
 			"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-			"dev": true,
 			"requires": {
 				"min-document": "^2.19.0",
 				"process": "~0.5.1"
@@ -8049,7 +7798,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
 			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-			"dev": true,
 			"requires": {
 				"ini": "^1.3.4"
 			}
@@ -8058,7 +7806,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
 			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-			"dev": true,
 			"requires": {
 				"global-prefix": "^1.0.1",
 				"is-windows": "^1.0.1",
@@ -8069,7 +7816,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
 			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-			"dev": true,
 			"requires": {
 				"expand-tilde": "^2.0.2",
 				"homedir-polyfill": "^1.0.1",
@@ -8082,7 +7828,6 @@
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/global-tunnel-ng/-/global-tunnel-ng-2.6.0.tgz",
 			"integrity": "sha512-glWGTgPzsOQs0mPRxHnWIwqYrEuQcxYpUFWF7BJxJL+c2F4fW304vdn53pqgod4PzOqZKDr1cex+a/pXCwrncA==",
-			"dev": true,
 			"requires": {
 				"encodeurl": "^1.0.2",
 				"lodash": "^4.17.10",
@@ -8090,11 +7835,15 @@
 				"tunnel": "^0.0.5"
 			}
 		},
+		"globals": {
+			"version": "9.18.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+		},
 		"globby": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
 			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-			"dev": true,
 			"requires": {
 				"array-union": "^1.0.1",
 				"glob": "^7.0.3",
@@ -8106,22 +7855,19 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
 		},
 		"globjoin": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
-			"integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
-			"dev": true
+			"integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM="
 		},
 		"globule": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
 			"integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
-			"dev": true,
 			"requires": {
 				"glob": "~7.1.1",
 				"lodash": "~4.17.10",
@@ -8132,7 +7878,6 @@
 			"version": "6.7.1",
 			"resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-			"dev": true,
 			"requires": {
 				"create-error-class": "^3.0.0",
 				"duplexer3": "^0.1.4",
@@ -8156,7 +7901,6 @@
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
 			"integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
-			"dev": true,
 			"requires": {
 				"lodash": "^4.17.2"
 			}
@@ -8165,7 +7909,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
 			"integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
-			"dev": true,
 			"requires": {
 				"duplexer": "^0.1.1"
 			}
@@ -8174,7 +7917,6 @@
 			"version": "4.0.12",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
 			"integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
-			"dev": true,
 			"requires": {
 				"async": "^2.5.0",
 				"optimist": "^0.6.1",
@@ -8186,20 +7928,17 @@
 					"version": "2.17.1",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
 					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-					"dev": true,
 					"optional": true
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"uglify-js": {
 					"version": "3.4.9",
 					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
 					"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"commander": "~2.17.1",
@@ -8211,14 +7950,12 @@
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"dev": true
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 		},
 		"har-validator": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-			"dev": true,
 			"requires": {
 				"ajv": "^5.1.0",
 				"har-schema": "^2.0.0"
@@ -8228,7 +7965,6 @@
 					"version": "5.5.2",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-					"dev": true,
 					"requires": {
 						"co": "^4.6.0",
 						"fast-deep-equal": "^1.0.0",
@@ -8239,8 +7975,7 @@
 				"fast-deep-equal": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-					"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-					"dev": true
+					"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
 				}
 			}
 		},
@@ -8248,7 +7983,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.0.2"
 			}
@@ -8257,7 +7991,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -8265,20 +7998,17 @@
 		"has-class-selector": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-class-selector/-/has-class-selector-1.0.0.tgz",
-			"integrity": "sha1-p79Rvs3C133/JQkgPtafNEUODC0=",
-			"dev": true
+			"integrity": "sha1-p79Rvs3C133/JQkgPtafNEUODC0="
 		},
 		"has-color": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-			"dev": true
+			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
 		},
 		"has-element-selector": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-element-selector/-/has-element-selector-1.0.0.tgz",
 			"integrity": "sha1-JohCJeEjQ36N+WBMATWB0p0ZC5c=",
-			"dev": true,
 			"requires": {
 				"css-selector-tokenizer": "^0.5.4"
 			},
@@ -8287,7 +8017,6 @@
 					"version": "0.5.4",
 					"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.5.4.tgz",
 					"integrity": "sha1-E5uv00o1/QwUKEhwSeBpnm9qLCE=",
-					"dev": true,
 					"requires": {
 						"cssesc": "^0.1.0",
 						"fastparse": "^1.1.1"
@@ -8298,20 +8027,17 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-id-selector": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-id-selector/-/has-id-selector-1.0.0.tgz",
-			"integrity": "sha1-1BtC6SKFhub+xWZyjOszqucay0U=",
-			"dev": true
+			"integrity": "sha1-1BtC6SKFhub+xWZyjOszqucay0U="
 		},
 		"has-pseudo-class": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-pseudo-class/-/has-pseudo-class-1.0.1.tgz",
 			"integrity": "sha1-Bj7cjp9ZRpdq9P9OuzLDMNVW4Ac=",
-			"dev": true,
 			"requires": {
 				"pseudo-classes": "0.0.1"
 			}
@@ -8320,7 +8046,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-pseudo-element/-/has-pseudo-element-1.0.0.tgz",
 			"integrity": "sha1-NMoZEgHAFDcJ9CtLc/HcY7dg8D8=",
-			"dev": true,
 			"requires": {
 				"pseudo-elements": "1.0.0"
 			}
@@ -8328,14 +8053,12 @@
 		"has-symbol-support-x": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-			"integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
-			"dev": true
+			"integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
 		},
 		"has-to-string-tag-x": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
 			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
-			"dev": true,
 			"requires": {
 				"has-symbol-support-x": "^1.4.1"
 			}
@@ -8343,14 +8066,12 @@
 		"has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"dev": true
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
 		},
 		"has-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-			"dev": true,
 			"requires": {
 				"get-value": "^2.0.6",
 				"has-values": "^1.0.0",
@@ -8361,7 +8082,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"kind-of": "^4.0.0"
@@ -8371,7 +8091,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -8381,14 +8100,12 @@
 		"has-yarn": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-1.0.0.tgz",
-			"integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
-			"dev": true
+			"integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac="
 		},
 		"hash-base": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
 			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -8398,7 +8115,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
 			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.0"
@@ -8407,20 +8123,17 @@
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-			"dev": true
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
 		},
 		"hex-color-regex": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
-			"integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
-			"dev": true
+			"integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-			"dev": true,
 			"requires": {
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
@@ -8430,20 +8143,17 @@
 		"hoek": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-			"dev": true
+			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
 		},
 		"hoist-non-react-statics": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-			"integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=",
-			"dev": true
+			"integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.1"
@@ -8453,7 +8163,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
 			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-			"dev": true,
 			"requires": {
 				"parse-passwd": "^1.0.0"
 			}
@@ -8461,44 +8170,37 @@
 		"hosted-git-info": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
-			"dev": true
+			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
 		},
 		"hsl-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
-			"integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
-			"dev": true
+			"integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4="
 		},
 		"hsla-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
-			"integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
-			"dev": true
+			"integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg="
 		},
 		"html-comment-regex": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
-			"integrity": "sha1-ZouTd26q5V696POtRkswekljYl4=",
-			"dev": true
+			"integrity": "sha1-ZouTd26q5V696POtRkswekljYl4="
 		},
 		"html-element-attributes": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/html-element-attributes/-/html-element-attributes-1.3.1.tgz",
-			"integrity": "sha512-UrRKgp5sQmRnDy4TEwAUsu14XBUlzKB8U3hjIYDjcZ3Hbp86Jtftzxfgrv6E/ii/h78tsaZwAnAE8HwnHr0dPA==",
-			"dev": true
+			"integrity": "sha512-UrRKgp5sQmRnDy4TEwAUsu14XBUlzKB8U3hjIYDjcZ3Hbp86Jtftzxfgrv6E/ii/h78tsaZwAnAE8HwnHr0dPA=="
 		},
 		"html-entities": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
-			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
-			"dev": true
+			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
 		},
 		"html-loader": {
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/html-loader/-/html-loader-0.5.5.tgz",
 			"integrity": "sha512-7hIW7YinOYUpo//kSYcPB6dCKoceKLmOwjEMmhIobHuWGDVl0Nwe4l68mdG/Ru0wcUxQjVMEoZpkalZ/SE7zog==",
-			"dev": true,
 			"requires": {
 				"es6-templates": "^0.2.3",
 				"fastparse": "^1.1.1",
@@ -8511,7 +8213,6 @@
 			"version": "3.5.15",
 			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.15.tgz",
 			"integrity": "sha512-OZa4rfb6tZOZ3Z8Xf0jKxXkiDcFWldQePGYFDcgKqES2sXeWaEv9y6QQvWUtX3ySI3feApQi5uCsHLINQ6NoAw==",
-			"dev": true,
 			"requires": {
 				"camel-case": "3.0.x",
 				"clean-css": "4.1.x",
@@ -8525,14 +8226,12 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"uglify-js": {
 					"version": "3.3.24",
 					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.24.tgz",
 					"integrity": "sha512-hS7+TDiqIqvWScCcKRybCQzmMnEzJ4ryl9ErRmW4GFyG48p0/dKZiy/5mVLbsFzU8CCnCgQdxMiJzZythvLzCg==",
-					"dev": true,
 					"requires": {
 						"commander": "~2.15.0",
 						"source-map": "~0.6.1"
@@ -8543,20 +8242,17 @@
 		"html-tag-names": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/html-tag-names/-/html-tag-names-1.1.3.tgz",
-			"integrity": "sha512-kY/ck6Q0lGLxGocn86BM8Q4vCTUCY78VN43h0uMGeZ8p9LU3XdSNQR4Rs3JEjrKZSS5iXI1YgzY0g8U1AFDQzA==",
-			"dev": true
+			"integrity": "sha512-kY/ck6Q0lGLxGocn86BM8Q4vCTUCY78VN43h0uMGeZ8p9LU3XdSNQR4Rs3JEjrKZSS5iXI1YgzY0g8U1AFDQzA=="
 		},
 		"html-tags": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
-			"integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=",
-			"dev": true
+			"integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos="
 		},
 		"html-to-react": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.3.3.tgz",
 			"integrity": "sha512-4Qi5/t8oBr6c1t1kBJKyxEeJu0lb7ctvq29oFZioiUHH0Wz88VWGwoXuH26HDt9v64bDHA4NMPNTH8bVrcaJWA==",
-			"dev": true,
 			"requires": {
 				"domhandler": "^2.3.0",
 				"escape-string-regexp": "^1.0.5",
@@ -8569,7 +8265,6 @@
 			"version": "2.30.1",
 			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.30.1.tgz",
 			"integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
-			"dev": true,
 			"requires": {
 				"bluebird": "^3.4.7",
 				"html-minifier": "^3.2.3",
@@ -8583,7 +8278,6 @@
 					"version": "0.2.17",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
 					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-					"dev": true,
 					"requires": {
 						"big.js": "^3.1.3",
 						"emojis-list": "^2.0.0",
@@ -8597,7 +8291,6 @@
 			"version": "3.9.2",
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
 			"integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
-			"dev": true,
 			"requires": {
 				"domelementtype": "^1.3.0",
 				"domhandler": "^2.3.0",
@@ -8610,14 +8303,12 @@
 		"http-cache-semantics": {
 			"version": "3.8.1",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
-			"dev": true
+			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
 		},
 		"http-errors": {
 			"version": "1.6.3",
 			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-			"dev": true,
 			"requires": {
 				"depd": "~1.1.2",
 				"inherits": "2.0.3",
@@ -8628,14 +8319,12 @@
 		"http-parser-js": {
 			"version": "0.4.13",
 			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
-			"integrity": "sha1-O9bW/ebjFyyTNMOzO2wZPYD+ETc=",
-			"dev": true
+			"integrity": "sha1-O9bW/ebjFyyTNMOzO2wZPYD+ETc="
 		},
 		"http-proxy-agent": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
 			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-			"dev": true,
 			"requires": {
 				"agent-base": "4",
 				"debug": "3.1.0"
@@ -8645,7 +8334,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -8655,14 +8343,12 @@
 		"https-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
-			"dev": true
+			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
 		},
 		"https-proxy-agent": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
 			"integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-			"dev": true,
 			"requires": {
 				"agent-base": "^4.1.0",
 				"debug": "^3.1.0"
@@ -8672,7 +8358,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/hullabaloo-config-manager/-/hullabaloo-config-manager-1.1.1.tgz",
 			"integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
-			"dev": true,
 			"requires": {
 				"dot-prop": "^4.1.0",
 				"es6-error": "^4.0.2",
@@ -8694,7 +8379,6 @@
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
 					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-					"dev": true,
 					"requires": {
 						"is-obj": "^1.0.0"
 					}
@@ -8702,8 +8386,7 @@
 				"resolve-from": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-					"dev": true
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
 				}
 			}
 		},
@@ -8711,7 +8394,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
 			"integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
-			"dev": true,
 			"requires": {
 				"ms": "^2.0.0"
 			}
@@ -8720,7 +8402,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/humanize-string/-/humanize-string-1.0.2.tgz",
 			"integrity": "sha512-PH5GBkXqFxw5+4eKaKRIkD23y6vRd/IXSl7IldyJxEXpDH9SEIXRORkBtkGni/ae2P7RVOw6Wxypd2tGXhha1w==",
-			"dev": true,
 			"requires": {
 				"decamelize": "^1.0.0"
 			}
@@ -8729,7 +8410,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz",
 			"integrity": "sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=",
-			"dev": true,
 			"requires": {
 				"normalize-url": "^1.0.0",
 				"strip-url-auth": "^1.0.0"
@@ -8738,14 +8418,12 @@
 		"hyphenate-style-name": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
-			"integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es=",
-			"dev": true
+			"integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
 		},
 		"iconv-lite": {
 			"version": "0.4.23",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
 			"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -8753,14 +8431,12 @@
 		"icss-replace-symbols": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
-			"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
-			"dev": true
+			"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
 		},
 		"icss-utils": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
 			"integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
-			"dev": true,
 			"requires": {
 				"postcss": "^6.0.1"
 			},
@@ -8769,7 +8445,6 @@
 					"version": "6.0.22",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
 					"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
 						"source-map": "^0.6.1",
@@ -8779,16 +8454,14 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"ieee754": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
-			"integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
-			"dev": true
+			"integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg=="
 		},
 		"iferr": {
 			"version": "0.1.5",
@@ -8798,26 +8471,22 @@
 		"ignore": {
 			"version": "3.3.8",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
-			"integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
-			"dev": true
+			"integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg=="
 		},
 		"ignore-by-default": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-			"integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
-			"dev": true
+			"integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk="
 		},
 		"immutable": {
 			"version": "3.8.2",
 			"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-			"integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
-			"dev": true
+			"integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
 		},
 		"import-local": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
 			"integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
-			"dev": true,
 			"requires": {
 				"pkg-dir": "^2.0.0",
 				"resolve-cwd": "^2.0.0"
@@ -8831,26 +8500,22 @@
 		"in-publish": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-			"integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
-			"dev": true
+			"integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
 		},
 		"indent-string": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-			"dev": true
+			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
 		},
 		"indexes-of": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
-			"dev": true
+			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
 		},
 		"indexof": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
-			"dev": true
+			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -8869,14 +8534,12 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"dev": true
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inline-style-prefixer": {
 			"version": "3.0.8",
 			"resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
 			"integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
-			"dev": true,
 			"requires": {
 				"bowser": "^1.7.3",
 				"css-in-js-utils": "^2.0.0"
@@ -8886,7 +8549,6 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.0",
@@ -8907,14 +8569,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -8925,7 +8585,6 @@
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/insight/-/insight-0.10.1.tgz",
 			"integrity": "sha512-kLGeYQkh18f8KuC68QKdi0iwUcIaayJVB/STpX7x452/7pAUm1yfG4giJwcxbrTh0zNYtc8kBR+6maLMOzglOQ==",
-			"dev": true,
 			"requires": {
 				"async": "^2.1.4",
 				"chalk": "^2.3.0",
@@ -8941,14 +8600,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"inquirer": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
 					"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
-					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.0.0",
 						"chalk": "^2.0.0",
@@ -8969,7 +8626,6 @@
 					"version": "5.5.12",
 					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
 					"integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-					"dev": true,
 					"requires": {
 						"symbol-observable": "1.0.1"
 					}
@@ -8978,7 +8634,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -8986,22 +8641,19 @@
 				"symbol-observable": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-					"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-					"dev": true
+					"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
 				}
 			}
 		},
 		"interpret": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
-			"dev": true
+			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
 		},
 		"into-stream": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
 			"integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
-			"dev": true,
 			"requires": {
 				"from2": "^2.1.1",
 				"p-is-promise": "^1.1.0"
@@ -9011,7 +8663,6 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -9019,38 +8670,32 @@
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-			"dev": true
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
 		},
 		"ip": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-			"dev": true
+			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
 		},
 		"ipaddr.js": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
-			"integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs=",
-			"dev": true
+			"integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
 		},
 		"irregular-plurals": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
-			"integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
-			"dev": true
+			"integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
 		},
 		"is-absolute-url": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
-			"integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
-			"dev": true
+			"integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY="
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
@@ -9058,20 +8703,17 @@
 		"is-alphabetical": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz",
-			"integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg==",
-			"dev": true
+			"integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg=="
 		},
 		"is-alphanumeric": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
-			"integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ=",
-			"dev": true
+			"integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ="
 		},
 		"is-alphanumerical": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
 			"integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
-			"dev": true,
 			"requires": {
 				"is-alphabetical": "^1.0.0",
 				"is-decimal": "^1.0.0"
@@ -9080,14 +8722,12 @@
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-			"dev": true
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-			"dev": true,
 			"requires": {
 				"binary-extensions": "^1.0.0"
 			}
@@ -9096,7 +8736,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-blank/-/is-blank-1.1.0.tgz",
 			"integrity": "sha1-knTdvUY2PLdnB1w4XUq4jGpk3Bc=",
-			"dev": true,
 			"requires": {
 				"is-empty": "0.0.1",
 				"is-whitespace": "^0.3.0"
@@ -9105,14 +8744,12 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"dev": true
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"dev": true,
 			"requires": {
 				"builtin-modules": "^1.0.0"
 			}
@@ -9120,14 +8757,12 @@
 		"is-callable": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
-			"dev": true
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
 		},
 		"is-ci": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
 			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
-			"dev": true,
 			"requires": {
 				"ci-info": "^1.0.0"
 			}
@@ -9136,7 +8771,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-css-shorthand/-/is-css-shorthand-1.0.1.tgz",
 			"integrity": "sha1-MPldAyEGBf7f3RKOU9rEpEN6kzw=",
-			"dev": true,
 			"requires": {
 				"css-shorthand-properties": "^1.0.0"
 			}
@@ -9145,7 +8779,6 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
@@ -9153,20 +8786,17 @@
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-			"dev": true
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
 		},
 		"is-decimal": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
-			"integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg==",
-			"dev": true
+			"integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg=="
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-			"dev": true,
 			"requires": {
 				"is-accessor-descriptor": "^0.1.6",
 				"is-data-descriptor": "^0.1.4",
@@ -9176,46 +8806,39 @@
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-					"dev": true
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				}
 			}
 		},
 		"is-directory": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-			"dev": true
+			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
 		},
 		"is-docker": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-1.1.0.tgz",
-			"integrity": "sha1-8EN01O7lMQ6ajhE78UlUEeRhdqE=",
-			"dev": true
+			"integrity": "sha1-8EN01O7lMQ6ajhE78UlUEeRhdqE="
 		},
 		"is-dom": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/is-dom/-/is-dom-1.0.9.tgz",
-			"integrity": "sha1-SDgy1SlyBz3hK5/j9gMghw2oNw0=",
-			"dev": true
+			"integrity": "sha1-SDgy1SlyBz3hK5/j9gMghw2oNw0="
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-			"dev": true
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
 		},
 		"is-empty": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/is-empty/-/is-empty-0.0.1.tgz",
-			"integrity": "sha1-Cf3D1kndpZaRVsCFOpt2vXgcWjM=",
-			"dev": true
+			"integrity": "sha1-Cf3D1kndpZaRVsCFOpt2vXgcWjM="
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"dev": true,
 			"requires": {
 				"is-primitive": "^2.0.0"
 			}
@@ -9223,26 +8846,22 @@
 		"is-error": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.1.tgz",
-			"integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw=",
-			"dev": true
+			"integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw="
 		},
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-			"dev": true
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-			"dev": true
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -9250,26 +8869,22 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 		},
 		"is-function": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
-			"dev": true
+			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
 		},
 		"is-generator-fn": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
-			"dev": true
+			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go="
 		},
 		"is-glob": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-			"dev": true,
 			"requires": {
 				"is-extglob": "^2.1.0"
 			}
@@ -9277,30 +8892,43 @@
 		"is-hexadecimal": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
-			"integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A==",
-			"dev": true
+			"integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A=="
 		},
 		"is-installed-globally": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
 			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-			"dev": true,
 			"requires": {
 				"global-dirs": "^0.1.0",
 				"is-path-inside": "^1.0.0"
 			}
 		},
+		"is-my-ip-valid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+			"integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
+		},
+		"is-my-json-valid": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
+			"integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
+			"requires": {
+				"generate-function": "^2.0.0",
+				"generate-object-property": "^1.1.0",
+				"is-my-ip-valid": "^1.0.0",
+				"jsonpointer": "^4.0.0",
+				"xtend": "^4.0.0"
+			}
+		},
 		"is-npm": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
-			"dev": true
+			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
 		},
 		"is-number": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
@@ -9308,20 +8936,17 @@
 		"is-obj": {
 			"version": "1.0.1",
 			"resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-			"dev": true
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
 		},
 		"is-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-			"dev": true
+			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
 		},
 		"is-observable": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
 			"integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
-			"dev": true,
 			"requires": {
 				"symbol-observable": "^0.2.2"
 			},
@@ -9329,8 +8954,7 @@
 				"symbol-observable": {
 					"version": "0.2.4",
 					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
-					"integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
-					"dev": true
+					"integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A="
 				}
 			}
 		},
@@ -9338,7 +8962,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
 			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-			"dev": true,
 			"requires": {
 				"is-number": "^4.0.0"
 			},
@@ -9346,22 +8969,19 @@
 				"is-number": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-					"dev": true
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
 				}
 			}
 		},
 		"is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-			"dev": true
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
 		},
 		"is-path-in-cwd": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
 			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-			"dev": true,
 			"requires": {
 				"is-path-inside": "^1.0.0"
 			}
@@ -9370,7 +8990,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-			"dev": true,
 			"requires": {
 				"path-is-inside": "^1.0.1"
 			}
@@ -9378,14 +8997,12 @@
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-			"dev": true
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			}
@@ -9393,14 +9010,12 @@
 		"is-posix-bracket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-			"dev": true
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
 		},
 		"is-present": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-present/-/is-present-1.0.0.tgz",
 			"integrity": "sha1-Kcm46ObnhqWUwpL8cjmqJL5wuAw=",
-			"dev": true,
 			"requires": {
 				"is-blank": "1.0.0"
 			},
@@ -9409,7 +9024,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-blank/-/is-blank-1.0.0.tgz",
 					"integrity": "sha1-YOOb60H5LDsnrLtQKcsPKfmD7mc=",
-					"dev": true,
 					"requires": {
 						"is-empty": "0.0.1",
 						"is-whitespace": "^0.3.0"
@@ -9420,26 +9034,27 @@
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-			"dev": true
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
 		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-			"dev": true
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+		},
+		"is-property": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
 		},
 		"is-redirect": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-			"dev": true
+			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
 		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-			"dev": true,
 			"requires": {
 				"has": "^1.0.1"
 			}
@@ -9447,26 +9062,27 @@
 		"is-regexp": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
-			"dev": true
+			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
+		},
+		"is-resolvable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
 		},
 		"is-retry-allowed": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-			"dev": true
+			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
 		},
 		"is-root": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz",
-			"integrity": "sha1-B7bCM7w5TNnQK6FclmvWZg1jQtU=",
-			"dev": true
+			"integrity": "sha1-B7bCM7w5TNnQK6FclmvWZg1jQtU="
 		},
 		"is-scoped": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
 			"integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
-			"dev": true,
 			"requires": {
 				"scoped-regex": "^1.0.0"
 			}
@@ -9474,32 +9090,27 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-string": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-			"integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
-			"dev": true
+			"integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ="
 		},
 		"is-subset": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
-			"dev": true
+			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY="
 		},
 		"is-supported-regexp-flag": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
-			"integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
-			"dev": true
+			"integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ=="
 		},
 		"is-svg": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
 			"integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
-			"dev": true,
 			"requires": {
 				"html-comment-regex": "^1.1.0"
 			}
@@ -9507,14 +9118,12 @@
 		"is-symbol": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-			"dev": true
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
 		},
 		"is-text-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
 			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
-			"dev": true,
 			"requires": {
 				"text-extensions": "^1.0.0"
 			}
@@ -9527,20 +9136,17 @@
 		"is-url": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-			"integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-			"dev": true
+			"integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
 		},
 		"is-utf8": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-			"dev": true
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
 		},
 		"is-vendor-prefixed": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/is-vendor-prefixed/-/is-vendor-prefixed-0.0.1.tgz",
 			"integrity": "sha1-Bc8NhTxidNf7K/htU+EHgguca0Q=",
-			"dev": true,
 			"requires": {
 				"vendor-prefixes": "0.0.1"
 			}
@@ -9548,55 +9154,55 @@
 		"is-whitespace": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz",
-			"integrity": "sha1-Fjnssb4DauxppUy7QBz77XEUq38=",
-			"dev": true
+			"integrity": "sha1-Fjnssb4DauxppUy7QBz77XEUq38="
 		},
 		"is-whitespace-character": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz",
-			"integrity": "sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ==",
-			"dev": true
+			"integrity": "sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ=="
 		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-			"dev": true
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
 		},
 		"is-word-character": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.2.tgz",
-			"integrity": "sha512-T3FlsX8rCHAH8e7RE7PfOPZVFQlcV3XRF9eOOBQ1uf70OxO7CjjSOjeImMPCADBdYWcStAbVbYvJ1m2D3tb+EA==",
-			"dev": true
+			"integrity": "sha512-T3FlsX8rCHAH8e7RE7PfOPZVFQlcV3XRF9eOOBQ1uf70OxO7CjjSOjeImMPCADBdYWcStAbVbYvJ1m2D3tb+EA=="
 		},
 		"is-wsl": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-			"dev": true
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
+		"isbinaryfile": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
+			"integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
+			"requires": {
+				"buffer-alloc": "^1.2.0"
+			}
+		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-			"dev": true
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 		},
 		"isomorphic-fetch": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-			"dev": true,
 			"requires": {
 				"node-fetch": "^1.0.1",
 				"whatwg-fetch": ">=0.10.0"
@@ -9607,11 +9213,20 @@
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
+		"istextorbinary": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",
+			"integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
+			"requires": {
+				"binaryextensions": "2",
+				"editions": "^1.3.3",
+				"textextensions": "2"
+			}
+		},
 		"isurl": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
 			"integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
-			"dev": true,
 			"requires": {
 				"has-to-string-tag-x": "^1.2.0",
 				"is-object": "^1.0.1"
@@ -9620,26 +9235,22 @@
 		"js-base64": {
 			"version": "2.4.3",
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-			"integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw==",
-			"dev": true
+			"integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
 		},
 		"js-string-escape": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-			"integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
-			"dev": true
+			"integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
 		},
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-			"dev": true
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 		},
 		"js-yaml": {
 			"version": "3.11.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
 			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
-			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -9649,44 +9260,45 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true,
 			"optional": true
 		},
 		"jsesc": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-			"dev": true
+			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 		},
 		"json-buffer": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
-			"dev": true
+			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
 		},
 		"json-loader": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-			"integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
-			"dev": true
+			"integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-			"dev": true
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
 		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-			"dev": true
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-			"dev": true
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"requires": {
+				"jsonify": "~0.0.0"
+			}
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
@@ -9696,20 +9308,17 @@
 		"json3": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-			"dev": true
+			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
 		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-			"dev": true
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
 		},
 		"jsonfile": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -9718,7 +9327,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/jsonfilter/-/jsonfilter-1.1.2.tgz",
 			"integrity": "sha1-Ie987cdRk4E8dZMulqmL4gW6WhE=",
-			"dev": true,
 			"requires": {
 				"JSONStream": "^0.8.4",
 				"minimist": "^1.1.0",
@@ -9730,7 +9338,6 @@
 					"version": "0.8.4",
 					"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
 					"integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
-					"dev": true,
 					"requires": {
 						"jsonparse": "0.0.5",
 						"through": ">=2.2.7 <3"
@@ -9739,26 +9346,22 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"jsonparse": {
 					"version": "0.0.5",
 					"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
-					"integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=",
-					"dev": true
+					"integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ="
 				},
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"readable-stream": {
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -9769,14 +9372,12 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				},
 				"through2": {
 					"version": "0.6.5",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
 					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-					"dev": true,
 					"requires": {
 						"readable-stream": ">=1.0.33-1 <1.1.0-0",
 						"xtend": ">=4.0.0 <4.1.0-0"
@@ -9787,20 +9388,22 @@
 		"jsonify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-			"dev": true
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
 		"jsonparse": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-			"dev": true
+			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+		},
+		"jsonpointer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
 		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -9811,22 +9414,24 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
 			}
+		},
+		"just-extend": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
+			"integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ=="
 		},
 		"keycode": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
-			"integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ=",
-			"dev": true
+			"integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
 		},
 		"keyv": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
 			"integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
-			"dev": true,
 			"requires": {
 				"json-buffer": "3.0.0"
 			}
@@ -9835,7 +9440,6 @@
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-			"dev": true,
 			"requires": {
 				"is-buffer": "^1.1.5"
 			}
@@ -9844,7 +9448,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/last-line-stream/-/last-line-stream-1.0.0.tgz",
 			"integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
-			"dev": true,
 			"requires": {
 				"through2": "^2.0.0"
 			}
@@ -9853,7 +9456,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
 			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-			"dev": true,
 			"requires": {
 				"package-json": "^4.0.0"
 			}
@@ -9861,14 +9463,12 @@
 		"lazy-cache": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-			"dev": true
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
 		},
 		"lcid": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-			"dev": true,
 			"requires": {
 				"invert-kv": "^1.0.0"
 			}
@@ -9877,7 +9477,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ldjson-stream/-/ldjson-stream-1.2.1.tgz",
 			"integrity": "sha1-kb7O2lrE7SsX5kn7d356v6AYnCs=",
-			"dev": true,
 			"requires": {
 				"split2": "^0.2.1",
 				"through2": "^0.6.1"
@@ -9886,14 +9485,12 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"readable-stream": {
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -9905,7 +9502,6 @@
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/split2/-/split2-0.2.1.tgz",
 					"integrity": "sha1-At2smtwD7Au3jBKC7Aecpuha6QA=",
-					"dev": true,
 					"requires": {
 						"through2": "~0.6.1"
 					}
@@ -9913,14 +9509,12 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				},
 				"through2": {
 					"version": "0.6.5",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
 					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-					"dev": true,
 					"requires": {
 						"readable-stream": ">=1.0.33-1 <1.1.0-0",
 						"xtend": ">=4.0.0 <4.1.0-0"
@@ -9932,7 +9526,6 @@
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/lerna/-/lerna-2.11.0.tgz",
 			"integrity": "sha512-kgM6zwe2P2tR30MYvgiLLW+9buFCm6E7o8HnRlhTgm70WVBvXVhydqv+q/MF2HrVZkCawfVtCfetyQmtd4oHhQ==",
-			"dev": true,
 			"requires": {
 				"async": "^1.5.0",
 				"chalk": "^2.1.0",
@@ -9978,14 +9571,12 @@
 				"async": {
 					"version": "1.5.2",
 					"resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-					"dev": true
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				},
 				"execa": {
 					"version": "0.8.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
 					"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
-					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -10000,7 +9591,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -10012,7 +9602,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -10023,7 +9612,6 @@
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
 					"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
-					"dev": true,
 					"requires": {
 						"detect-indent": "^5.0.0",
 						"graceful-fs": "^4.1.2",
@@ -10039,7 +9627,6 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/lerna-changelog/-/lerna-changelog-0.7.0.tgz",
 			"integrity": "sha512-ALEBSyDaXnaCnxBk/8/0nnfxMU0l31OgHfd3s6vdHGQUE4v/0PY2zLD3DO70PXoSVaZpSmWq7z5R0ai6ae9jTg==",
-			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3",
 				"execa": "^0.6.3",
@@ -10055,20 +9642,17 @@
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 				},
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-					"dev": true
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -10081,7 +9665,6 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1",
@@ -10092,7 +9675,6 @@
 					"version": "0.6.3",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.6.3.tgz",
 					"integrity": "sha1-V7aaWU8IF1nGnlNw8NF7nLEWWP4=",
-					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -10107,7 +9689,6 @@
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
 					"integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"jsonfile": "^2.1.0"
@@ -10117,7 +9698,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -10126,7 +9706,6 @@
 					"version": "2.4.0",
 					"resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
 					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.6"
 					}
@@ -10135,7 +9714,6 @@
 					"version": "1.4.0",
 					"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"dev": true,
 					"requires": {
 						"lcid": "^1.0.0"
 					}
@@ -10144,7 +9722,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -10154,20 +9731,17 @@
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				},
 				"which-module": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-					"dev": true
+					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
 				},
 				"yargs": {
 					"version": "6.6.0",
 					"resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
 					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^3.0.0",
 						"cliui": "^3.2.0",
@@ -10188,24 +9762,41 @@
 					"version": "4.2.1",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
 					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^3.0.0"
 					}
 				}
 			}
 		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"requires": {
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
+			}
+		},
+		"load-json-file": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
+			}
+		},
 		"loader-runner": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
-			"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=",
-			"dev": true
+			"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI="
 		},
 		"loader-utils": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-			"dev": true,
 			"requires": {
 				"big.js": "^3.1.3",
 				"emojis-list": "^2.0.0",
@@ -10216,7 +9807,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-			"dev": true,
 			"requires": {
 				"p-locate": "^2.0.0",
 				"path-exists": "^3.0.0"
@@ -10225,110 +9815,97 @@
 		"locutus": {
 			"version": "2.0.10",
 			"resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.10.tgz",
-			"integrity": "sha512-AZg2kCqrquMJ5FehDsBidV0qHl98NrsYtseUClzjAQ3HFnsDBJTCwGVplSQ82t9/QfgahqvTjaKcZqZkHmS0wQ==",
-			"dev": true
+			"integrity": "sha512-AZg2kCqrquMJ5FehDsBidV0qHl98NrsYtseUClzjAQ3HFnsDBJTCwGVplSQ82t9/QfgahqvTjaKcZqZkHmS0wQ=="
 		},
 		"lodash": {
 			"version": "4.17.10",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-			"dev": true
+			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
 		},
 		"lodash-es": {
 			"version": "4.17.10",
 			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
-			"integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg==",
-			"dev": true
+			"integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg=="
 		},
 		"lodash._getnative": {
 			"version": "3.9.1",
 			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-			"dev": true
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
 		},
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-			"dev": true
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
 		},
 		"lodash.assign": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-			"dev": true
+			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
 		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-			"dev": true
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
 		},
 		"lodash.clonedeep": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-			"dev": true
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
 		},
 		"lodash.clonedeepwith": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
-			"integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ=",
-			"dev": true
+			"integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ="
 		},
 		"lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-			"dev": true
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
 		},
 		"lodash.difference": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-			"dev": true
+			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
 		},
 		"lodash.flatten": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-			"dev": true
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
 		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
-			"dev": true
+			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
+		},
+		"lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
 		},
 		"lodash.isarguments": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-			"dev": true
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
 		},
 		"lodash.isarray": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-			"dev": true
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
 		},
 		"lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-			"dev": true
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-			"dev": true
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
 		},
 		"lodash.keys": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
 			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-			"dev": true,
 			"requires": {
 				"lodash._getnative": "^3.0.0",
 				"lodash.isarguments": "^3.0.0",
@@ -10338,68 +9915,57 @@
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-			"dev": true
+			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
 		},
 		"lodash.merge": {
 			"version": "4.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
-			"dev": true
+			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
 		},
 		"lodash.mergewith": {
 			"version": "4.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
-			"dev": true
+			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
 		},
 		"lodash.pad": {
 			"version": "4.5.1",
 			"resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
-			"integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
-			"dev": true
+			"integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA="
 		},
 		"lodash.padend": {
 			"version": "4.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-			"integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
-			"dev": true
+			"integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
 		},
 		"lodash.padstart": {
 			"version": "4.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-			"integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
-			"dev": true
+			"integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
 		},
 		"lodash.pick": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-			"integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
-			"dev": true
+			"integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
 		},
 		"lodash.some": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-			"integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
-			"dev": true
+			"integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-			"dev": true
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
 		},
 		"lodash.tail": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
-			"integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
-			"dev": true
+			"integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ="
 		},
 		"lodash.template": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
 			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "~3.0.0",
 				"lodash.templatesettings": "^4.0.0"
@@ -10409,7 +9975,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
 			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "~3.0.0"
 			}
@@ -10417,41 +9982,40 @@
 		"lodash.throttle": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
-			"dev": true
+			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
 		},
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
-			"dev": true
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
 		},
 		"log-symbols": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1"
 			}
 		},
+		"lolex": {
+			"version": "2.7.5",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+			"integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q=="
+		},
 		"longest": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-			"dev": true
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
 		},
 		"longest-streak": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.2.tgz",
-			"integrity": "sha512-TmYTeEYxiAmSVdpbnQDXGtvYOIRsCMg89CVZzwzc2o7GFL1CjoiRPjH5ec0NFAVlAx3fVof9dX/t6KKRAo2OWA==",
-			"dev": true
+			"integrity": "sha512-TmYTeEYxiAmSVdpbnQDXGtvYOIRsCMg89CVZzwzc2o7GFL1CjoiRPjH5ec0NFAVlAx3fVof9dX/t6KKRAo2OWA=="
 		},
 		"loose-envify": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0"
 			}
@@ -10460,7 +10024,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-			"dev": true,
 			"requires": {
 				"currently-unhandled": "^0.4.1",
 				"signal-exit": "^3.0.0"
@@ -10469,20 +10032,17 @@
 		"lower-case": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
-			"dev": true
+			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
 		},
 		"lowercase-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-			"dev": true
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
 		},
 		"lru-cache": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-			"dev": true,
 			"requires": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
@@ -10491,20 +10051,17 @@
 		"macaddress": {
 			"version": "0.2.9",
 			"resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.9.tgz",
-			"integrity": "sha512-k4F1JUof6cQXxNFzx3thLby4oJzXTXQueAOOts944Vqizn+Rjc2QNFenT9FJSLU1CH3PmrHRSyZs2E+Cqw+P2w==",
-			"dev": true
+			"integrity": "sha512-k4F1JUof6cQXxNFzx3thLby4oJzXTXQueAOOts944Vqizn+Rjc2QNFenT9FJSLU1CH3PmrHRSyZs2E+Cqw+P2w=="
 		},
 		"macos-release": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
-			"integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA==",
-			"dev": true
+			"integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA=="
 		},
 		"make-dir": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
 			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-			"dev": true,
 			"requires": {
 				"pify": "^3.0.0"
 			}
@@ -10512,14 +10069,12 @@
 		"make-error": {
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
-			"integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g==",
-			"dev": true
+			"integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g=="
 		},
 		"make-fetch-happen": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.6.0.tgz",
 			"integrity": "sha512-FFq0lNI0ax+n9IWzWpH8A4JdgYiAp2DDYIZ3rsaav8JDe8I+72CzK6PQW/oom15YDZpV5bYW/9INd6nIJ2ZfZw==",
-			"dev": true,
 			"requires": {
 				"agentkeepalive": "^3.3.0",
 				"cacache": "^10.0.0",
@@ -10538,7 +10093,6 @@
 					"version": "1.3.1",
 					"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.1.tgz",
 					"integrity": "sha512-/6rB8YXFbAtsUVRphIRQqB0+9c7VaPHCjVtvto+JqwVxgz8Zz+I+f68/JgQ+Pb4VlZb2svA9OtdXnHHsZz7ltg==",
-					"dev": true,
 					"requires": {
 						"concat-stream": "^1.5.0",
 						"duplexify": "^3.4.2",
@@ -10556,7 +10110,6 @@
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
 					"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -10567,26 +10120,22 @@
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-			"dev": true
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
 		},
 		"map-obj": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-			"dev": true
+			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
 		},
 		"map-stream": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
-			"dev": true
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
 		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-			"dev": true,
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
@@ -10594,14 +10143,12 @@
 		"markdown-escapes": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.2.tgz",
-			"integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA==",
-			"dev": true
+			"integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA=="
 		},
 		"markdown-loader": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/markdown-loader/-/markdown-loader-2.0.2.tgz",
 			"integrity": "sha512-v/ej7DflZbb6t//3Yu9vg0T+sun+Q9EoqggifeyABKfvFROqPwwwpv+hd1NKT2QxTRg6VCFk10IIJcMI13yCoQ==",
-			"dev": true,
 			"requires": {
 				"loader-utils": "^1.1.0",
 				"marked": "^0.3.9"
@@ -10610,20 +10157,17 @@
 		"markdown-table": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz",
-			"integrity": "sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw==",
-			"dev": true
+			"integrity": "sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw=="
 		},
 		"marked": {
 			"version": "0.3.19",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-			"integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
-			"dev": true
+			"integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
 		},
 		"matcher": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.0.tgz",
 			"integrity": "sha512-aZGv6JBTHqfqAd09jmAlbKnAICTfIvb5Z8gXVxPB5WZtFfHMaAMdACL7tQflD2V+6/8KNcY8s6DYtWLgpJP5lA==",
-			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.4"
 			}
@@ -10631,26 +10175,22 @@
 		"math-expression-evaluator": {
 			"version": "1.2.17",
 			"resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
-			"integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
-			"dev": true
+			"integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw="
 		},
 		"math-random": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-			"dev": true
+			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
 		},
 		"mathml-tag-names": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.0.tgz",
-			"integrity": "sha512-3Zs9P/0zzwTob2pdgT0CHZuMbnSUSp8MB1bddfm+HDmnFWHGT4jvEZRf+2RuPoa+cjdn/z25SEt5gFTqdhvJAg==",
-			"dev": true
+			"integrity": "sha512-3Zs9P/0zzwTob2pdgT0CHZuMbnSUSp8MB1bddfm+HDmnFWHGT4jvEZRf+2RuPoa+cjdn/z25SEt5gFTqdhvJAg=="
 		},
 		"md5-hex": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
 			"integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
-			"dev": true,
 			"requires": {
 				"md5-o-matic": "^0.1.1"
 			}
@@ -10658,14 +10198,12 @@
 		"md5-o-matic": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
-			"dev": true
+			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
 		},
 		"md5.js": {
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
 			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
-			"dev": true,
 			"requires": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
@@ -10675,7 +10213,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.1.tgz",
 			"integrity": "sha1-zbX4TitqLTEU3zO9BdnLMuPECDo=",
-			"dev": true,
 			"requires": {
 				"unist-util-modify-children": "^1.0.0",
 				"unist-util-visit": "^1.1.0"
@@ -10684,14 +10221,12 @@
 		"media-typer": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-			"dev": true
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"mem": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-			"dev": true,
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
@@ -10700,18 +10235,63 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
 			"integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
-			"dev": true,
 			"requires": {
 				"through2": "^2.0.0",
 				"vinyl": "^1.1.0",
 				"vinyl-file": "^2.0.0"
 			}
 		},
+		"mem-fs-editor": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz",
+			"integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
+			"requires": {
+				"commondir": "^1.0.1",
+				"deep-extend": "^0.4.0",
+				"ejs": "^2.3.1",
+				"glob": "^7.0.3",
+				"globby": "^6.1.0",
+				"mkdirp": "^0.5.0",
+				"multimatch": "^2.0.0",
+				"rimraf": "^2.2.8",
+				"through2": "^2.0.0",
+				"vinyl": "^2.0.1"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+				},
+				"clone-stats": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+				},
+				"deep-extend": {
+					"version": "0.4.2",
+					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+					"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+				},
+				"vinyl": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+					"requires": {
+						"clone": "^2.1.1",
+						"clone-buffer": "^1.0.0",
+						"clone-stats": "^1.0.0",
+						"cloneable-readable": "^1.0.0",
+						"remove-trailing-separator": "^1.0.1",
+						"replace-ext": "^1.0.0"
+					}
+				}
+			}
+		},
 		"memory-fs": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-			"dev": true,
 			"requires": {
 				"errno": "^0.1.3",
 				"readable-stream": "^2.0.1"
@@ -10720,14 +10300,12 @@
 		"memorystream": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-			"integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
-			"dev": true
+			"integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI="
 		},
 		"meow": {
 			"version": "3.7.0",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-			"dev": true,
 			"requires": {
 				"camelcase-keys": "^2.0.0",
 				"decamelize": "^1.1.2",
@@ -10744,14 +10322,12 @@
 				"camelcase": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-					"dev": true
+					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
 				},
 				"camelcase-keys": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^2.0.0",
 						"map-obj": "^1.0.0"
@@ -10761,7 +10337,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-					"dev": true,
 					"requires": {
 						"repeating": "^2.0.0"
 					}
@@ -10769,20 +10344,17 @@
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-					"dev": true
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
 				},
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"redent": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-					"dev": true,
 					"requires": {
 						"indent-string": "^2.1.0",
 						"strip-indent": "^1.0.1"
@@ -10792,7 +10364,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-					"dev": true,
 					"requires": {
 						"get-stdin": "^4.0.1"
 					}
@@ -10800,34 +10371,29 @@
 				"trim-newlines": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-					"dev": true
+					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
 				}
 			}
 		},
 		"merge-descriptors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-			"dev": true
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
 		},
 		"merge2": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
-			"integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg==",
-			"dev": true
+			"integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg=="
 		},
 		"methods": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-			"dev": true
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
 		"micromatch": {
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-			"dev": true,
 			"requires": {
 				"arr-diff": "^2.0.0",
 				"array-unique": "^0.2.1",
@@ -10848,7 +10414,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.0.1"
 					}
@@ -10856,14 +10421,12 @@
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"dev": true
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
 					"requires": {
 						"expand-range": "^1.8.1",
 						"preserve": "^0.2.0",
@@ -10874,7 +10437,6 @@
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
 					"requires": {
 						"is-posix-bracket": "^0.1.0"
 					}
@@ -10883,7 +10445,6 @@
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -10891,14 +10452,12 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -10909,7 +10468,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
 			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.0.0",
 				"brorand": "^1.0.1"
@@ -10918,8 +10476,7 @@
 		"mime": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-			"dev": true
+			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
 		},
 		"mime-db": {
 			"version": "1.33.0",
@@ -10937,20 +10494,17 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-			"dev": true
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
 		},
 		"mimic-response": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-			"dev": true
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
 		},
 		"min-document": {
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
 			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-			"dev": true,
 			"requires": {
 				"dom-walk": "^0.1.0"
 			}
@@ -10958,14 +10512,12 @@
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-			"dev": true
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
 		},
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-			"dev": true
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
 		},
 		"minimatch": {
 			"version": "3.0.4",
@@ -10984,7 +10536,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
 			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
-			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
 				"is-plain-obj": "^1.1.0"
@@ -10994,7 +10545,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
 			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
-			"dev": true,
 			"requires": {
 				"concat-stream": "^1.5.0",
 				"duplexify": "^3.4.2",
@@ -11012,7 +10562,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
-			"dev": true,
 			"requires": {
 				"for-in": "^1.0.2",
 				"is-extendable": "^1.0.1"
@@ -11022,7 +10571,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -11033,7 +10581,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
 			"integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
-			"dev": true,
 			"requires": {
 				"for-in": "^0.1.3",
 				"is-extendable": "^0.1.1"
@@ -11042,8 +10589,7 @@
 				"for-in": {
 					"version": "0.1.8",
 					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-					"integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
-					"dev": true
+					"integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
 				}
 			}
 		},
@@ -11058,14 +10604,12 @@
 		"modify-values": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
-			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
-			"dev": true
+			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw=="
 		},
 		"moment": {
 			"version": "2.22.2",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-			"integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
-			"dev": true
+			"integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
 		},
 		"move-concurrently": {
 			"version": "1.0.1",
@@ -11083,14 +10627,12 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"multimatch": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
 			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-			"dev": true,
 			"requires": {
 				"array-differ": "^1.0.0",
 				"array-union": "^1.0.1",
@@ -11101,20 +10643,17 @@
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-			"dev": true
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
 		"nan": {
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-			"dev": true
+			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
 		},
 		"nanomatch": {
 			"version": "1.2.9",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
 			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
-			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
 				"array-unique": "^0.3.2",
@@ -11133,40 +10672,74 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
 		},
 		"negotiator": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-			"dev": true
+			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
 		},
 		"neo-async": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.1.tgz",
-			"integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA==",
-			"dev": true
+			"integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA=="
 		},
 		"next-tick": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-			"dev": true
+			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
 		},
 		"nice-try": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
-			"integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
-			"dev": true
+			"integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
+		},
+		"nise": {
+			"version": "1.4.6",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.6.tgz",
+			"integrity": "sha512-1GedetLKzmqmgwabuMSqPsT7oumdR77SBpDfNNJhADRIeA3LN/2RVqR4fFqwvzhAqcTef6PPCzQwITE/YQ8S8A==",
+			"requires": {
+				"@sinonjs/formatio": "3.0.0",
+				"just-extend": "^3.0.0",
+				"lolex": "^2.3.2",
+				"path-to-regexp": "^1.7.0",
+				"text-encoding": "^0.6.4"
+			},
+			"dependencies": {
+				"@sinonjs/formatio": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
+					"integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
+					"requires": {
+						"@sinonjs/samsam": "2.1.0"
+					}
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"path-to-regexp": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+					"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+					"requires": {
+						"isarray": "0.0.1"
+					}
+				}
+			}
 		},
 		"no-case": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
 			"integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
-			"dev": true,
 			"requires": {
 				"lower-case": "^1.1.1"
 			}
@@ -11175,7 +10748,6 @@
 			"version": "0.1.17",
 			"resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
 			"integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
-			"dev": true,
 			"requires": {
 				"minimatch": "^3.0.2"
 			}
@@ -11184,7 +10756,6 @@
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-			"dev": true,
 			"requires": {
 				"encoding": "^0.1.11",
 				"is-stream": "^1.0.1"
@@ -11194,7 +10765,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
 			"integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
-			"dev": true,
 			"requires": {
 				"encoding": "^0.1.11",
 				"json-parse-better-errors": "^1.0.0",
@@ -11205,7 +10775,6 @@
 			"version": "3.8.0",
 			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
 			"integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
-			"dev": true,
 			"requires": {
 				"fstream": "^1.0.0",
 				"glob": "^7.0.3",
@@ -11224,8 +10793,7 @@
 				"semver": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-					"dev": true
+					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
 				}
 			}
 		},
@@ -11233,7 +10801,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
 			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
-			"dev": true,
 			"requires": {
 				"assert": "^1.1.1",
 				"browserify-zlib": "^0.2.0",
@@ -11263,14 +10830,12 @@
 				"events": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-					"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-					"dev": true
+					"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
 				},
 				"process": {
 					"version": "0.11.10",
 					"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-					"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-					"dev": true
+					"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
 				}
 			}
 		},
@@ -11278,7 +10843,6 @@
 			"version": "4.9.3",
 			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.3.tgz",
 			"integrity": "sha512-XzXyGjO+84wxyH7fV6IwBOTrEBe2f0a6SBze9QWWYR/cL74AcQUks2AsqcCZenl/Fp/JVbuEaLpgrLtocwBUww==",
-			"dev": true,
 			"requires": {
 				"async-foreach": "^0.1.3",
 				"chalk": "^1.1.1",
@@ -11304,14 +10868,12 @@
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -11324,7 +10886,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
 					"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-					"dev": true,
 					"requires": {
 						"lru-cache": "^4.0.1",
 						"which": "^1.2.9"
@@ -11333,8 +10894,7 @@
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -11342,7 +10902,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/node-sass-import/-/node-sass-import-2.0.1.tgz",
 			"integrity": "sha512-V0G3+bcVpLmOLD2tqUGy5DRi1FKpDIaJBuFCEYn/MmFp6EoJGnw4duM5419af0Xg4gFAOSFZPXX8MXEHpmFlGQ==",
-			"dev": true,
 			"requires": {
 				"async": "2.6.0",
 				"glob": "7.1.2",
@@ -11355,14 +10914,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"async": {
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
 					"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-					"dev": true,
 					"requires": {
 						"lodash": "^4.14.0"
 					}
@@ -11370,14 +10927,12 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"cliui": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-					"dev": true,
 					"requires": {
 						"string-width": "^2.1.1",
 						"strip-ansi": "^4.0.0",
@@ -11388,7 +10943,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -11397,7 +10951,6 @@
 					"version": "11.0.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
 					"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
-					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^1.1.1",
@@ -11417,7 +10970,6 @@
 					"version": "9.0.2",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
 					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
 					}
@@ -11428,7 +10980,6 @@
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-			"dev": true,
 			"requires": {
 				"abbrev": "1"
 			}
@@ -11436,14 +10987,12 @@
 		"normalize-git-url": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.2.tgz",
-			"integrity": "sha1-jl8Uvgva7bc+ByADEKpBbCc1D8Q=",
-			"dev": true
+			"integrity": "sha1-jl8Uvgva7bc+ByADEKpBbCc1D8Q="
 		},
 		"normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
 				"is-builtin-module": "^1.0.0",
@@ -11455,7 +11004,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
 			}
@@ -11463,20 +11011,17 @@
 		"normalize-range": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
-			"dev": true
+			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
 		},
 		"normalize-selector": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
-			"integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
-			"dev": true
+			"integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM="
 		},
 		"normalize-url": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
 			"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-			"dev": true,
 			"requires": {
 				"object-assign": "^4.0.1",
 				"prepend-http": "^1.0.0",
@@ -11488,7 +11033,6 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
 					"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-					"dev": true,
 					"requires": {
 						"is-plain-obj": "^1.0.0"
 					}
@@ -11499,7 +11043,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
 			"integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
-			"dev": true,
 			"requires": {
 				"config-chain": "^1.1.11",
 				"pify": "^3.0.0"
@@ -11509,7 +11052,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/npm-keyword/-/npm-keyword-5.0.0.tgz",
 			"integrity": "sha1-mbha7Cn8s4jS3TUfABO/Umh4fmc=",
-			"dev": true,
 			"requires": {
 				"got": "^7.1.0",
 				"registry-url": "^3.0.3"
@@ -11519,7 +11061,6 @@
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
 					"integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-					"dev": true,
 					"requires": {
 						"decompress-response": "^3.2.0",
 						"duplexer3": "^0.1.4",
@@ -11540,14 +11081,12 @@
 				"p-cancelable": {
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-					"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
-					"dev": true
+					"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
 				},
 				"p-timeout": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
 					"integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
-					"dev": true,
 					"requires": {
 						"p-finally": "^1.0.0"
 					}
@@ -11558,7 +11097,6 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.3.tgz",
 			"integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.0",
 				"chalk": "^2.1.0",
@@ -11575,7 +11113,6 @@
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
 						"path-key": "^2.0.1",
@@ -11588,7 +11125,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -11600,7 +11136,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -11613,7 +11148,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-			"dev": true,
 			"requires": {
 				"path-key": "^2.0.0"
 			}
@@ -11622,7 +11156,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"dev": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -11634,7 +11167,6 @@
 			"version": "10.2.0",
 			"resolved": "https://registry.npmjs.org/npx/-/npx-10.2.0.tgz",
 			"integrity": "sha512-DqjFkzET0DeaXYXNJnirnvEovwk4lBa33ZQCw1jxMuas4yH9jdU8q2U8L3cLaB2UqzgmW2Ssqk8lcGiPRL8pRg==",
-			"dev": true,
 			"requires": {
 				"libnpx": "10.2.0",
 				"npm": "5.1.0"
@@ -11644,7 +11176,6 @@
 					"version": "4.11.8",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
 					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-					"dev": true,
 					"requires": {
 						"co": "^4.6.0",
 						"json-stable-stringify": "^1.0.1"
@@ -11654,7 +11185,6 @@
 							"version": "1.0.1",
 							"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 							"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-							"dev": true,
 							"requires": {
 								"jsonify": "~0.0.0"
 							}
@@ -11665,7 +11195,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
 					"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-					"dev": true,
 					"requires": {
 						"string-width": "^2.0.0"
 					}
@@ -11673,14 +11202,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -11688,8 +11215,7 @@
 				"assert-plus": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-					"dev": true
+					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
 				},
 				"balanced-match": {
 					"version": "1.0.0",
@@ -11700,7 +11226,6 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
 					"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-					"dev": true,
 					"requires": {
 						"ansi-align": "^2.0.0",
 						"camelcase": "^4.0.0",
@@ -11723,8 +11248,7 @@
 				"builtins": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-					"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
-					"dev": true
+					"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
 				},
 				"cacache": {
 					"version": "9.2.9",
@@ -11756,20 +11280,17 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"capture-stack-trace": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-					"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-					"dev": true
+					"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
 				},
 				"chalk": {
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -11779,20 +11300,17 @@
 				"ci-info": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-					"integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
-					"dev": true
+					"integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg=="
 				},
 				"cli-boxes": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-					"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
-					"dev": true
+					"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
 				},
 				"cliui": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
 					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
-					"dev": true,
 					"requires": {
 						"string-width": "^2.1.1",
 						"strip-ansi": "^4.0.0",
@@ -11802,14 +11320,12 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-					"dev": true
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 				},
 				"color-convert": {
 					"version": "1.9.1",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 					"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-					"dev": true,
 					"requires": {
 						"color-name": "^1.1.1"
 					}
@@ -11817,8 +11333,7 @@
 				"color-name": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
 				"concat-map": {
 					"version": "0.0.1",
@@ -11829,7 +11344,6 @@
 					"version": "3.1.2",
 					"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
 					"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
-					"dev": true,
 					"requires": {
 						"dot-prop": "^4.1.0",
 						"graceful-fs": "^4.1.2",
@@ -11843,7 +11357,6 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
 					"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-					"dev": true,
 					"requires": {
 						"capture-stack-trace": "^1.0.0"
 					}
@@ -11852,7 +11365,6 @@
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-					"dev": true,
 					"requires": {
 						"lru-cache": "^4.0.1",
 						"shebang-command": "^1.2.0",
@@ -11862,26 +11374,22 @@
 				"crypto-random-string": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-					"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-					"dev": true
+					"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
 				},
 				"decamelize": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-					"dev": true
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 				},
 				"deep-extend": {
 					"version": "0.4.2",
 					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-					"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-					"dev": true
+					"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
 				},
 				"dot-prop": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
 					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-					"dev": true,
 					"requires": {
 						"is-obj": "^1.0.0"
 					}
@@ -11889,26 +11397,22 @@
 				"dotenv": {
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
-					"integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
-					"dev": true
+					"integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
 				},
 				"duplexer3": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-					"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-					"dev": true
+					"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-					"dev": true
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"execa": {
 					"version": "0.7.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -11923,7 +11427,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
@@ -11936,14 +11439,12 @@
 				"get-caller-file": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-					"dev": true
+					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
 				},
 				"get-stream": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-					"dev": true
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 				},
 				"glob": {
 					"version": "7.1.2",
@@ -11962,7 +11463,6 @@
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
 					"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-					"dev": true,
 					"requires": {
 						"ini": "^1.3.4"
 					}
@@ -11971,7 +11471,6 @@
 					"version": "6.7.1",
 					"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
 					"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-					"dev": true,
 					"requires": {
 						"create-error-class": "^3.0.0",
 						"duplexer3": "^0.1.4",
@@ -11994,32 +11493,27 @@
 				"har-schema": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-					"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-					"dev": true
+					"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
 				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"hosted-git-info": {
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-					"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
-					"dev": true
+					"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
 				},
 				"import-lazy": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-					"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
-					"dev": true
+					"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-					"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-					"dev": true
+					"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
 				},
 				"inflight": {
 					"version": "1.0.6",
@@ -12038,20 +11532,17 @@
 				"ini": {
 					"version": "1.3.5",
 					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-					"dev": true
+					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 				},
 				"invert-kv": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-					"dev": true
+					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
 				},
 				"is-ci": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
 					"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
-					"dev": true,
 					"requires": {
 						"ci-info": "^1.0.0"
 					}
@@ -12059,14 +11550,12 @@
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 				},
 				"is-installed-globally": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
 					"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-					"dev": true,
 					"requires": {
 						"global-dirs": "^0.1.0",
 						"is-path-inside": "^1.0.0"
@@ -12075,20 +11564,17 @@
 				"is-npm": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-					"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
-					"dev": true
+					"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
 				},
 				"is-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-					"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-					"dev": true
+					"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
 				},
 				"is-path-inside": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 					"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-					"dev": true,
 					"requires": {
 						"path-is-inside": "^1.0.1"
 					}
@@ -12096,32 +11582,27 @@
 				"is-redirect": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-					"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-					"dev": true
+					"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
 				},
 				"is-retry-allowed": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-					"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-					"dev": true
+					"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
 				},
 				"is-stream": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-					"dev": true
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 				},
 				"isexe": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-					"dev": true
+					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 				},
 				"latest-version": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
 					"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-					"dev": true,
 					"requires": {
 						"package-json": "^4.0.0"
 					}
@@ -12130,7 +11611,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-					"dev": true,
 					"requires": {
 						"invert-kv": "^1.0.0"
 					}
@@ -12139,7 +11619,6 @@
 					"version": "10.2.0",
 					"resolved": "https://registry.npmjs.org/libnpx/-/libnpx-10.2.0.tgz",
 					"integrity": "sha512-X28coei8/XRCt15cYStbLBph+KGhFra4VQhRBPuH/HHMkC5dxM8v24RVgUsvODKCrUZ0eTgiTqJp6zbl0sskQQ==",
-					"dev": true,
 					"requires": {
 						"dotenv": "^5.0.1",
 						"npm-package-arg": "^6.0.0",
@@ -12155,7 +11634,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
@@ -12164,8 +11642,7 @@
 				"lowercase-keys": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-					"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-					"dev": true
+					"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
 				},
 				"lru-cache": {
 					"version": "4.1.2",
@@ -12180,7 +11657,6 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
 					"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
-					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -12189,7 +11665,6 @@
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.6.0.tgz",
 					"integrity": "sha512-FFq0lNI0ax+n9IWzWpH8A4JdgYiAp2DDYIZ3rsaav8JDe8I+72CzK6PQW/oom15YDZpV5bYW/9INd6nIJ2ZfZw==",
-					"dev": true,
 					"requires": {
 						"agentkeepalive": "^3.3.0",
 						"cacache": "^10.0.0",
@@ -12208,7 +11683,6 @@
 							"version": "10.0.4",
 							"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
 							"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
-							"dev": true,
 							"requires": {
 								"bluebird": "^3.5.1",
 								"chownr": "^1.0.1",
@@ -12229,7 +11703,6 @@
 									"version": "2.0.0",
 									"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
 									"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
-									"dev": true,
 									"requires": {
 										"concat-stream": "^1.5.0",
 										"duplexify": "^3.4.2",
@@ -12249,7 +11722,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
 							"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-							"dev": true,
 							"requires": {
 								"end-of-stream": "^1.1.0",
 								"once": "^1.3.1"
@@ -12259,7 +11731,6 @@
 							"version": "5.3.0",
 							"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
 							"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
-							"dev": true,
 							"requires": {
 								"safe-buffer": "^5.1.1"
 							}
@@ -12270,7 +11741,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-					"dev": true,
 					"requires": {
 						"mimic-fn": "^1.0.0"
 					}
@@ -12278,8 +11748,7 @@
 				"mimic-fn": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-					"dev": true
+					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
 				},
 				"minimatch": {
 					"version": "3.0.4",
@@ -12292,8 +11761,7 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"mississippi": {
 					"version": "1.3.1",
@@ -12316,7 +11784,6 @@
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/npm/-/npm-5.1.0.tgz",
 					"integrity": "sha512-pt5ClxEmY/dLpb60SmGQQBKi3nB6Ljx1FXmpoCUdAULlGqGVn2uCyXxPCWFbcuHGthT7qGiaGa1wOfs/UjGYMw==",
-					"dev": true,
 					"requires": {
 						"JSONStream": "~1.3.1",
 						"abbrev": "~1.1.0",
@@ -12420,7 +11887,6 @@
 							"version": "1.3.1",
 							"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
 							"integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-							"dev": true,
 							"requires": {
 								"jsonparse": "^1.2.0",
 								"through": ">=2.2.7 <3"
@@ -12429,64 +11895,54 @@
 								"jsonparse": {
 									"version": "1.3.1",
 									"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-									"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-									"dev": true
+									"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
 								},
 								"through": {
 									"version": "2.3.8",
 									"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-									"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-									"dev": true
+									"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 								}
 							}
 						},
 						"abbrev": {
 							"version": "1.1.0",
 							"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-							"integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
-							"dev": true
+							"integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8="
 						},
 						"ansi-regex": {
 							"version": "3.0.0",
 							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-							"dev": true
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 						},
 						"ansicolors": {
 							"version": "0.3.2",
 							"resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-							"integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
-							"dev": true
+							"integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
 						},
 						"ansistyles": {
 							"version": "0.1.3",
 							"resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-							"integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
-							"dev": true
+							"integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk="
 						},
 						"aproba": {
 							"version": "1.1.2",
 							"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-							"integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
-							"dev": true
+							"integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw=="
 						},
 						"archy": {
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-							"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-							"dev": true
+							"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
 						},
 						"bluebird": {
 							"version": "3.5.0",
 							"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-							"integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
-							"dev": true
+							"integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
 						},
 						"cacache": {
 							"version": "9.2.9",
 							"resolved": "https://registry.npmjs.org/cacache/-/cacache-9.2.9.tgz",
 							"integrity": "sha512-ghg1j5OyTJ6qsrqU++dN23QiTDxb5AZCFGsF3oB+v9v/gY+F4X8L/0gdQMEjd+8Ot3D29M2etX5PKozHRn2JQw==",
-							"dev": true,
 							"requires": {
 								"bluebird": "^3.5.0",
 								"chownr": "^1.0.1",
@@ -12506,20 +11962,17 @@
 						"call-limit": {
 							"version": "1.1.0",
 							"resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.0.tgz",
-							"integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o=",
-							"dev": true
+							"integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o="
 						},
 						"chownr": {
 							"version": "1.0.1",
 							"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-							"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-							"dev": true
+							"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
 						},
 						"cmd-shim": {
 							"version": "2.0.2",
 							"resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
 							"integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
-							"dev": true,
 							"requires": {
 								"graceful-fs": "^4.1.2",
 								"mkdirp": "~0.5.0"
@@ -12529,7 +11982,6 @@
 							"version": "1.5.4",
 							"resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
 							"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
-							"dev": true,
 							"requires": {
 								"strip-ansi": "^3.0.0",
 								"wcwidth": "^1.0.0"
@@ -12539,7 +11991,6 @@
 									"version": "3.0.1",
 									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 									"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-									"dev": true,
 									"requires": {
 										"ansi-regex": "^2.0.0"
 									},
@@ -12547,8 +11998,7 @@
 										"ansi-regex": {
 											"version": "2.1.1",
 											"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-											"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-											"dev": true
+											"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 										}
 									}
 								},
@@ -12556,7 +12006,6 @@
 									"version": "1.0.1",
 									"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
 									"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-									"dev": true,
 									"requires": {
 										"defaults": "^1.0.3"
 									},
@@ -12565,7 +12014,6 @@
 											"version": "1.0.3",
 											"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
 											"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-											"dev": true,
 											"requires": {
 												"clone": "^1.0.2"
 											},
@@ -12573,8 +12021,7 @@
 												"clone": {
 													"version": "1.0.2",
 													"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-													"integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
-													"dev": true
+													"integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
 												}
 											}
 										}
@@ -12586,7 +12033,6 @@
 							"version": "1.1.11",
 							"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
 							"integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
-							"dev": true,
 							"requires": {
 								"ini": "^1.3.4",
 								"proto-list": "~1.2.1"
@@ -12595,34 +12041,29 @@
 								"proto-list": {
 									"version": "1.2.4",
 									"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-									"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-									"dev": true
+									"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
 								}
 							}
 						},
 						"debuglog": {
 							"version": "1.0.1",
 							"resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-							"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
-							"dev": true
+							"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
 						},
 						"deep-extend": {
 							"version": "0.6.0",
 							"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-							"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-							"dev": true
+							"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
 						},
 						"detect-indent": {
 							"version": "5.0.0",
 							"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-							"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-							"dev": true
+							"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
 						},
 						"dezalgo": {
 							"version": "1.0.3",
 							"resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
 							"integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-							"dev": true,
 							"requires": {
 								"asap": "^2.0.0",
 								"wrappy": "1"
@@ -12631,22 +12072,19 @@
 								"asap": {
 									"version": "2.0.5",
 									"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
-									"integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8=",
-									"dev": true
+									"integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8="
 								}
 							}
 						},
 						"editor": {
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
-							"integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
-							"dev": true
+							"integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I="
 						},
 						"fs-vacuum": {
 							"version": "1.2.10",
 							"resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
 							"integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
-							"dev": true,
 							"requires": {
 								"graceful-fs": "^4.1.2",
 								"path-is-inside": "^1.0.1",
@@ -12657,7 +12095,6 @@
 							"version": "1.0.10",
 							"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
 							"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-							"dev": true,
 							"requires": {
 								"graceful-fs": "^4.1.2",
 								"iferr": "^0.1.5",
@@ -12669,7 +12106,6 @@
 							"version": "1.0.11",
 							"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
 							"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-							"dev": true,
 							"requires": {
 								"graceful-fs": "^4.1.2",
 								"inherits": "~2.0.0",
@@ -12681,7 +12117,6 @@
 							"version": "1.2.1",
 							"resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.1.tgz",
 							"integrity": "sha512-iBHpm/LmD1qw0TlHMAqVd9rwdU6M+EHRUnPkXpRi5G/Hf0FIFH+oZFryodAU2MFNfGRh/CzhUFlMKV3pdeOTDw==",
-							"dev": true,
 							"requires": {
 								"fstream-ignore": "^1.0.0",
 								"inherits": "2"
@@ -12691,7 +12126,6 @@
 									"version": "1.0.5",
 									"resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
 									"integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-									"dev": true,
 									"requires": {
 										"fstream": "^1.0.0",
 										"inherits": "2",
@@ -12702,7 +12136,6 @@
 											"version": "3.0.4",
 											"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 											"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-											"dev": true,
 											"requires": {
 												"brace-expansion": "^1.1.7"
 											},
@@ -12711,7 +12144,6 @@
 													"version": "1.1.8",
 													"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 													"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-													"dev": true,
 													"requires": {
 														"balanced-match": "^1.0.0",
 														"concat-map": "0.0.1"
@@ -12720,14 +12152,12 @@
 														"balanced-match": {
 															"version": "1.0.0",
 															"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-															"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-															"dev": true
+															"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 														},
 														"concat-map": {
 															"version": "0.0.1",
 															"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-															"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-															"dev": true
+															"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 														}
 													}
 												}
@@ -12741,7 +12171,6 @@
 							"version": "7.1.2",
 							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 							"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-							"dev": true,
 							"requires": {
 								"fs.realpath": "^1.0.0",
 								"inflight": "^1.0.4",
@@ -12754,14 +12183,12 @@
 								"fs.realpath": {
 									"version": "1.0.0",
 									"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-									"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-									"dev": true
+									"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 								},
 								"minimatch": {
 									"version": "3.0.4",
 									"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 									"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-									"dev": true,
 									"requires": {
 										"brace-expansion": "^1.1.7"
 									},
@@ -12770,7 +12197,6 @@
 											"version": "1.1.8",
 											"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 											"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-											"dev": true,
 											"requires": {
 												"balanced-match": "^1.0.0",
 												"concat-map": "0.0.1"
@@ -12779,14 +12205,12 @@
 												"balanced-match": {
 													"version": "1.0.0",
 													"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-													"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-													"dev": true
+													"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 												},
 												"concat-map": {
 													"version": "0.0.1",
 													"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-													"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-													"dev": true
+													"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 												}
 											}
 										}
@@ -12795,46 +12219,39 @@
 								"path-is-absolute": {
 									"version": "1.0.1",
 									"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-									"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-									"dev": true
+									"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 								}
 							}
 						},
 						"graceful-fs": {
 							"version": "4.1.11",
 							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-							"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-							"dev": true
+							"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
 						},
 						"has-unicode": {
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-							"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-							"dev": true
+							"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
 						},
 						"hosted-git-info": {
 							"version": "2.5.0",
 							"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-							"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-							"dev": true
+							"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
 						},
 						"iferr": {
 							"version": "0.1.5",
 							"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-							"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-							"dev": true
+							"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
 						},
 						"imurmurhash": {
 							"version": "0.1.4",
 							"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-							"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-							"dev": true
+							"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
 						},
 						"inflight": {
 							"version": "1.0.6",
 							"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 							"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-							"dev": true,
 							"requires": {
 								"once": "^1.3.0",
 								"wrappy": "1"
@@ -12843,20 +12260,17 @@
 						"inherits": {
 							"version": "2.0.3",
 							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-							"dev": true
+							"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 						},
 						"ini": {
 							"version": "1.3.4",
 							"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-							"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-							"dev": true
+							"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
 						},
 						"init-package-json": {
 							"version": "1.10.1",
 							"resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.1.tgz",
 							"integrity": "sha1-zYc6FneWvvuZYSsodioLY5P9j2o=",
-							"dev": true,
 							"requires": {
 								"glob": "^7.1.1",
 								"npm-package-arg": "^4.0.0 || ^5.0.0",
@@ -12872,7 +12286,6 @@
 									"version": "0.3.0",
 									"resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
 									"integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
-									"dev": true,
 									"requires": {
 										"read": "1"
 									}
@@ -12882,26 +12295,22 @@
 						"lazy-property": {
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
-							"integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
-							"dev": true
+							"integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc="
 						},
 						"lockfile": {
 							"version": "1.0.3",
 							"resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
-							"integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k=",
-							"dev": true
+							"integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k="
 						},
 						"lodash._baseindexof": {
 							"version": "3.1.0",
 							"resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
-							"integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
-							"dev": true
+							"integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw="
 						},
 						"lodash._baseuniq": {
 							"version": "4.6.0",
 							"resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
 							"integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
-							"dev": true,
 							"requires": {
 								"lodash._createset": "~4.0.0",
 								"lodash._root": "~3.0.0"
@@ -12910,34 +12319,29 @@
 								"lodash._createset": {
 									"version": "4.0.3",
 									"resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
-									"integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
-									"dev": true
+									"integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY="
 								},
 								"lodash._root": {
 									"version": "3.0.1",
 									"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-									"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
-									"dev": true
+									"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
 								}
 							}
 						},
 						"lodash._bindcallback": {
 							"version": "3.0.1",
 							"resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-							"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
-							"dev": true
+							"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
 						},
 						"lodash._cacheindexof": {
 							"version": "3.0.2",
 							"resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
-							"integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
-							"dev": true
+							"integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI="
 						},
 						"lodash._createcache": {
 							"version": "3.1.2",
 							"resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
 							"integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
-							"dev": true,
 							"requires": {
 								"lodash._getnative": "^3.0.0"
 							}
@@ -12945,44 +12349,37 @@
 						"lodash._getnative": {
 							"version": "3.9.1",
 							"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-							"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-							"dev": true
+							"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
 						},
 						"lodash.clonedeep": {
 							"version": "4.5.0",
 							"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-							"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-							"dev": true
+							"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
 						},
 						"lodash.restparam": {
 							"version": "3.6.1",
 							"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-							"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-							"dev": true
+							"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
 						},
 						"lodash.union": {
 							"version": "4.6.0",
 							"resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-							"integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
-							"dev": true
+							"integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
 						},
 						"lodash.uniq": {
 							"version": "4.5.0",
 							"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-							"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
-							"dev": true
+							"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
 						},
 						"lodash.without": {
 							"version": "4.4.0",
 							"resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
-							"integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
-							"dev": true
+							"integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
 						},
 						"lru-cache": {
 							"version": "4.1.1",
 							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
 							"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-							"dev": true,
 							"requires": {
 								"pseudomap": "^1.0.2",
 								"yallist": "^2.1.2"
@@ -12991,14 +12388,12 @@
 								"pseudomap": {
 									"version": "1.0.2",
 									"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-									"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-									"dev": true
+									"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 								},
 								"yallist": {
 									"version": "2.1.2",
 									"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-									"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-									"dev": true
+									"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 								}
 							}
 						},
@@ -13006,7 +12401,6 @@
 							"version": "1.3.0",
 							"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
 							"integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
-							"dev": true,
 							"requires": {
 								"concat-stream": "^1.5.0",
 								"duplexify": "^3.4.2",
@@ -13024,7 +12418,6 @@
 									"version": "1.6.0",
 									"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
 									"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-									"dev": true,
 									"requires": {
 										"inherits": "^2.0.3",
 										"readable-stream": "^2.2.2",
@@ -13034,8 +12427,7 @@
 										"typedarray": {
 											"version": "0.0.6",
 											"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-											"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-											"dev": true
+											"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 										}
 									}
 								},
@@ -13043,7 +12435,6 @@
 									"version": "3.5.0",
 									"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
 									"integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
-									"dev": true,
 									"requires": {
 										"end-of-stream": "1.0.0",
 										"inherits": "^2.0.1",
@@ -13055,7 +12446,6 @@
 											"version": "1.0.0",
 											"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
 											"integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
-											"dev": true,
 											"requires": {
 												"once": "~1.3.0"
 											},
@@ -13064,7 +12454,6 @@
 													"version": "1.3.3",
 													"resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
 													"integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-													"dev": true,
 													"requires": {
 														"wrappy": "1"
 													}
@@ -13074,8 +12463,7 @@
 										"stream-shift": {
 											"version": "1.0.0",
 											"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-											"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-											"dev": true
+											"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
 										}
 									}
 								},
@@ -13083,7 +12471,6 @@
 									"version": "1.4.0",
 									"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
 									"integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-									"dev": true,
 									"requires": {
 										"once": "^1.4.0"
 									}
@@ -13092,7 +12479,6 @@
 									"version": "1.0.2",
 									"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
 									"integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
-									"dev": true,
 									"requires": {
 										"inherits": "^2.0.1",
 										"readable-stream": "^2.0.4"
@@ -13102,7 +12488,6 @@
 									"version": "2.3.0",
 									"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
 									"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-									"dev": true,
 									"requires": {
 										"inherits": "^2.0.1",
 										"readable-stream": "^2.0.0"
@@ -13112,7 +12497,6 @@
 									"version": "1.1.0",
 									"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
 									"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
-									"dev": true,
 									"requires": {
 										"cyclist": "~0.2.2",
 										"inherits": "^2.0.3",
@@ -13122,8 +12506,7 @@
 										"cyclist": {
 											"version": "0.2.2",
 											"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-											"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
-											"dev": true
+											"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
 										}
 									}
 								},
@@ -13131,7 +12514,6 @@
 									"version": "1.0.2",
 									"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
 									"integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
-									"dev": true,
 									"requires": {
 										"end-of-stream": "^1.1.0",
 										"once": "^1.3.1"
@@ -13141,7 +12523,6 @@
 									"version": "1.3.5",
 									"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
 									"integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
-									"dev": true,
 									"requires": {
 										"duplexify": "^3.1.2",
 										"inherits": "^2.0.1",
@@ -13152,7 +12533,6 @@
 									"version": "1.2.0",
 									"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.0.tgz",
 									"integrity": "sha1-HpXUdXP1gNgU3A/4zQ9m8c5TyZE=",
-									"dev": true,
 									"requires": {
 										"end-of-stream": "^1.1.0",
 										"stream-shift": "^1.0.0"
@@ -13161,8 +12541,7 @@
 										"stream-shift": {
 											"version": "1.0.0",
 											"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-											"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-											"dev": true
+											"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
 										}
 									}
 								},
@@ -13170,7 +12549,6 @@
 									"version": "2.0.3",
 									"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 									"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-									"dev": true,
 									"requires": {
 										"readable-stream": "^2.1.5",
 										"xtend": "~4.0.1"
@@ -13179,8 +12557,7 @@
 										"xtend": {
 											"version": "4.0.1",
 											"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-											"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-											"dev": true
+											"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 										}
 									}
 								}
@@ -13190,7 +12567,6 @@
 							"version": "0.5.1",
 							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-							"dev": true,
 							"requires": {
 								"minimist": "0.0.8"
 							},
@@ -13198,8 +12574,7 @@
 								"minimist": {
 									"version": "0.0.8",
 									"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-									"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-									"dev": true
+									"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 								}
 							}
 						},
@@ -13207,7 +12582,6 @@
 							"version": "1.0.1",
 							"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
 							"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
-							"dev": true,
 							"requires": {
 								"aproba": "^1.1.1",
 								"copy-concurrently": "^1.0.0",
@@ -13221,7 +12595,6 @@
 									"version": "1.0.3",
 									"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.3.tgz",
 									"integrity": "sha1-Rft4ZiSaHKiJqlcI5svSc+dbslA=",
-									"dev": true,
 									"requires": {
 										"aproba": "^1.1.1",
 										"fs-write-stream-atomic": "^1.0.8",
@@ -13235,7 +12608,6 @@
 									"version": "1.0.3",
 									"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
 									"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
-									"dev": true,
 									"requires": {
 										"aproba": "^1.1.1"
 									}
@@ -13246,7 +12618,6 @@
 							"version": "3.6.2",
 							"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
 							"integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
-							"dev": true,
 							"requires": {
 								"fstream": "^1.0.0",
 								"glob": "^7.0.3",
@@ -13267,7 +12638,6 @@
 									"version": "3.0.4",
 									"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 									"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-									"dev": true,
 									"requires": {
 										"brace-expansion": "^1.1.7"
 									},
@@ -13276,7 +12646,6 @@
 											"version": "1.1.8",
 											"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 											"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-											"dev": true,
 											"requires": {
 												"balanced-match": "^1.0.0",
 												"concat-map": "0.0.1"
@@ -13285,14 +12654,12 @@
 												"balanced-match": {
 													"version": "1.0.0",
 													"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-													"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-													"dev": true
+													"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 												},
 												"concat-map": {
 													"version": "0.0.1",
 													"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-													"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-													"dev": true
+													"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 												}
 											}
 										}
@@ -13302,7 +12669,6 @@
 									"version": "3.0.6",
 									"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 									"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-									"dev": true,
 									"requires": {
 										"abbrev": "1"
 									}
@@ -13313,7 +12679,6 @@
 							"version": "4.0.1",
 							"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
 							"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-							"dev": true,
 							"requires": {
 								"abbrev": "1",
 								"osenv": "^0.1.4"
@@ -13323,7 +12688,6 @@
 							"version": "2.4.0",
 							"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 							"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-							"dev": true,
 							"requires": {
 								"hosted-git-info": "^2.1.4",
 								"is-builtin-module": "^1.0.0",
@@ -13335,7 +12699,6 @@
 									"version": "1.0.0",
 									"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 									"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-									"dev": true,
 									"requires": {
 										"builtin-modules": "^1.0.0"
 									},
@@ -13343,8 +12706,7 @@
 										"builtin-modules": {
 											"version": "1.1.1",
 											"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-											"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-											"dev": true
+											"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
 										}
 									}
 								}
@@ -13353,14 +12715,12 @@
 						"npm-cache-filename": {
 							"version": "1.0.2",
 							"resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
-							"integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
-							"dev": true
+							"integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE="
 						},
 						"npm-install-checks": {
 							"version": "3.0.0",
 							"resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
 							"integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
-							"dev": true,
 							"requires": {
 								"semver": "^2.3.0 || 3.x || 4 || 5"
 							}
@@ -13369,7 +12729,6 @@
 							"version": "5.1.2",
 							"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
 							"integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
-							"dev": true,
 							"requires": {
 								"hosted-git-info": "^2.4.2",
 								"osenv": "^0.1.4",
@@ -13381,7 +12740,6 @@
 							"version": "8.4.0",
 							"resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.4.0.tgz",
 							"integrity": "sha512-PVNfqq0lyRdFnE//nDmn3CC9uqTsr8Bya9KPLIevlXMfkP0m4RpCVyFFk0W1Gfx436kKwyhLA6J+lV+rgR81gQ==",
-							"dev": true,
 							"requires": {
 								"concat-stream": "^1.5.2",
 								"graceful-fs": "^4.1.6",
@@ -13400,7 +12758,6 @@
 									"version": "1.6.0",
 									"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
 									"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-									"dev": true,
 									"requires": {
 										"inherits": "^2.0.3",
 										"readable-stream": "^2.2.2",
@@ -13410,8 +12767,7 @@
 										"typedarray": {
 											"version": "0.0.6",
 											"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-											"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-											"dev": true
+											"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 										}
 									}
 								}
@@ -13420,14 +12776,12 @@
 						"npm-user-validate": {
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.0.tgz",
-							"integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
-							"dev": true
+							"integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE="
 						},
 						"npmlog": {
 							"version": "4.1.2",
 							"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 							"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-							"dev": true,
 							"requires": {
 								"are-we-there-yet": "~1.1.2",
 								"console-control-strings": "~1.1.0",
@@ -13439,7 +12793,6 @@
 									"version": "1.1.4",
 									"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
 									"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-									"dev": true,
 									"requires": {
 										"delegates": "^1.0.0",
 										"readable-stream": "^2.0.6"
@@ -13448,22 +12801,19 @@
 										"delegates": {
 											"version": "1.0.0",
 											"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-											"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-											"dev": true
+											"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
 										}
 									}
 								},
 								"console-control-strings": {
 									"version": "1.1.0",
 									"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-									"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-									"dev": true
+									"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 								},
 								"gauge": {
 									"version": "2.7.4",
 									"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 									"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-									"dev": true,
 									"requires": {
 										"aproba": "^1.0.3",
 										"console-control-strings": "^1.0.0",
@@ -13478,20 +12828,17 @@
 										"object-assign": {
 											"version": "4.1.1",
 											"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-											"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-											"dev": true
+											"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 										},
 										"signal-exit": {
 											"version": "3.0.2",
 											"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-											"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-											"dev": true
+											"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 										},
 										"string-width": {
 											"version": "1.0.2",
 											"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 											"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-											"dev": true,
 											"requires": {
 												"code-point-at": "^1.0.0",
 												"is-fullwidth-code-point": "^1.0.0",
@@ -13501,14 +12848,12 @@
 												"code-point-at": {
 													"version": "1.1.0",
 													"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-													"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-													"dev": true
+													"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 												},
 												"is-fullwidth-code-point": {
 													"version": "1.0.0",
 													"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 													"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-													"dev": true,
 													"requires": {
 														"number-is-nan": "^1.0.0"
 													},
@@ -13516,8 +12861,7 @@
 														"number-is-nan": {
 															"version": "1.0.1",
 															"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-															"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-															"dev": true
+															"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 														}
 													}
 												}
@@ -13527,7 +12871,6 @@
 											"version": "3.0.1",
 											"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 											"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-											"dev": true,
 											"requires": {
 												"ansi-regex": "^2.0.0"
 											},
@@ -13535,8 +12878,7 @@
 												"ansi-regex": {
 													"version": "2.1.1",
 													"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-													"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-													"dev": true
+													"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 												}
 											}
 										},
@@ -13544,7 +12886,6 @@
 											"version": "1.1.2",
 											"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
 											"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-											"dev": true,
 											"requires": {
 												"string-width": "^1.0.2"
 											}
@@ -13554,8 +12895,7 @@
 								"set-blocking": {
 									"version": "2.0.0",
 									"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-									"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-									"dev": true
+									"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 								}
 							}
 						},
@@ -13563,7 +12903,6 @@
 							"version": "1.4.0",
 							"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-							"dev": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -13571,14 +12910,12 @@
 						"opener": {
 							"version": "1.4.3",
 							"resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
-							"integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
-							"dev": true
+							"integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg="
 						},
 						"osenv": {
 							"version": "0.1.4",
 							"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
 							"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-							"dev": true,
 							"requires": {
 								"os-homedir": "^1.0.0",
 								"os-tmpdir": "^1.0.0"
@@ -13587,14 +12924,12 @@
 								"os-homedir": {
 									"version": "1.0.2",
 									"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-									"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-									"dev": true
+									"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 								},
 								"os-tmpdir": {
 									"version": "1.0.2",
 									"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-									"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-									"dev": true
+									"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 								}
 							}
 						},
@@ -13602,7 +12937,6 @@
 							"version": "2.7.38",
 							"resolved": "https://registry.npmjs.org/pacote/-/pacote-2.7.38.tgz",
 							"integrity": "sha512-XxHUyHQB7QCVBxoXeVu0yKxT+2PvJucsc0+1E+6f95lMUxEAYERgSAc71ckYXrYr35Ew3xFU/LrhdIK21GQFFA==",
-							"dev": true,
 							"requires": {
 								"bluebird": "^3.5.0",
 								"cacache": "^9.2.9",
@@ -13631,7 +12965,6 @@
 									"version": "3.0.4",
 									"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 									"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-									"dev": true,
 									"requires": {
 										"brace-expansion": "^1.1.7"
 									},
@@ -13640,7 +12973,6 @@
 											"version": "1.1.8",
 											"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 											"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-											"dev": true,
 											"requires": {
 												"balanced-match": "^1.0.0",
 												"concat-map": "0.0.1"
@@ -13649,14 +12981,12 @@
 												"balanced-match": {
 													"version": "1.0.0",
 													"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-													"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-													"dev": true
+													"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 												},
 												"concat-map": {
 													"version": "0.0.1",
 													"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-													"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-													"dev": true
+													"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 												}
 											}
 										}
@@ -13666,7 +12996,6 @@
 									"version": "1.0.4",
 									"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-1.0.4.tgz",
 									"integrity": "sha512-MKxNdeyOZysPRTTbHtW0M5Fw38Jo/3ARsoGw5qjCfS+XGjvNB/Gb4qtAZUFmKPM2mVum+eX559eHvKywU856BQ==",
-									"dev": true,
 									"requires": {
 										"npm-package-arg": "^5.1.2",
 										"semver": "^5.3.0"
@@ -13676,7 +13005,6 @@
 									"version": "1.1.1",
 									"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
 									"integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
-									"dev": true,
 									"requires": {
 										"err-code": "^1.0.0",
 										"retry": "^0.10.0"
@@ -13685,8 +13013,7 @@
 										"err-code": {
 											"version": "1.1.2",
 											"resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-											"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
-											"dev": true
+											"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
 										}
 									}
 								},
@@ -13694,7 +13021,6 @@
 									"version": "4.0.0",
 									"resolved": "https://registry.npmjs.org/protoduck/-/protoduck-4.0.0.tgz",
 									"integrity": "sha1-/kh02MeRM2bP2erRJFOiLNNlf44=",
-									"dev": true,
 									"requires": {
 										"genfun": "^4.0.1"
 									},
@@ -13702,8 +13028,7 @@
 										"genfun": {
 											"version": "4.0.1",
 											"resolved": "https://registry.npmjs.org/genfun/-/genfun-4.0.1.tgz",
-											"integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E=",
-											"dev": true
+											"integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E="
 										}
 									}
 								},
@@ -13711,7 +13036,6 @@
 									"version": "1.15.3",
 									"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.3.tgz",
 									"integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
-									"dev": true,
 									"requires": {
 										"chownr": "^1.0.1",
 										"mkdirp": "^0.5.1",
@@ -13723,7 +13047,6 @@
 											"version": "1.0.2",
 											"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
 											"integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
-											"dev": true,
 											"requires": {
 												"end-of-stream": "^1.1.0",
 												"once": "^1.3.1"
@@ -13733,7 +13056,6 @@
 													"version": "1.4.0",
 													"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
 													"integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-													"dev": true,
 													"requires": {
 														"once": "^1.4.0"
 													}
@@ -13746,7 +13068,6 @@
 									"version": "1.5.4",
 									"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
 									"integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
-									"dev": true,
 									"requires": {
 										"bl": "^1.0.0",
 										"end-of-stream": "^1.0.0",
@@ -13758,7 +13079,6 @@
 											"version": "1.2.1",
 											"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
 											"integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
-											"dev": true,
 											"requires": {
 												"readable-stream": "^2.0.5"
 											}
@@ -13767,7 +13087,6 @@
 											"version": "1.4.0",
 											"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
 											"integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-											"dev": true,
 											"requires": {
 												"once": "^1.4.0"
 											}
@@ -13775,8 +13094,7 @@
 										"xtend": {
 											"version": "4.0.1",
 											"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-											"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-											"dev": true
+											"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 										}
 									}
 								}
@@ -13785,20 +13103,17 @@
 						"path-is-inside": {
 							"version": "1.0.2",
 							"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-							"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-							"dev": true
+							"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
 						},
 						"promise-inflight": {
 							"version": "1.0.1",
 							"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-							"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
-							"dev": true
+							"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
 						},
 						"rc": {
 							"version": "1.2.8",
 							"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 							"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-							"dev": true,
 							"requires": {
 								"deep-extend": "^0.6.0",
 								"ini": "~1.3.0",
@@ -13810,7 +13125,6 @@
 							"version": "1.0.7",
 							"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
 							"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-							"dev": true,
 							"requires": {
 								"mute-stream": "~0.0.4"
 							},
@@ -13818,8 +13132,7 @@
 								"mute-stream": {
 									"version": "0.0.7",
 									"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-									"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-									"dev": true
+									"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 								}
 							}
 						},
@@ -13827,7 +13140,6 @@
 							"version": "1.0.1",
 							"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
 							"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
-							"dev": true,
 							"requires": {
 								"graceful-fs": "^4.1.2"
 							}
@@ -13836,7 +13148,6 @@
 							"version": "4.0.3",
 							"resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
 							"integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
-							"dev": true,
 							"requires": {
 								"debuglog": "^1.0.1",
 								"graceful-fs": "^4.1.2",
@@ -13850,8 +13161,7 @@
 								"util-extend": {
 									"version": "1.0.3",
 									"resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
-									"integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
-									"dev": true
+									"integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
 								}
 							}
 						},
@@ -13859,7 +13169,6 @@
 							"version": "2.0.9",
 							"resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.9.tgz",
 							"integrity": "sha512-vuV8p921IgyelL4UOKv3FsRuRZSaRn30HanLAOKargsr8TbBEq+I3MgloSRXYuKhNdYP1wlEGilMWAIayA2RFg==",
-							"dev": true,
 							"requires": {
 								"glob": "^7.1.1",
 								"graceful-fs": "^4.1.2",
@@ -13871,7 +13180,6 @@
 									"version": "1.0.3",
 									"resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
 									"integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
-									"dev": true,
 									"requires": {
 										"jju": "^1.1.0"
 									},
@@ -13879,8 +13187,7 @@
 										"jju": {
 											"version": "1.3.0",
 											"resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
-											"integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
-											"dev": true
+											"integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo="
 										}
 									}
 								}
@@ -13890,7 +13197,6 @@
 							"version": "5.1.6",
 							"resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.6.tgz",
 							"integrity": "sha512-FCX1aT3GWyY658wzDICef4p+n0dB+ENRct8E/Qyvppj6xVpOYerBHfUu7OP5Rt1/393Tdglguf5ju5DEX4wZNg==",
-							"dev": true,
 							"requires": {
 								"debuglog": "^1.0.1",
 								"dezalgo": "^1.0.0",
@@ -13903,7 +13209,6 @@
 							"version": "2.3.2",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
 							"integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
-							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
 								"inherits": "~2.0.3",
@@ -13917,26 +13222,22 @@
 								"core-util-is": {
 									"version": "1.0.2",
 									"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-									"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-									"dev": true
+									"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 								},
 								"isarray": {
 									"version": "1.0.0",
 									"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-									"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-									"dev": true
+									"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 								},
 								"process-nextick-args": {
 									"version": "1.0.7",
 									"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-									"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-									"dev": true
+									"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
 								},
 								"string_decoder": {
 									"version": "1.0.3",
 									"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 									"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-									"dev": true,
 									"requires": {
 										"safe-buffer": "~5.1.0"
 									}
@@ -13944,8 +13245,7 @@
 								"util-deprecate": {
 									"version": "1.0.2",
 									"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-									"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-									"dev": true
+									"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 								}
 							}
 						},
@@ -13953,7 +13253,6 @@
 							"version": "1.0.2",
 							"resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
 							"integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
-							"dev": true,
 							"requires": {
 								"debuglog": "^1.0.1",
 								"dezalgo": "^1.0.0",
@@ -13965,7 +13264,6 @@
 							"version": "2.81.0",
 							"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
 							"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-							"dev": true,
 							"requires": {
 								"aws-sign2": "~0.6.0",
 								"aws4": "^1.2.1",
@@ -13994,14 +13292,12 @@
 								"aws-sign2": {
 									"version": "0.6.0",
 									"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-									"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-									"dev": true
+									"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
 								},
 								"form-data": {
 									"version": "2.1.4",
 									"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
 									"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-									"dev": true,
 									"requires": {
 										"asynckit": "^0.4.0",
 										"combined-stream": "^1.0.5",
@@ -14012,7 +13308,6 @@
 									"version": "4.2.1",
 									"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
 									"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-									"dev": true,
 									"requires": {
 										"ajv": "^4.9.1",
 										"har-schema": "^1.0.5"
@@ -14022,7 +13317,6 @@
 									"version": "3.1.3",
 									"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
 									"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-									"dev": true,
 									"requires": {
 										"boom": "2.x.x",
 										"cryptiles": "2.x.x",
@@ -14034,7 +13328,6 @@
 									"version": "1.1.1",
 									"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
 									"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-									"dev": true,
 									"requires": {
 										"assert-plus": "^0.2.0",
 										"jsprim": "^1.2.2",
@@ -14044,34 +13337,29 @@
 								"performance-now": {
 									"version": "0.2.0",
 									"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-									"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-									"dev": true
+									"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
 								},
 								"qs": {
 									"version": "6.4.0",
 									"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-									"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-									"dev": true
+									"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
 								},
 								"stringstream": {
 									"version": "0.0.6",
 									"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-									"integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
-									"dev": true
+									"integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
 								}
 							}
 						},
 						"retry": {
 							"version": "0.10.1",
 							"resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-							"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
-							"dev": true
+							"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
 						},
 						"rimraf": {
 							"version": "2.6.1",
 							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 							"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-							"dev": true,
 							"requires": {
 								"glob": "^7.0.5"
 							}
@@ -14079,20 +13367,17 @@
 						"safe-buffer": {
 							"version": "5.1.1",
 							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-							"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-							"dev": true
+							"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
 						},
 						"semver": {
 							"version": "5.3.0",
 							"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-							"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-							"dev": true
+							"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
 						},
 						"sha": {
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
 							"integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
-							"dev": true,
 							"requires": {
 								"graceful-fs": "^4.1.2",
 								"readable-stream": "^2.0.2"
@@ -14101,20 +13386,17 @@
 						"slide": {
 							"version": "1.1.6",
 							"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-							"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-							"dev": true
+							"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
 						},
 						"sorted-object": {
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
-							"integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
-							"dev": true
+							"integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw="
 						},
 						"sorted-union-stream": {
 							"version": "2.1.3",
 							"resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
 							"integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
-							"dev": true,
 							"requires": {
 								"from2": "^1.3.0",
 								"stream-iterate": "^1.1.0"
@@ -14124,7 +13406,6 @@
 									"version": "1.3.0",
 									"resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
 									"integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
-									"dev": true,
 									"requires": {
 										"inherits": "~2.0.1",
 										"readable-stream": "~1.1.10"
@@ -14134,7 +13415,6 @@
 											"version": "1.1.14",
 											"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 											"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-											"dev": true,
 											"requires": {
 												"core-util-is": "~1.0.0",
 												"inherits": "~2.0.1",
@@ -14145,20 +13425,17 @@
 												"core-util-is": {
 													"version": "1.0.2",
 													"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-													"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-													"dev": true
+													"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 												},
 												"isarray": {
 													"version": "0.0.1",
 													"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-													"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-													"dev": true
+													"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 												},
 												"string_decoder": {
 													"version": "0.10.31",
 													"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-													"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-													"dev": true
+													"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 												}
 											}
 										}
@@ -14168,7 +13445,6 @@
 									"version": "1.2.0",
 									"resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
 									"integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
-									"dev": true,
 									"requires": {
 										"readable-stream": "^2.1.5",
 										"stream-shift": "^1.0.0"
@@ -14177,8 +13453,7 @@
 										"stream-shift": {
 											"version": "1.0.0",
 											"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-											"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-											"dev": true
+											"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
 										}
 									}
 								}
@@ -14188,7 +13463,6 @@
 							"version": "4.1.6",
 							"resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
 							"integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
-							"dev": true,
 							"requires": {
 								"safe-buffer": "^5.1.0"
 							}
@@ -14197,7 +13471,6 @@
 							"version": "4.0.0",
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							},
@@ -14205,8 +13478,7 @@
 								"ansi-regex": {
 									"version": "3.0.0",
 									"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-									"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-									"dev": true
+									"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 								}
 							}
 						},
@@ -14214,7 +13486,6 @@
 							"version": "2.2.1",
 							"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
 							"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-							"dev": true,
 							"requires": {
 								"block-stream": "*",
 								"fstream": "^1.0.2",
@@ -14225,7 +13496,6 @@
 									"version": "0.0.9",
 									"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
 									"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-									"dev": true,
 									"requires": {
 										"inherits": "~2.0.0"
 									}
@@ -14235,26 +13505,22 @@
 						"text-table": {
 							"version": "0.2.0",
 							"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-							"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-							"dev": true
+							"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
 						},
 						"uid-number": {
 							"version": "0.0.6",
 							"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-							"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-							"dev": true
+							"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
 						},
 						"umask": {
 							"version": "1.1.0",
 							"resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-							"integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
-							"dev": true
+							"integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0="
 						},
 						"unique-filename": {
 							"version": "1.1.0",
 							"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
 							"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
-							"dev": true,
 							"requires": {
 								"unique-slug": "^2.0.0"
 							},
@@ -14263,7 +13529,6 @@
 									"version": "2.0.0",
 									"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
 									"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
-									"dev": true,
 									"requires": {
 										"imurmurhash": "^0.1.4"
 									}
@@ -14273,14 +13538,12 @@
 						"unpipe": {
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-							"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-							"dev": true
+							"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
 						},
 						"update-notifier": {
 							"version": "2.2.0",
 							"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
 							"integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
-							"dev": true,
 							"requires": {
 								"boxen": "^1.0.0",
 								"chalk": "^1.0.0",
@@ -14296,7 +13559,6 @@
 									"version": "1.1.0",
 									"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz",
 									"integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI=",
-									"dev": true,
 									"requires": {
 										"ansi-align": "^2.0.0",
 										"camelcase": "^4.0.0",
@@ -14311,7 +13573,6 @@
 											"version": "2.0.0",
 											"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
 											"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-											"dev": true,
 											"requires": {
 												"string-width": "^2.0.0"
 											}
@@ -14319,20 +13580,17 @@
 										"camelcase": {
 											"version": "4.1.0",
 											"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-											"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-											"dev": true
+											"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 										},
 										"cli-boxes": {
 											"version": "1.0.0",
 											"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-											"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
-											"dev": true
+											"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
 										},
 										"string-width": {
 											"version": "2.1.0",
 											"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
 											"integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
-											"dev": true,
 											"requires": {
 												"is-fullwidth-code-point": "^2.0.0",
 												"strip-ansi": "^4.0.0"
@@ -14341,14 +13599,12 @@
 												"is-fullwidth-code-point": {
 													"version": "2.0.0",
 													"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-													"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-													"dev": true
+													"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 												},
 												"strip-ansi": {
 													"version": "4.0.0",
 													"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 													"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-													"dev": true,
 													"requires": {
 														"ansi-regex": "^3.0.0"
 													}
@@ -14359,7 +13615,6 @@
 											"version": "0.1.1",
 											"resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
 											"integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
-											"dev": true,
 											"requires": {
 												"execa": "^0.4.0"
 											},
@@ -14368,7 +13623,6 @@
 													"version": "0.4.0",
 													"resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
 													"integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
-													"dev": true,
 													"requires": {
 														"cross-spawn-async": "^2.1.1",
 														"is-stream": "^1.1.0",
@@ -14382,7 +13636,6 @@
 															"version": "2.2.5",
 															"resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
 															"integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
-															"dev": true,
 															"requires": {
 																"lru-cache": "^4.0.0",
 																"which": "^1.2.8"
@@ -14391,14 +13644,12 @@
 														"is-stream": {
 															"version": "1.1.0",
 															"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-															"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-															"dev": true
+															"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 														},
 														"npm-run-path": {
 															"version": "1.0.0",
 															"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
 															"integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
-															"dev": true,
 															"requires": {
 																"path-key": "^1.0.0"
 															}
@@ -14406,20 +13657,17 @@
 														"object-assign": {
 															"version": "4.1.1",
 															"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-															"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-															"dev": true
+															"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 														},
 														"path-key": {
 															"version": "1.0.0",
 															"resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
-															"integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
-															"dev": true
+															"integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68="
 														},
 														"strip-eof": {
 															"version": "1.0.0",
 															"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-															"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-															"dev": true
+															"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 														}
 													}
 												}
@@ -14429,7 +13677,6 @@
 											"version": "1.0.0",
 											"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
 											"integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
-											"dev": true,
 											"requires": {
 												"string-width": "^1.0.1"
 											},
@@ -14438,7 +13685,6 @@
 													"version": "1.0.2",
 													"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 													"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-													"dev": true,
 													"requires": {
 														"code-point-at": "^1.0.0",
 														"is-fullwidth-code-point": "^1.0.0",
@@ -14448,14 +13694,12 @@
 														"code-point-at": {
 															"version": "1.1.0",
 															"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-															"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-															"dev": true
+															"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 														},
 														"is-fullwidth-code-point": {
 															"version": "1.0.0",
 															"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 															"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-															"dev": true,
 															"requires": {
 																"number-is-nan": "^1.0.0"
 															},
@@ -14463,8 +13707,7 @@
 																"number-is-nan": {
 																	"version": "1.0.1",
 																	"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-																	"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-																	"dev": true
+																	"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 																}
 															}
 														},
@@ -14472,7 +13715,6 @@
 															"version": "3.0.1",
 															"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 															"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-															"dev": true,
 															"requires": {
 																"ansi-regex": "^2.0.0"
 															},
@@ -14480,8 +13722,7 @@
 																"ansi-regex": {
 																	"version": "2.1.1",
 																	"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-																	"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-																	"dev": true
+																	"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 																}
 															}
 														}
@@ -14495,7 +13736,6 @@
 									"version": "1.1.3",
 									"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 									"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-									"dev": true,
 									"requires": {
 										"ansi-styles": "^2.2.1",
 										"escape-string-regexp": "^1.0.2",
@@ -14507,20 +13747,17 @@
 										"ansi-styles": {
 											"version": "2.2.1",
 											"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-											"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-											"dev": true
+											"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 										},
 										"escape-string-regexp": {
 											"version": "1.0.5",
 											"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-											"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-											"dev": true
+											"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 										},
 										"has-ansi": {
 											"version": "2.0.0",
 											"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 											"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-											"dev": true,
 											"requires": {
 												"ansi-regex": "^2.0.0"
 											},
@@ -14528,8 +13765,7 @@
 												"ansi-regex": {
 													"version": "2.1.1",
 													"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-													"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-													"dev": true
+													"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 												}
 											}
 										},
@@ -14537,7 +13773,6 @@
 											"version": "3.0.1",
 											"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 											"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-											"dev": true,
 											"requires": {
 												"ansi-regex": "^2.0.0"
 											},
@@ -14545,16 +13780,14 @@
 												"ansi-regex": {
 													"version": "2.1.1",
 													"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-													"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-													"dev": true
+													"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 												}
 											}
 										},
 										"supports-color": {
 											"version": "2.0.0",
 											"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-											"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-											"dev": true
+											"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 										}
 									}
 								},
@@ -14562,7 +13795,6 @@
 									"version": "3.1.0",
 									"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz",
 									"integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE=",
-									"dev": true,
 									"requires": {
 										"dot-prop": "^4.1.0",
 										"graceful-fs": "^4.1.2",
@@ -14576,7 +13808,6 @@
 											"version": "4.1.1",
 											"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
 											"integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
-											"dev": true,
 											"requires": {
 												"is-obj": "^1.0.0"
 											},
@@ -14584,8 +13815,7 @@
 												"is-obj": {
 													"version": "1.0.1",
 													"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-													"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-													"dev": true
+													"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
 												}
 											}
 										},
@@ -14593,7 +13823,6 @@
 											"version": "1.0.0",
 											"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
 											"integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
-											"dev": true,
 											"requires": {
 												"pify": "^2.3.0"
 											},
@@ -14601,8 +13830,7 @@
 												"pify": {
 													"version": "2.3.0",
 													"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-													"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-													"dev": true
+													"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 												}
 											}
 										},
@@ -14610,7 +13838,6 @@
 											"version": "1.0.0",
 											"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
 											"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-											"dev": true,
 											"requires": {
 												"crypto-random-string": "^1.0.0"
 											},
@@ -14618,8 +13845,7 @@
 												"crypto-random-string": {
 													"version": "1.0.0",
 													"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-													"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-													"dev": true
+													"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
 												}
 											}
 										}
@@ -14628,20 +13854,17 @@
 								"import-lazy": {
 									"version": "2.1.0",
 									"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-									"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
-									"dev": true
+									"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
 								},
 								"is-npm": {
 									"version": "1.0.0",
 									"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-									"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
-									"dev": true
+									"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
 								},
 								"latest-version": {
 									"version": "3.1.0",
 									"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
 									"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-									"dev": true,
 									"requires": {
 										"package-json": "^4.0.0"
 									},
@@ -14650,7 +13873,6 @@
 											"version": "4.0.1",
 											"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
 											"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-											"dev": true,
 											"requires": {
 												"got": "^6.7.1",
 												"registry-auth-token": "^3.0.1",
@@ -14662,7 +13884,6 @@
 													"version": "6.7.1",
 													"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
 													"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-													"dev": true,
 													"requires": {
 														"create-error-class": "^3.0.0",
 														"duplexer3": "^0.1.4",
@@ -14681,7 +13902,6 @@
 															"version": "3.0.2",
 															"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
 															"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-															"dev": true,
 															"requires": {
 																"capture-stack-trace": "^1.0.0"
 															},
@@ -14689,64 +13909,54 @@
 																"capture-stack-trace": {
 																	"version": "1.0.0",
 																	"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-																	"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-																	"dev": true
+																	"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
 																}
 															}
 														},
 														"duplexer3": {
 															"version": "0.1.4",
 															"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-															"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-															"dev": true
+															"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
 														},
 														"get-stream": {
 															"version": "3.0.0",
 															"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-															"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-															"dev": true
+															"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 														},
 														"is-redirect": {
 															"version": "1.0.0",
 															"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-															"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-															"dev": true
+															"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
 														},
 														"is-retry-allowed": {
 															"version": "1.1.0",
 															"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-															"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-															"dev": true
+															"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
 														},
 														"is-stream": {
 															"version": "1.1.0",
 															"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-															"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-															"dev": true
+															"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 														},
 														"lowercase-keys": {
 															"version": "1.0.0",
 															"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-															"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-															"dev": true
+															"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
 														},
 														"timed-out": {
 															"version": "4.0.1",
 															"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-															"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-															"dev": true
+															"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 														},
 														"unzip-response": {
 															"version": "2.0.1",
 															"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-															"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-															"dev": true
+															"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
 														},
 														"url-parse-lax": {
 															"version": "1.0.0",
 															"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
 															"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-															"dev": true,
 															"requires": {
 																"prepend-http": "^1.0.1"
 															},
@@ -14754,8 +13964,7 @@
 																"prepend-http": {
 																	"version": "1.0.4",
 																	"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-																	"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-																	"dev": true
+																	"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
 																}
 															}
 														}
@@ -14765,7 +13974,6 @@
 													"version": "3.3.1",
 													"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
 													"integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
-													"dev": true,
 													"requires": {
 														"rc": "^1.1.6",
 														"safe-buffer": "^5.0.1"
@@ -14775,7 +13983,6 @@
 													"version": "3.1.0",
 													"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 													"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-													"dev": true,
 													"requires": {
 														"rc": "^1.0.1"
 													},
@@ -14784,7 +13991,6 @@
 															"version": "1.2.8",
 															"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 															"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-															"dev": true,
 															"requires": {
 																"deep-extend": "^0.6.0",
 																"ini": "~1.3.0",
@@ -14802,7 +14008,6 @@
 									"version": "2.1.0",
 									"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
 									"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-									"dev": true,
 									"requires": {
 										"semver": "^5.0.3"
 									}
@@ -14810,22 +14015,19 @@
 								"xdg-basedir": {
 									"version": "3.0.0",
 									"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-									"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-									"dev": true
+									"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
 								}
 							}
 						},
 						"uuid": {
 							"version": "3.1.0",
 							"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-							"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-							"dev": true
+							"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
 						},
 						"validate-npm-package-license": {
 							"version": "3.0.1",
 							"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
 							"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-							"dev": true,
 							"requires": {
 								"spdx-correct": "~1.0.0",
 								"spdx-expression-parse": "~1.0.0"
@@ -14835,7 +14037,6 @@
 									"version": "1.0.2",
 									"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
 									"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-									"dev": true,
 									"requires": {
 										"spdx-license-ids": "^1.0.2"
 									},
@@ -14843,16 +14044,14 @@
 										"spdx-license-ids": {
 											"version": "1.2.2",
 											"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-											"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-											"dev": true
+											"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
 										}
 									}
 								},
 								"spdx-expression-parse": {
 									"version": "1.0.4",
 									"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-									"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-									"dev": true
+									"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
 								}
 							}
 						},
@@ -14860,7 +14059,6 @@
 							"version": "3.0.0",
 							"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
 							"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
-							"dev": true,
 							"requires": {
 								"builtins": "^1.0.3"
 							},
@@ -14868,8 +14066,7 @@
 								"builtins": {
 									"version": "1.0.3",
 									"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-									"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
-									"dev": true
+									"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
 								}
 							}
 						},
@@ -14877,7 +14074,6 @@
 							"version": "1.2.14",
 							"resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
 							"integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-							"dev": true,
 							"requires": {
 								"isexe": "^2.0.0"
 							},
@@ -14885,8 +14081,7 @@
 								"isexe": {
 									"version": "2.0.0",
 									"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-									"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-									"dev": true
+									"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 								}
 							}
 						},
@@ -14894,7 +14089,6 @@
 							"version": "1.3.1",
 							"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.1.tgz",
 							"integrity": "sha1-QzMRK7SbF6oFC4eJXKayys9A5f8=",
-							"dev": true,
 							"requires": {
 								"errno": ">=0.1.1 <0.2.0-0",
 								"xtend": ">=4.0.0 <4.1.0-0"
@@ -14904,7 +14098,6 @@
 									"version": "0.1.4",
 									"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
 									"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-									"dev": true,
 									"requires": {
 										"prr": "~0.0.0"
 									},
@@ -14912,30 +14105,26 @@
 										"prr": {
 											"version": "0.0.0",
 											"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-											"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
-											"dev": true
+											"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
 										}
 									}
 								},
 								"xtend": {
 									"version": "4.0.1",
 									"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-									"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-									"dev": true
+									"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 								}
 							}
 						},
 						"wrappy": {
 							"version": "1.0.2",
 							"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-							"dev": true
+							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 						},
 						"write-file-atomic": {
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
 							"integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
-							"dev": true,
 							"requires": {
 								"graceful-fs": "^4.1.11",
 								"imurmurhash": "^0.1.4",
@@ -14945,8 +14134,7 @@
 						"y18n": {
 							"version": "3.2.1",
 							"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-							"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-							"dev": true
+							"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 						}
 					}
 				},
@@ -14954,7 +14142,6 @@
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
 					"integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
-					"dev": true,
 					"requires": {
 						"hosted-git-info": "^2.6.0",
 						"osenv": "^0.1.5",
@@ -14966,7 +14153,6 @@
 					"version": "2.0.2",
 					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-					"dev": true,
 					"requires": {
 						"path-key": "^2.0.0"
 					}
@@ -14974,8 +14160,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-					"dev": true
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 				},
 				"once": {
 					"version": "1.4.0",
@@ -14988,14 +14173,12 @@
 				"os-homedir": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-					"dev": true
+					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 				},
 				"os-locale": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-					"dev": true,
 					"requires": {
 						"execa": "^0.7.0",
 						"lcid": "^1.0.0",
@@ -15005,14 +14188,12 @@
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-					"dev": true
+					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 				},
 				"osenv": {
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-					"dev": true,
 					"requires": {
 						"os-homedir": "^1.0.0",
 						"os-tmpdir": "^1.0.0"
@@ -15021,14 +14202,12 @@
 				"p-finally": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-					"dev": true
+					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 				},
 				"p-limit": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
 					"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-					"dev": true,
 					"requires": {
 						"p-try": "^1.0.0"
 					}
@@ -15037,7 +14216,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
 					}
@@ -15045,14 +14223,12 @@
 				"p-try": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-					"dev": true
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 				},
 				"package-json": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
 					"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-					"dev": true,
 					"requires": {
 						"got": "^6.7.1",
 						"registry-auth-token": "^3.0.1",
@@ -15063,8 +14239,7 @@
 				"path-exists": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
@@ -15074,26 +14249,22 @@
 				"path-is-inside": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-					"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-					"dev": true
+					"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
 				},
 				"path-key": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-					"dev": true
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 				},
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				},
 				"prepend-http": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-					"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-					"dev": true
+					"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
 				},
 				"pseudomap": {
 					"version": "1.0.2",
@@ -15111,8 +14282,8 @@
 				},
 				"rc": {
 					"version": "1.2.6",
-					"resolved": "",
-					"dev": true,
+					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
+					"integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
 					"requires": {
 						"deep-extend": "~0.4.0",
 						"ini": "~1.3.0",
@@ -15124,7 +14295,6 @@
 					"version": "3.3.2",
 					"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
 					"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-					"dev": true,
 					"requires": {
 						"rc": "^1.1.6",
 						"safe-buffer": "^5.0.1"
@@ -15134,7 +14304,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 					"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-					"dev": true,
 					"requires": {
 						"rc": "^1.0.1"
 					}
@@ -15163,14 +14332,12 @@
 				"require-directory": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-					"dev": true
+					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-					"dev": true
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 				},
 				"rimraf": {
 					"version": "2.6.2",
@@ -15188,14 +14355,12 @@
 				"semver": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-					"dev": true
+					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
 				},
 				"semver-diff": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
 					"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-					"dev": true,
 					"requires": {
 						"semver": "^5.0.3"
 					}
@@ -15203,14 +14368,12 @@
 				"set-blocking": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-					"dev": true
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 				},
 				"shebang-command": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
 					}
@@ -15218,14 +14381,12 @@
 				"shebang-regex": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-					"dev": true
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-					"dev": true
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 				},
 				"ssri": {
 					"version": "4.1.6",
@@ -15239,7 +14400,6 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -15249,7 +14409,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -15257,20 +14416,17 @@
 				"strip-eof": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-					"dev": true
+					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-					"dev": true
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 				},
 				"supports-color": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -15279,7 +14435,6 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
 					"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-					"dev": true,
 					"requires": {
 						"execa": "^0.7.0"
 					}
@@ -15287,14 +14442,12 @@
 				"timed-out": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-					"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-					"dev": true
+					"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 				},
 				"unique-string": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
 					"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-					"dev": true,
 					"requires": {
 						"crypto-random-string": "^1.0.0"
 					}
@@ -15302,14 +14455,12 @@
 				"unzip-response": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-					"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-					"dev": true
+					"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
 				},
 				"update-notifier": {
 					"version": "2.4.0",
 					"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.4.0.tgz",
 					"integrity": "sha1-+bTHAPv9TsEsgRWHJYd31WPYyGY=",
-					"dev": true,
 					"requires": {
 						"boxen": "^1.2.1",
 						"chalk": "^2.0.1",
@@ -15327,7 +14478,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
 					"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-					"dev": true,
 					"requires": {
 						"prepend-http": "^1.0.1"
 					}
@@ -15336,7 +14486,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
 					"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
-					"dev": true,
 					"requires": {
 						"builtins": "^1.0.3"
 					}
@@ -15345,7 +14494,6 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 					"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -15353,14 +14501,12 @@
 				"which-module": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-					"dev": true
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 				},
 				"widest-line": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
 					"integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
-					"dev": true,
 					"requires": {
 						"string-width": "^2.1.1"
 					}
@@ -15369,7 +14515,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1"
@@ -15378,14 +14523,12 @@
 						"ansi-regex": {
 							"version": "2.1.1",
 							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-							"dev": true
+							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-							"dev": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -15394,7 +14537,6 @@
 							"version": "1.0.2",
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -15405,7 +14547,6 @@
 							"version": "3.0.1",
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-							"dev": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -15421,7 +14562,6 @@
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 					"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
 						"imurmurhash": "^0.1.4",
@@ -15431,14 +14571,12 @@
 				"xdg-basedir": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-					"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-					"dev": true
+					"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
 				},
 				"y18n": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-					"dev": true
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 				},
 				"yallist": {
 					"version": "2.1.2",
@@ -15449,7 +14587,6 @@
 					"version": "11.0.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
 					"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
-					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^1.1.1",
@@ -15468,8 +14605,7 @@
 						"y18n": {
 							"version": "3.2.1",
 							"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-							"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-							"dev": true
+							"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 						}
 					}
 				},
@@ -15477,7 +14613,6 @@
 					"version": "9.0.2",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
 					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
 					}
@@ -15488,7 +14623,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
 			"integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-			"dev": true,
 			"requires": {
 				"boolbase": "~1.0.0"
 			}
@@ -15496,14 +14630,12 @@
 		"num2fraction": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
-			"dev": true
+			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
 		},
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"dev": true
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"oauth-sign": {
 			"version": "0.8.2",
@@ -15513,14 +14645,12 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-			"dev": true,
 			"requires": {
 				"copy-descriptor": "^0.1.0",
 				"define-property": "^0.2.5",
@@ -15531,30 +14661,31 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
 				}
 			}
 		},
+		"object-inspect": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+			"integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
+		},
 		"object-keys": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-			"dev": true
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
 		},
 		"object-values": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/object-values/-/object-values-1.0.0.tgz",
-			"integrity": "sha1-cq+DljARnluYw7AruMJ+MjcVgQU=",
-			"dev": true
+			"integrity": "sha1-cq+DljARnluYw7AruMJ+MjcVgQU="
 		},
 		"object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.0"
 			}
@@ -15563,7 +14694,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
 			"integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.6.1",
@@ -15575,7 +14705,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.5.1"
@@ -15585,7 +14714,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"dev": true,
 			"requires": {
 				"for-own": "^0.1.4",
 				"is-extendable": "^0.1.1"
@@ -15595,7 +14723,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			}
@@ -15604,7 +14731,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
 			"integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.6.1",
@@ -15616,7 +14742,6 @@
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/observable-to-promise/-/observable-to-promise-0.5.0.tgz",
 			"integrity": "sha1-yCjw8NxH6fhq+KSXfF1VB2znqR8=",
-			"dev": true,
 			"requires": {
 				"is-observable": "^0.2.0",
 				"symbol-observable": "^1.0.4"
@@ -15626,7 +14751,6 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/octicons/-/octicons-6.0.1.tgz",
 			"integrity": "sha512-NaLn2khboD1Teg2TGQnu618FbmMedt19XKy9EaRNirBK36U/HntlvwgDvAkxgUien+f8NUeKBpBunxweIK4cCQ==",
-			"dev": true,
 			"requires": {
 				"object-assign": "^4.1.1"
 			}
@@ -15635,7 +14759,6 @@
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/octokat/-/octokat-0.4.18.tgz",
 			"integrity": "sha1-r6flJlS1Rkkj+AGRezoxz/emhI0=",
-			"dev": true,
 			"requires": {
 				"es6-promise": "3.0.2",
 				"xmlhttprequest": "~1.8.0"
@@ -15645,7 +14768,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
 			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-			"dev": true,
 			"requires": {
 				"ee-first": "1.1.1"
 			}
@@ -15661,14 +14783,12 @@
 		"onecolor": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/onecolor/-/onecolor-3.0.5.tgz",
-			"integrity": "sha1-Nu/zIgE3nv3xGA+0ReUajiQl+fY=",
-			"dev": true
+			"integrity": "sha1-Nu/zIgE3nv3xGA+0ReUajiQl+fY="
 		},
 		"onetime": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-			"dev": true,
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
@@ -15677,7 +14797,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/opn/-/opn-5.2.0.tgz",
 			"integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
-			"dev": true,
 			"requires": {
 				"is-wsl": "^1.1.0"
 			}
@@ -15686,7 +14805,6 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-			"dev": true,
 			"requires": {
 				"minimist": "~0.0.1",
 				"wordwrap": "~0.0.2"
@@ -15695,14 +14813,32 @@
 		"option-chain": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/option-chain/-/option-chain-1.0.0.tgz",
-			"integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI=",
-			"dev": true
+			"integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI="
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"requires": {
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+				}
+			}
 		},
 		"original": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
 			"integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
-			"dev": true,
 			"requires": {
 				"url-parse": "^1.4.3"
 			}
@@ -15710,20 +14846,17 @@
 		"os-browserify": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
-			"dev": true
+			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
 		},
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-			"dev": true
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-			"dev": true,
 			"requires": {
 				"execa": "^0.7.0",
 				"lcid": "^1.0.0",
@@ -15734,7 +14867,6 @@
 					"version": "0.7.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -15751,7 +14883,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
 			"integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
-			"dev": true,
 			"requires": {
 				"macos-release": "^1.0.0",
 				"win-release": "^1.0.0"
@@ -15760,20 +14891,17 @@
 		"os-shim": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-			"integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
-			"dev": true
+			"integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc="
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
 		"osenv": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.0"
@@ -15783,7 +14911,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/p-any/-/p-any-1.1.0.tgz",
 			"integrity": "sha512-Ef0tVa4CZ5pTAmKn+Cg3w8ABBXh+hHO1aV8281dKOoUHfX+3tjG2EaFcC+aZyagg9b4EYGsHEjz21DnEE8Og2g==",
-			"dev": true,
 			"requires": {
 				"p-some": "^2.0.0"
 			}
@@ -15791,26 +14918,22 @@
 		"p-cancelable": {
 			"version": "0.4.1",
 			"resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
-			"integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
-			"dev": true
+			"integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
 		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"dev": true
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-is-promise": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
-			"dev": true
+			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
 		},
 		"p-limit": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
 			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-			"dev": true,
 			"requires": {
 				"p-try": "^1.0.0"
 			}
@@ -15819,7 +14942,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-			"dev": true,
 			"requires": {
 				"p-limit": "^1.1.0"
 			}
@@ -15827,14 +14949,12 @@
 		"p-map": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
-			"dev": true
+			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
 		},
 		"p-some": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/p-some/-/p-some-2.0.1.tgz",
 			"integrity": "sha1-Zdh8ixVO289SIdFnd4ttLhUPbwY=",
-			"dev": true,
 			"requires": {
 				"aggregate-error": "^1.0.0"
 			}
@@ -15843,7 +14963,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
 			"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
-			"dev": true,
 			"requires": {
 				"p-finally": "^1.0.0"
 			}
@@ -15851,14 +14970,12 @@
 		"p-try": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-			"dev": true
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 		},
 		"package-hash": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
 			"integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"lodash.flattendeep": "^4.4.0",
@@ -15870,7 +14987,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
 			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-			"dev": true,
 			"requires": {
 				"got": "^6.7.1",
 				"registry-auth-token": "^3.0.1",
@@ -15881,14 +14997,12 @@
 		"pad-component": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/pad-component/-/pad-component-0.0.1.tgz",
-			"integrity": "sha1-rR8izhvw/cDW3dkIrxfzUaQEuKw=",
-			"dev": true
+			"integrity": "sha1-rR8izhvw/cDW3dkIrxfzUaQEuKw="
 		},
 		"pako": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
-			"dev": true
+			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
 		},
 		"parallel-transform": {
 			"version": "1.1.0",
@@ -15904,7 +15018,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
 			"integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-			"dev": true,
 			"requires": {
 				"no-case": "^2.2.0"
 			}
@@ -15913,7 +15026,6 @@
 			"version": "5.1.1",
 			"resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
 			"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
-			"dev": true,
 			"requires": {
 				"asn1.js": "^4.0.0",
 				"browserify-aes": "^1.0.0",
@@ -15926,7 +15038,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.2.tgz",
 			"integrity": "sha512-5N9lmQ7tmxfXf+hO3X6KRG6w7uYO/HL9fHalSySTdyn63C3WNvTM/1R8tn1u1larNcEbo3Slcy2bsVDQqvEpUg==",
-			"dev": true,
 			"requires": {
 				"character-entities": "^1.0.0",
 				"character-entities-legacy": "^1.0.0",
@@ -15939,14 +15050,12 @@
 		"parse-github-repo-url": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
-			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
-			"dev": true
+			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A="
 		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"dev": true,
 			"requires": {
 				"glob-base": "^0.3.0",
 				"is-dotfile": "^1.0.0",
@@ -15957,14 +15066,12 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -15975,7 +15082,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-help/-/parse-help-1.0.0.tgz",
 			"integrity": "sha512-dlOrbBba6Rrw/nrJ+V7/vkGZdiimWJQzMHZZrYsUq03JE8AV3fAv6kOYX7dP/w2h67lIdmRf8ES8mU44xAgE/Q==",
-			"dev": true,
 			"requires": {
 				"execall": "^1.0.0"
 			}
@@ -15984,7 +15090,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-			"dev": true,
 			"requires": {
 				"error-ex": "^1.3.1",
 				"json-parse-better-errors": "^1.0.1"
@@ -15993,38 +15098,32 @@
 		"parse-ms": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-			"integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
-			"dev": true
+			"integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0="
 		},
 		"parse-pairs": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/parse-pairs/-/parse-pairs-0.2.2.tgz",
-			"integrity": "sha1-htPMkPpNOs1AO1VW9o2fzSCMOr4=",
-			"dev": true
+			"integrity": "sha1-htPMkPpNOs1AO1VW9o2fzSCMOr4="
 		},
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-			"dev": true
+			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
 		},
 		"parseurl": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
-			"dev": true
+			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
 		},
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-			"dev": true
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
 		},
 		"passwd-user": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/passwd-user/-/passwd-user-2.1.0.tgz",
 			"integrity": "sha1-+tnbauJS+LCI4MXezSCn2gxdnx4=",
-			"dev": true,
 			"requires": {
 				"execa": "^0.4.0",
 				"pify": "^2.3.0"
@@ -16034,7 +15133,6 @@
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
 					"integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
-					"dev": true,
 					"requires": {
 						"cross-spawn-async": "^2.1.1",
 						"is-stream": "^1.1.0",
@@ -16048,7 +15146,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
 					"integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
-					"dev": true,
 					"requires": {
 						"path-key": "^1.0.0"
 					}
@@ -16056,40 +15153,34 @@
 				"path-key": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
-					"integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
-					"dev": true
+					"integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68="
 				},
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
 		},
 		"path-browserify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
-			"dev": true
+			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
 		},
 		"path-dirname": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-			"dev": true
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
 		},
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 		},
 		"path-format": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/path-format/-/path-format-1.2.1.tgz",
 			"integrity": "sha1-qkyffE3odLJP+rxCH7KygG68/VE=",
-			"dev": true,
 			"requires": {
 				"is-object": "^1.0.1",
 				"is-string": "^1.0.4"
@@ -16103,32 +15194,27 @@
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-			"dev": true
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
 		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-			"dev": true
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 		},
 		"path-parse": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-			"dev": true
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-			"dev": true
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
 		},
 		"path-type": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-			"dev": true,
 			"requires": {
 				"pify": "^3.0.0"
 			}
@@ -16137,7 +15223,6 @@
 			"version": "0.0.11",
 			"resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
 			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-			"dev": true,
 			"requires": {
 				"through": "~2.3"
 			}
@@ -16146,7 +15231,6 @@
 			"version": "3.0.16",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
 			"integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
-			"dev": true,
 			"requires": {
 				"create-hash": "^1.1.2",
 				"create-hmac": "^1.1.4",
@@ -16158,26 +15242,22 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"pify": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-			"dev": true
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-			"dev": true
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"dev": true,
 			"requires": {
 				"pinkie": "^2.0.0"
 			}
@@ -16186,7 +15266,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pipetteur/-/pipetteur-2.0.3.tgz",
 			"integrity": "sha1-GVV2CVno0aEcsqUOyD7sRwYz5J8=",
-			"dev": true,
 			"requires": {
 				"onecolor": "^3.0.4",
 				"synesthesia": "^1.0.1"
@@ -16196,7 +15275,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
 			"integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
-			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
 				"load-json-file": "^4.0.0"
@@ -16206,7 +15284,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -16220,7 +15297,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-			"dev": true,
 			"requires": {
 				"find-up": "^2.1.0"
 			}
@@ -16229,7 +15305,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
 			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
-			"dev": true,
 			"requires": {
 				"find-up": "^2.1.0"
 			}
@@ -16238,22 +15313,24 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
 			"integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
-			"dev": true,
 			"requires": {
 				"irregular-plurals": "^1.0.0"
 			}
 		},
+		"pluralize": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+			"integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU="
+		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-			"dev": true
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
 		},
 		"postcss": {
 			"version": "5.2.18",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 			"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3",
 				"js-base64": "^2.1.9",
@@ -16264,14 +15341,12 @@
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -16283,28 +15358,24 @@
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-							"dev": true
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
 					"requires": {
 						"has-flag": "^1.0.0"
 					}
@@ -16315,7 +15386,6 @@
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
 			"integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
-			"dev": true,
 			"requires": {
 				"postcss": "^5.0.2",
 				"postcss-message-helpers": "^2.0.0",
@@ -16326,7 +15396,6 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
 			"integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
-			"dev": true,
 			"requires": {
 				"colormin": "^1.0.5",
 				"postcss": "^5.0.13",
@@ -16337,7 +15406,6 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
 			"integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
-			"dev": true,
 			"requires": {
 				"postcss": "^5.0.11",
 				"postcss-value-parser": "^3.1.2"
@@ -16347,7 +15415,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
 			"integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
-			"dev": true,
 			"requires": {
 				"postcss": "^5.0.14"
 			}
@@ -16356,7 +15423,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
 			"integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
-			"dev": true,
 			"requires": {
 				"postcss": "^5.0.4"
 			}
@@ -16365,7 +15431,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
 			"integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
-			"dev": true,
 			"requires": {
 				"postcss": "^5.0.14"
 			}
@@ -16374,7 +15439,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
 			"integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
-			"dev": true,
 			"requires": {
 				"postcss": "^5.0.16"
 			}
@@ -16383,7 +15447,6 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
 			"integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
-			"dev": true,
 			"requires": {
 				"postcss": "^5.0.14",
 				"uniqs": "^2.0.0"
@@ -16393,7 +15456,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
 			"integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
-			"dev": true,
 			"requires": {
 				"postcss": "^5.0.4",
 				"uniqid": "^4.0.0"
@@ -16403,7 +15465,6 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-3.3.1.tgz",
 			"integrity": "sha512-9y9kDDf2F9EjKX6x9ueNa5GARvsUbXw4ezH8vXItXHwKzljbu8awP7t5dCaabKYm18Vs1lo5bKQcnc0HkISt+w==",
-			"dev": true,
 			"requires": {
 				"postcss": "^6.0.1"
 			},
@@ -16412,7 +15473,6 @@
 					"version": "6.0.22",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
 					"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
 						"source-map": "^0.6.1",
@@ -16422,16 +15482,22 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
+			}
+		},
+		"postcss-less": {
+			"version": "0.14.0",
+			"resolved": "http://registry.npmjs.org/postcss-less/-/postcss-less-0.14.0.tgz",
+			"integrity": "sha1-xjGwicbM5CK5oQ86lY0r7dOBkyQ=",
+			"requires": {
+				"postcss": "^5.0.21"
 			}
 		},
 		"postcss-load-config": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
 			"integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
-			"dev": true,
 			"requires": {
 				"cosmiconfig": "^2.1.0",
 				"object-assign": "^4.1.0",
@@ -16443,7 +15509,6 @@
 					"version": "2.2.2",
 					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
 					"integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
-					"dev": true,
 					"requires": {
 						"is-directory": "^0.3.1",
 						"js-yaml": "^3.4.3",
@@ -16457,14 +15522,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"parse-json": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
@@ -16472,8 +15535,7 @@
 				"require-from-string": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-					"integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
-					"dev": true
+					"integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
 				}
 			}
 		},
@@ -16481,7 +15543,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
 			"integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
-			"dev": true,
 			"requires": {
 				"cosmiconfig": "^2.1.0",
 				"object-assign": "^4.1.0"
@@ -16491,7 +15552,6 @@
 					"version": "2.2.2",
 					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
 					"integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
-					"dev": true,
 					"requires": {
 						"is-directory": "^0.3.1",
 						"js-yaml": "^3.4.3",
@@ -16505,14 +15565,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"parse-json": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
@@ -16520,8 +15578,7 @@
 				"require-from-string": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-					"integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
-					"dev": true
+					"integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
 				}
 			}
 		},
@@ -16529,7 +15586,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
 			"integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
-			"dev": true,
 			"requires": {
 				"cosmiconfig": "^2.1.1",
 				"object-assign": "^4.1.0"
@@ -16539,7 +15595,6 @@
 					"version": "2.2.2",
 					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
 					"integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
-					"dev": true,
 					"requires": {
 						"is-directory": "^0.3.1",
 						"js-yaml": "^3.4.3",
@@ -16553,14 +15608,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"parse-json": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
@@ -16568,8 +15621,7 @@
 				"require-from-string": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-					"integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
-					"dev": true
+					"integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
 				}
 			}
 		},
@@ -16577,7 +15629,6 @@
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.1.5.tgz",
 			"integrity": "sha512-pV7kB5neJ0/1tZ8L1uGOBNTVBCSCXQoIsZMsrwvO8V2rKGa2tBl/f80GGVxow2jJnRJ2w1ocx693EKhZAb9Isg==",
-			"dev": true,
 			"requires": {
 				"loader-utils": "^1.1.0",
 				"postcss": "^6.0.0",
@@ -16589,7 +15640,6 @@
 					"version": "6.0.22",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
 					"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
 						"source-map": "^0.6.1",
@@ -16599,22 +15649,19 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-media-query-parser": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
-			"integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
-			"dev": true
+			"integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ="
 		},
 		"postcss-merge-idents": {
 			"version": "2.1.7",
 			"resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
 			"integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
-			"dev": true,
 			"requires": {
 				"has": "^1.0.1",
 				"postcss": "^5.0.10",
@@ -16625,7 +15672,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
 			"integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
-			"dev": true,
 			"requires": {
 				"postcss": "^5.0.4"
 			}
@@ -16634,7 +15680,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
 			"integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
-			"dev": true,
 			"requires": {
 				"browserslist": "^1.5.2",
 				"caniuse-api": "^1.5.2",
@@ -16647,7 +15692,6 @@
 					"version": "2.2.3",
 					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
 					"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-					"dev": true,
 					"requires": {
 						"flatten": "^1.0.2",
 						"indexes-of": "^1.0.1",
@@ -16659,14 +15703,12 @@
 		"postcss-message-helpers": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
-			"integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
-			"dev": true
+			"integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4="
 		},
 		"postcss-minify-font-values": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
 			"integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
-			"dev": true,
 			"requires": {
 				"object-assign": "^4.0.1",
 				"postcss": "^5.0.4",
@@ -16677,7 +15719,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
 			"integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
-			"dev": true,
 			"requires": {
 				"postcss": "^5.0.12",
 				"postcss-value-parser": "^3.3.0"
@@ -16687,7 +15728,6 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
 			"integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
-			"dev": true,
 			"requires": {
 				"alphanum-sort": "^1.0.1",
 				"postcss": "^5.0.2",
@@ -16699,7 +15739,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
 			"integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
-			"dev": true,
 			"requires": {
 				"alphanum-sort": "^1.0.2",
 				"has": "^1.0.1",
@@ -16711,7 +15750,6 @@
 					"version": "2.2.3",
 					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
 					"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-					"dev": true,
 					"requires": {
 						"flatten": "^1.0.2",
 						"indexes-of": "^1.0.1",
@@ -16724,7 +15762,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
 			"integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
-			"dev": true,
 			"requires": {
 				"postcss": "^6.0.1"
 			},
@@ -16733,7 +15770,6 @@
 					"version": "6.0.22",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
 					"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
 						"source-map": "^0.6.1",
@@ -16743,8 +15779,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -16752,7 +15787,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
 			"integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
-			"dev": true,
 			"requires": {
 				"css-selector-tokenizer": "^0.7.0",
 				"postcss": "^6.0.1"
@@ -16762,7 +15796,6 @@
 					"version": "6.0.22",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
 					"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
 						"source-map": "^0.6.1",
@@ -16772,8 +15805,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -16781,7 +15813,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
 			"integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
-			"dev": true,
 			"requires": {
 				"css-selector-tokenizer": "^0.7.0",
 				"postcss": "^6.0.1"
@@ -16791,7 +15822,6 @@
 					"version": "6.0.22",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
 					"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
 						"source-map": "^0.6.1",
@@ -16801,8 +15831,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -16810,7 +15839,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
 			"integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
-			"dev": true,
 			"requires": {
 				"icss-replace-symbols": "^1.1.0",
 				"postcss": "^6.0.1"
@@ -16820,7 +15848,6 @@
 					"version": "6.0.22",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
 					"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
 						"source-map": "^0.6.1",
@@ -16830,8 +15857,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -16839,7 +15865,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
 			"integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
-			"dev": true,
 			"requires": {
 				"postcss": "^5.0.5"
 			}
@@ -16848,7 +15873,6 @@
 			"version": "3.0.8",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
 			"integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
-			"dev": true,
 			"requires": {
 				"is-absolute-url": "^2.0.0",
 				"normalize-url": "^1.4.0",
@@ -16860,7 +15884,6 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
 			"integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
-			"dev": true,
 			"requires": {
 				"postcss": "^5.0.4",
 				"postcss-value-parser": "^3.0.1"
@@ -16870,7 +15893,6 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
 			"integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
-			"dev": true,
 			"requires": {
 				"postcss": "^5.0.4",
 				"postcss-value-parser": "^3.0.2"
@@ -16880,7 +15902,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
 			"integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
-			"dev": true,
 			"requires": {
 				"postcss": "^5.0.4"
 			}
@@ -16889,33 +15910,80 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
 			"integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
-			"dev": true,
 			"requires": {
 				"has": "^1.0.1",
 				"postcss": "^5.0.8",
 				"postcss-value-parser": "^3.0.1"
 			}
 		},
+		"postcss-reporter": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-1.4.1.tgz",
+			"integrity": "sha1-wTbwpbFhkV83ndN2XGEHX357mvI=",
+			"requires": {
+				"chalk": "^1.0.0",
+				"lodash": "^4.1.0",
+				"log-symbols": "^1.0.2",
+				"postcss": "^5.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"log-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+					"requires": {
+						"chalk": "^1.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
+			}
+		},
 		"postcss-resolve-nested-selector": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
-			"integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
-			"dev": true
+			"integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4="
 		},
 		"postcss-safe-parser": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-2.0.1.tgz",
 			"integrity": "sha1-Oz0cS0OiTDlC4vC+eWE4KzSLOxM=",
-			"dev": true,
 			"requires": {
 				"postcss": "^5.2.16"
+			}
+		},
+		"postcss-scss": {
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-0.1.9.tgz",
+			"integrity": "sha1-dgbK/2S7SzS3YFq3SVdM942Iawg=",
+			"requires": {
+				"postcss": "^5.1.0"
 			}
 		},
 		"postcss-selector-parser": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
 			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-			"dev": true,
 			"requires": {
 				"flatten": "^1.0.2",
 				"indexes-of": "^1.0.1",
@@ -16926,7 +15994,6 @@
 			"version": "2.1.6",
 			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
 			"integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
-			"dev": true,
 			"requires": {
 				"is-svg": "^2.0.0",
 				"postcss": "^5.0.14",
@@ -16938,7 +16005,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
 			"integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
-			"dev": true,
 			"requires": {
 				"alphanum-sort": "^1.0.1",
 				"postcss": "^5.0.4",
@@ -16948,37 +16014,42 @@
 		"postcss-value-parser": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
-			"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
-			"dev": true
+			"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
 		},
 		"postcss-zindex": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
 			"integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
-			"dev": true,
 			"requires": {
 				"has": "^1.0.1",
 				"postcss": "^5.0.4",
 				"uniqs": "^2.0.0"
 			}
 		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+		},
 		"prepend-http": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-			"dev": true
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-			"dev": true
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+		},
+		"pretty-bytes": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+			"integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
 		},
 		"pretty-error": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
 			"integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
-			"dev": true,
 			"requires": {
 				"renderkid": "^2.0.1",
 				"utila": "~0.4"
@@ -16988,7 +16059,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.1.0.tgz",
 			"integrity": "sha1-6crJx2v27lL+lC3ZxsQhMVOxKIE=",
-			"dev": true,
 			"requires": {
 				"parse-ms": "^1.0.0",
 				"plur": "^2.1.2"
@@ -16996,7 +16066,6 @@
 		},
 		"primer-module-build": {
 			"version": "file:tools/primer-module-build",
-			"dev": true,
 			"requires": {
 				"autoprefixer": "^6.7.7",
 				"cssstats": "^3.2.0",
@@ -17010,14 +16079,12 @@
 		"primer-support": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.6.0.tgz",
-			"integrity": "sha1-Qq0w6+ox9/q7UpEnsyhk1sv8Kzw=",
-			"dev": true
+			"integrity": "sha1-Qq0w6+ox9/q7UpEnsyhk1sv8Kzw="
 		},
 		"primer-utilities": {
 			"version": "4.12.0",
 			"resolved": "https://registry.npmjs.org/primer-utilities/-/primer-utilities-4.12.0.tgz",
 			"integrity": "sha1-eu5Y11ouIzJvas/kG1W7ySjSJE4=",
-			"dev": true,
 			"requires": {
 				"primer-support": "4.6.0"
 			}
@@ -17025,14 +16092,12 @@
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-			"dev": true
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
 		},
 		"process": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-			"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
-			"dev": true
+			"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
@@ -17042,14 +16107,12 @@
 		"progress": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-			"integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-			"dev": true
+			"integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
 		},
 		"promise": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"dev": true,
 			"requires": {
 				"asap": "~2.0.3"
 			}
@@ -17063,7 +16126,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
 			"integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
-			"dev": true,
 			"requires": {
 				"err-code": "^1.0.0",
 				"retry": "^0.10.0"
@@ -17073,7 +16135,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-3.1.0.tgz",
 			"integrity": "sha512-7p/K2f6dI+dM8yjRQEGrTQs5hTQixUAdOGpMEA3+pVxpX5oHKRSKAXyLw9Q9HUWDTdwtoo39dSHGQtN90HcEwQ==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.9.0",
@@ -17084,7 +16145,6 @@
 			"version": "15.6.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
-			"dev": true,
 			"requires": {
 				"fbjs": "^0.8.16",
 				"loose-envify": "^1.3.1",
@@ -17094,14 +16154,12 @@
 		"proto-list": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-			"dev": true
+			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
 		},
 		"proxy-addr": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
 			"integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
-			"dev": true,
 			"requires": {
 				"forwarded": "~0.1.2",
 				"ipaddr.js": "1.6.0"
@@ -17110,14 +16168,12 @@
 		"prr": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-			"dev": true
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
 		},
 		"ps-tree": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
 			"integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
-			"dev": true,
 			"requires": {
 				"event-stream": "~3.3.0"
 			}
@@ -17125,26 +16181,22 @@
 		"pseudo-classes": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/pseudo-classes/-/pseudo-classes-0.0.1.tgz",
-			"integrity": "sha1-3smD2Upo0D3f3vPwfESvn2wiOls=",
-			"dev": true
+			"integrity": "sha1-3smD2Upo0D3f3vPwfESvn2wiOls="
 		},
 		"pseudo-elements": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/pseudo-elements/-/pseudo-elements-1.0.0.tgz",
-			"integrity": "sha1-S+YMvNhJlpKh1yz90+WDnautFhg=",
-			"dev": true
+			"integrity": "sha1-S+YMvNhJlpKh1yz90+WDnautFhg="
 		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"public-encrypt": {
 			"version": "4.0.2",
 			"resolved": "http://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
 			"integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"browserify-rsa": "^4.0.0",
@@ -17180,20 +16232,17 @@
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-			"dev": true
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
 		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-			"dev": true
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 		},
 		"query-string": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
 			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-			"dev": true,
 			"requires": {
 				"object-assign": "^4.1.0",
 				"strict-uri-encode": "^1.0.0"
@@ -17202,32 +16251,27 @@
 		"querystring": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-			"dev": true
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
 		},
 		"querystring-es3": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
-			"dev": true
+			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
 		},
 		"querystringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
-			"integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==",
-			"dev": true
+			"integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
 		},
 		"quick-lru": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
-			"dev": true
+			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
 		},
 		"radium": {
 			"version": "0.19.6",
 			"resolved": "https://registry.npmjs.org/radium/-/radium-0.19.6.tgz",
 			"integrity": "sha512-IABYntqCwYelUUIwA52maSCgJbqtJjHKIoD21wgpw3dGhIUbJ5chDShDGdaFiEzdF03hN9jfQqlmn0bF4YhfrQ==",
-			"dev": true,
 			"requires": {
 				"array-find": "^1.0.0",
 				"exenv": "^1.2.1",
@@ -17239,7 +16283,6 @@
 					"version": "2.0.5",
 					"resolved": "http://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz",
 					"integrity": "sha1-wVPH6I/YT+9cYC6VqBaLJ3BnH+c=",
-					"dev": true,
 					"requires": {
 						"bowser": "^1.0.0",
 						"hyphenate-style-name": "^1.0.1"
@@ -17250,14 +16293,12 @@
 		"ramda": {
 			"version": "0.25.0",
 			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
-			"integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==",
-			"dev": true
+			"integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
 		},
 		"randomatic": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
 			"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
-			"dev": true,
 			"requires": {
 				"is-number": "^4.0.0",
 				"kind-of": "^6.0.0",
@@ -17267,14 +16308,12 @@
 				"is-number": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-					"dev": true
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -17282,7 +16321,6 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
 			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -17291,7 +16329,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
 			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-			"dev": true,
 			"requires": {
 				"randombytes": "^2.0.5",
 				"safe-buffer": "^5.1.0"
@@ -17300,14 +16337,12 @@
 		"range-parser": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
-			"dev": true
+			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
 		},
 		"raw-body": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
 			"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-			"dev": true,
 			"requires": {
 				"bytes": "3.0.0",
 				"http-errors": "1.6.2",
@@ -17318,20 +16353,17 @@
 				"bytes": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-					"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-					"dev": true
+					"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
 				},
 				"depd": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-					"dev": true
+					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
 				},
 				"http-errors": {
 					"version": "1.6.2",
 					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
 					"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-					"dev": true,
 					"requires": {
 						"depd": "1.1.1",
 						"inherits": "2.0.3",
@@ -17342,28 +16374,24 @@
 				"iconv-lite": {
 					"version": "0.4.19",
 					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-					"dev": true
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
 				},
 				"setprototypeof": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-					"dev": true
+					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
 				}
 			}
 		},
 		"raw-loader": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
-			"integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
-			"dev": true
+			"integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao="
 		},
 		"rc": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
 			"integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
-			"dev": true,
 			"requires": {
 				"deep-extend": "^0.5.1",
 				"ini": "~1.3.0",
@@ -17374,8 +16402,7 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
 		},
@@ -17383,7 +16410,6 @@
 			"version": "15.6.2",
 			"resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
 			"integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
-			"dev": true,
 			"requires": {
 				"create-react-class": "^15.6.0",
 				"fbjs": "^0.8.9",
@@ -17396,7 +16422,6 @@
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-5.0.3.tgz",
 			"integrity": "sha512-Mvs6ofsc2xTjeZIrMaIfbXfsPVrbdVy/cVqq6SAacnqfMlcBpDuivhWZ1ODGeJ8HgmyWTLH971PYjj/EPCDVAw==",
-			"dev": true,
 			"requires": {
 				"address": "1.0.3",
 				"babel-code-frame": "6.26.0",
@@ -17421,14 +16446,12 @@
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -17440,8 +16463,7 @@
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -17449,7 +16471,6 @@
 			"version": "3.0.0-beta9",
 			"resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-3.0.0-beta9.tgz",
 			"integrity": "sha512-3UqwxygAP/eZdDtOKum6vClKWUlceZ7RBVQ3Fe122l1WBYOqHcBzoUZIwN8feaLVo+s2eB/q+NkBfanLgvmt+w==",
-			"dev": true,
 			"requires": {
 				"async": "^2.1.4",
 				"babel-runtime": "^6.9.2",
@@ -17464,7 +16485,6 @@
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
 					"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-					"dev": true,
 					"requires": {
 						"lodash": "^4.14.0"
 					}
@@ -17472,8 +16492,7 @@
 				"babylon": {
 					"version": "7.0.0-beta.31",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
-					"integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
-					"dev": true
+					"integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ=="
 				}
 			}
 		},
@@ -17481,7 +16500,6 @@
 			"version": "15.6.2",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
 			"integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
-			"dev": true,
 			"requires": {
 				"fbjs": "^0.8.9",
 				"loose-envify": "^1.1.0",
@@ -17492,14 +16510,12 @@
 		"react-error-overlay": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-4.0.1.tgz",
-			"integrity": "sha512-xXUbDAZkU08aAkjtUvldqbvI04ogv+a1XdHxvYuHPYKIVk/42BIOD0zSKTHAWV4+gDy3yGm283z2072rA2gdtw==",
-			"dev": true
+			"integrity": "sha512-xXUbDAZkU08aAkjtUvldqbvI04ogv+a1XdHxvYuHPYKIVk/42BIOD0zSKTHAWV4+gDy3yGm283z2072rA2gdtw=="
 		},
 		"react-fuzzy": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/react-fuzzy/-/react-fuzzy-0.5.2.tgz",
 			"integrity": "sha512-qIZZxaCheb/HhcBi5fABbiCFg85+K5r1TCps1D4uaL0LAMMD/1zm/x1/kNR130Tx7nnY9V7mbFyY0DquPYeLAw==",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.23.0",
 				"classnames": "^2.2.5",
@@ -17511,7 +16527,6 @@
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/react-html-attributes/-/react-html-attributes-1.4.2.tgz",
 			"integrity": "sha1-DSzPE0/Hmy01Q4N9wVkdMre5A/k=",
-			"dev": true,
 			"requires": {
 				"html-element-attributes": "^1.0.0"
 			}
@@ -17519,14 +16534,12 @@
 		"react-icon-base": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/react-icon-base/-/react-icon-base-2.1.0.tgz",
-			"integrity": "sha1-oZbjP98eeqof2jrvu2i9rZ6Cp50=",
-			"dev": true
+			"integrity": "sha1-oZbjP98eeqof2jrvu2i9rZ6Cp50="
 		},
 		"react-icons": {
 			"version": "2.2.7",
 			"resolved": "https://registry.npmjs.org/react-icons/-/react-icons-2.2.7.tgz",
 			"integrity": "sha512-0n4lcGqzJFcIQLoQytLdJCE0DKSA9dkwEZRYoGrIDJZFvIT6Hbajx5mv9geqhqFiNjUgtxg8kPyDfjlhymbGFg==",
-			"dev": true,
 			"requires": {
 				"react-icon-base": "2.1.0"
 			}
@@ -17535,7 +16548,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-2.3.0.tgz",
 			"integrity": "sha512-aIcbWb0fKFhEMB+RadoOYawlr1JoMMfrQ1oRgPUG/f/e4zERVJ6nYcIaQmrQmdHCZ63BOqe2cEkoeY0kyLBzNg==",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"is-dom": "^1.0.9"
@@ -17544,14 +16556,12 @@
 		"react-lifecycles-compat": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-			"dev": true
+			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
 		},
 		"react-modal": {
 			"version": "3.4.4",
 			"resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.4.4.tgz",
 			"integrity": "sha512-5VYNvy301Z0xxGBQhPmDdzOcyEkUG8sU7bpRsAPI4OHgEUkbBFrpjzs/ocNI0m824/lOqTxddXzwgmDJXx3s3Q==",
-			"dev": true,
 			"requires": {
 				"exenv": "^1.2.0",
 				"prop-types": "^15.5.10",
@@ -17563,7 +16573,6 @@
 			"version": "0.1.77",
 			"resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.77.tgz",
 			"integrity": "sha512-xq0PPsbkNI9xEd6yTrGPr7hzf6XfIgnsxuUEdRJELq+kLPHMsO3ymFCjhiYP35wlDPn9W46+rHDsJd7LFYteMw==",
-			"dev": true,
 			"requires": {
 				"inline-style-prefixer": "^3.0.6",
 				"prop-types": "^15.5.10",
@@ -17574,7 +16583,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/react-style-proptype/-/react-style-proptype-3.2.1.tgz",
 			"integrity": "sha512-Z02QsgmdZ4wYNxJsHhNGGZsIF8+MO93fYmdPaC+ljdqX3rq8tl/fSMXOGBbofGJNzq5W/2LFcONllmV6vzyYHA==",
-			"dev": true,
 			"requires": {
 				"prop-types": "^15.5.4"
 			}
@@ -17583,7 +16591,6 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.3.1.tgz",
 			"integrity": "sha512-hu4/LAOFSKjWt1+1hgnOv3ldxmt6lvZGTWz4KUkFrqzXrNDIVSu6txIcPszw7PNduR8en9YTN55JLRyd/L1ZiQ==",
-			"dev": true,
 			"requires": {
 				"dom-helpers": "^3.3.1",
 				"loose-envify": "^1.3.1",
@@ -17594,7 +16601,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/react-treebeard/-/react-treebeard-2.1.0.tgz",
 			"integrity": "sha512-unoy8IJL1NR5jgTtK+CqOCZKZylh/Tlid0oYajW9bLZCbFelxzmCsF8Y2hyS6pvHqM4W501oOm5O/jvg3VZCrg==",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.23.0",
 				"deep-equal": "^1.0.1",
@@ -17604,11 +16610,19 @@
 				"velocity-react": "^1.3.1"
 			}
 		},
+		"read-chunk": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
+			"integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
+			"requires": {
+				"pify": "^3.0.0",
+				"safe-buffer": "^5.1.1"
+			}
+		},
 		"read-cmd-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
 			"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2"
 			}
@@ -17617,7 +16631,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/read-file-stdin/-/read-file-stdin-0.2.1.tgz",
 			"integrity": "sha1-JezP86FTtoCa+ssj7hU4fbng7mE=",
-			"dev": true,
 			"requires": {
 				"gather-stream": "^1.0.0"
 			}
@@ -17626,7 +16639,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
 			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-			"dev": true,
 			"requires": {
 				"load-json-file": "^2.0.0",
 				"normalize-package-data": "^2.3.2",
@@ -17637,7 +16649,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
@@ -17649,7 +16660,6 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
@@ -17658,7 +16668,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
 					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-					"dev": true,
 					"requires": {
 						"pify": "^2.0.0"
 					}
@@ -17666,8 +16675,7 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
 		},
@@ -17675,7 +16683,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-			"dev": true,
 			"requires": {
 				"find-up": "^1.0.0",
 				"read-pkg": "^1.0.0"
@@ -17685,7 +16692,6 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
 					"requires": {
 						"path-exists": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
@@ -17695,7 +16701,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
@@ -17708,7 +16713,6 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
@@ -17717,7 +16721,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
@@ -17726,7 +16729,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"pify": "^2.0.0",
@@ -17736,14 +16738,12 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^1.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -17754,7 +16754,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -17779,7 +16778,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"minimatch": "^3.0.2",
@@ -17787,11 +16785,35 @@
 				"set-immediate-shim": "^1.0.1"
 			}
 		},
+		"readline2": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+			"integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+			"requires": {
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
+				"mute-stream": "0.0.5"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"mute-stream": {
+					"version": "0.0.5",
+					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+					"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
+				}
+			}
+		},
 		"recast": {
 			"version": "0.12.9",
 			"resolved": "https://registry.npmjs.org/recast/-/recast-0.12.9.tgz",
 			"integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
-			"dev": true,
 			"requires": {
 				"ast-types": "0.10.1",
 				"core-js": "^2.4.1",
@@ -17803,8 +16825,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -17812,7 +16833,6 @@
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-			"dev": true,
 			"requires": {
 				"resolve": "^1.1.6"
 			}
@@ -17821,7 +16841,6 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
 			"integrity": "sha1-kO8jHQd4xc4JPJpI105cVCLROpk=",
-			"dev": true,
 			"requires": {
 				"minimatch": "3.0.3"
 			},
@@ -17830,7 +16849,6 @@
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 					"integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.0.0"
 					}
@@ -17841,7 +16859,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 			"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-			"dev": true,
 			"requires": {
 				"indent-string": "^3.0.0",
 				"strip-indent": "^2.0.0"
@@ -17851,7 +16868,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
 			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^0.4.2",
 				"math-expression-evaluator": "^1.2.14",
@@ -17861,8 +16877,7 @@
 				"balanced-match": {
 					"version": "0.4.2",
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-					"dev": true
+					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
 				}
 			}
 		},
@@ -17870,7 +16885,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
 			"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^0.4.2"
 			},
@@ -17878,8 +16892,7 @@
 				"balanced-match": {
 					"version": "0.4.2",
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-					"dev": true
+					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
 				}
 			}
 		},
@@ -17887,7 +16900,6 @@
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
 			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
-			"dev": true,
 			"requires": {
 				"lodash": "^4.2.1",
 				"lodash-es": "^4.2.1",
@@ -17898,20 +16910,17 @@
 		"regenerate": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
-			"dev": true
+			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
 		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-			"dev": true
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.18.0",
 				"babel-types": "^6.19.0",
@@ -17922,7 +16931,6 @@
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-			"dev": true,
 			"requires": {
 				"is-equal-shallow": "^0.1.3"
 			}
@@ -17931,7 +16939,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
@@ -17941,7 +16948,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
 			"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-			"dev": true,
 			"requires": {
 				"regenerate": "^1.2.1",
 				"regjsgen": "^0.2.0",
@@ -17952,7 +16958,6 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
 			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-			"dev": true,
 			"requires": {
 				"rc": "^1.1.6",
 				"safe-buffer": "^5.0.1"
@@ -17962,7 +16967,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-			"dev": true,
 			"requires": {
 				"rc": "^1.0.1"
 			}
@@ -17970,14 +16974,12 @@
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-			"dev": true
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-			"dev": true,
 			"requires": {
 				"jsesc": "~0.5.0"
 			}
@@ -17985,14 +16987,12 @@
 		"relateurl": {
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
-			"dev": true
+			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
 		},
 		"release-zalgo": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
 			"integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
-			"dev": true,
 			"requires": {
 				"es6-error": "^4.0.1"
 			}
@@ -18001,7 +17001,6 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/remark/-/remark-8.0.0.tgz",
 			"integrity": "sha512-K0PTsaZvJlXTl9DN6qYlvjTkqSZBFELhROZMrblm2rB+085flN84nz4g/BscKRMqDvhzlK1oQ/xnWQumdeNZYw==",
-			"dev": true,
 			"requires": {
 				"remark-parse": "^4.0.0",
 				"remark-stringify": "^4.0.0",
@@ -18012,7 +17011,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-4.0.0.tgz",
 					"integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
-					"dev": true,
 					"requires": {
 						"collapse-white-space": "^1.0.2",
 						"is-alphabetical": "^1.0.0",
@@ -18035,7 +17033,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-4.0.0.tgz",
 					"integrity": "sha512-xLuyKTnuQer3ke9hkU38SUYLiTmS078QOnoFavztmbt/pAJtNSkNtFgR0U//uCcmG0qnyxao+PDuatQav46F1w==",
-					"dev": true,
 					"requires": {
 						"ccount": "^1.0.0",
 						"is-alphanumeric": "^1.0.0",
@@ -18058,14 +17055,12 @@
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-			"dev": true
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
 		},
 		"renderkid": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
 			"integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
-			"dev": true,
 			"requires": {
 				"css-select": "^1.1.0",
 				"dom-converter": "~0.1",
@@ -18078,7 +17073,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
 					"integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
-					"dev": true,
 					"requires": {
 						"domelementtype": "1"
 					}
@@ -18087,7 +17081,6 @@
 					"version": "1.1.6",
 					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
 					"integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
-					"dev": true,
 					"requires": {
 						"domelementtype": "1"
 					}
@@ -18096,7 +17089,6 @@
 					"version": "3.3.0",
 					"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
 					"integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
-					"dev": true,
 					"requires": {
 						"domelementtype": "1",
 						"domhandler": "2.1",
@@ -18107,14 +17099,12 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"readable-stream": {
 					"version": "1.0.34",
 					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -18125,34 +17115,29 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				},
 				"utila": {
 					"version": "0.3.3",
 					"resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
-					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY=",
-					"dev": true
+					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY="
 				}
 			}
 		},
 		"repeat-element": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-			"dev": true
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-			"dev": true
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"dev": true,
 			"requires": {
 				"is-finite": "^1.0.0"
 			}
@@ -18160,14 +17145,12 @@
 		"replace-ext": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-			"dev": true
+			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
 		},
 		"request": {
 			"version": "2.87.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
 			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
-			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.6.0",
@@ -18194,38 +17177,41 @@
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"dev": true
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
 		"require-from-string": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-			"dev": true
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"require-precompiled": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/require-precompiled/-/require-precompiled-0.1.0.tgz",
-			"integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo=",
-			"dev": true
+			"integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo="
+		},
+		"require-uncached": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"requires": {
+				"caller-path": "^0.1.0",
+				"resolve-from": "^1.0.0"
+			}
 		},
 		"requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-			"dev": true
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
 		},
 		"resolve": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
 			"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
-			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.5"
 			}
@@ -18234,7 +17220,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-			"dev": true,
 			"requires": {
 				"resolve-from": "^3.0.0"
 			},
@@ -18242,8 +17227,7 @@
 				"resolve-from": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-					"dev": true
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
 				}
 			}
 		},
@@ -18251,23 +17235,25 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
 			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-			"dev": true,
 			"requires": {
 				"expand-tilde": "^2.0.0",
 				"global-modules": "^1.0.0"
 			}
 		},
+		"resolve-from": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+		},
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-			"dev": true
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
 		},
 		"responselike": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
 			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-			"dev": true,
 			"requires": {
 				"lowercase-keys": "^1.0.0"
 			}
@@ -18276,47 +17262,48 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-			"dev": true,
 			"requires": {
 				"onetime": "^2.0.0",
 				"signal-exit": "^3.0.2"
 			}
 		},
+		"resumer": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+			"integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+			"requires": {
+				"through": "~2.3.4"
+			}
+		},
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-			"dev": true
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
 		"retry": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
-			"dev": true
+			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
 		},
 		"reverse-arguments": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/reverse-arguments/-/reverse-arguments-1.0.0.tgz",
-			"integrity": "sha1-woCVo6khrHFdYYNN3s6QJ5kmZ80=",
-			"dev": true
+			"integrity": "sha1-woCVo6khrHFdYYNN3s6QJ5kmZ80="
 		},
 		"rgb-regex": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
-			"integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
-			"dev": true
+			"integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE="
 		},
 		"rgba-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
-			"integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
-			"dev": true
+			"integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
 		},
 		"right-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-			"dev": true,
 			"requires": {
 				"align-text": "^0.1.1"
 			}
@@ -18333,7 +17320,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
 			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-			"dev": true,
 			"requires": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
@@ -18343,7 +17329,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/root-check/-/root-check-1.0.0.tgz",
 			"integrity": "sha1-xSp5S/Dbn61WdTbkGJjwyeCoZpc=",
-			"dev": true,
 			"requires": {
 				"downgrade-root": "^1.0.0",
 				"sudo-block": "^1.1.0"
@@ -18353,7 +17338,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-			"dev": true,
 			"requires": {
 				"is-promise": "^2.1.0"
 			}
@@ -18369,20 +17353,17 @@
 		"rx": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-			"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
-			"dev": true
+			"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
 		},
 		"rx-lite": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-			"dev": true
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
 		},
 		"rx-lite-aggregates": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-			"dev": true,
 			"requires": {
 				"rx-lite": "*"
 			}
@@ -18391,7 +17372,6 @@
 			"version": "6.3.2",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.2.tgz",
 			"integrity": "sha512-hV7criqbR0pe7EeL3O66UYVg92IR0XsA97+9y+BWTePK9SKmEI5Qd3Zj6uPnGkNzXsBywBQWTvujPl+1Kn9Zjw==",
-			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -18405,7 +17385,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-			"dev": true,
 			"requires": {
 				"ret": "~0.1.10"
 			}
@@ -18413,14 +17392,17 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"samsam": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
 		},
 		"sass-graph": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
 			"integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
-			"dev": true,
 			"requires": {
 				"glob": "^7.0.0",
 				"lodash": "^4.0.0",
@@ -18431,14 +17413,12 @@
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-					"dev": true
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
 				},
 				"cliui": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1",
@@ -18449,7 +17429,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -18458,7 +17437,6 @@
 					"version": "1.4.0",
 					"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"dev": true,
 					"requires": {
 						"lcid": "^1.0.0"
 					}
@@ -18467,7 +17445,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -18477,14 +17454,12 @@
 				"which-module": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-					"dev": true
+					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
 				},
 				"yargs": {
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
 					"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^3.0.0",
 						"cliui": "^3.2.0",
@@ -18505,7 +17480,6 @@
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
 					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^3.0.0"
 					}
@@ -18516,7 +17490,6 @@
 			"version": "6.0.7",
 			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.7.tgz",
 			"integrity": "sha512-JoiyD00Yo1o61OJsoP2s2kb19L1/Y2p3QFcCdWdF6oomBGKVYuZyqHWemRBfQ2uGYsk+CH3eCguXNfpjzlcpaA==",
-			"dev": true,
 			"requires": {
 				"clone-deep": "^2.0.1",
 				"loader-utils": "^1.0.1",
@@ -18528,14 +17501,12 @@
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-			"dev": true
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"schema-utils": {
 			"version": "0.4.5",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
 			"integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
-			"dev": true,
 			"requires": {
 				"ajv": "^6.1.0",
 				"ajv-keywords": "^3.1.0"
@@ -18544,14 +17515,12 @@
 		"scoped-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
-			"integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg=",
-			"dev": true
+			"integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg="
 		},
 		"scss-tokenizer": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
 			"integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
-			"dev": true,
 			"requires": {
 				"js-base64": "^2.1.8",
 				"source-map": "^0.4.2"
@@ -18560,14 +17529,12 @@
 		"semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-			"dev": true
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
 		},
 		"semver-diff": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
 			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-			"dev": true,
 			"requires": {
 				"semver": "^5.0.3"
 			}
@@ -18575,14 +17542,12 @@
 		"semver-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
-			"integrity": "sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=",
-			"dev": true
+			"integrity": "sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk="
 		},
 		"semver-truncate": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.2.tgz",
 			"integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
-			"dev": true,
 			"requires": {
 				"semver": "^5.3.0"
 			}
@@ -18591,7 +17556,6 @@
 			"version": "0.16.2",
 			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
 			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
 				"depd": "~1.1.2",
@@ -18612,7 +17576,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -18622,14 +17585,12 @@
 		"serialize-javascript": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
-			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
-			"dev": true
+			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ=="
 		},
 		"serve-favicon": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.5.0.tgz",
 			"integrity": "sha1-k10kDN/g9YBTB/3+ln2IlCosvPA=",
-			"dev": true,
 			"requires": {
 				"etag": "~1.8.1",
 				"fresh": "0.5.2",
@@ -18641,14 +17602,12 @@
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-					"dev": true
+					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
 				}
 			}
 		},
@@ -18656,7 +17615,6 @@
 			"version": "1.13.2",
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
 			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-			"dev": true,
 			"requires": {
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
@@ -18667,20 +17625,17 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-			"dev": true
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
 		},
 		"set-value": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-extendable": "^0.1.1",
@@ -18692,7 +17647,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -18702,20 +17656,17 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"setprototypeof": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-			"dev": true
+			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
 		},
 		"sha.js": {
 			"version": "2.4.11",
 			"resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -18725,7 +17676,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-1.0.0.tgz",
 			"integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
-			"dev": true,
 			"requires": {
 				"is-extendable": "^0.1.1",
 				"kind-of": "^5.0.0",
@@ -18735,8 +17685,7 @@
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-					"dev": true
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				}
 			}
 		},
@@ -18744,7 +17693,6 @@
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-0.2.2.tgz",
 			"integrity": "sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=",
-			"dev": true,
 			"requires": {
 				"lodash.keys": "^3.1.2"
 			}
@@ -18753,7 +17701,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"dev": true,
 			"requires": {
 				"shebang-regex": "^1.0.0"
 			}
@@ -18761,14 +17708,12 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-			"dev": true
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 		},
 		"shell-quote": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
 			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-			"dev": true,
 			"requires": {
 				"array-filter": "~0.0.0",
 				"array-map": "~0.0.0",
@@ -18780,7 +17725,6 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
 			"integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.0.0",
 				"interpret": "^1.0.0",
@@ -18790,20 +17734,31 @@
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-			"dev": true
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		},
+		"sinon": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-5.1.1.tgz",
+			"integrity": "sha512-h/3uHscbt5pQNxkf7Y/Lb9/OM44YNCicHakcq73ncbrIS8lXg+ZGOZbtuU+/km4YnyiCYfQQEwANaReJz7KDfw==",
+			"requires": {
+				"@sinonjs/formatio": "^2.0.0",
+				"diff": "^3.5.0",
+				"lodash.get": "^4.4.2",
+				"lolex": "^2.4.2",
+				"nise": "^1.3.3",
+				"supports-color": "^5.4.0",
+				"type-detect": "^4.0.8"
+			}
 		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-			"dev": true
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 		},
 		"slice-ansi": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0"
 			}
@@ -18811,20 +17766,17 @@
 		"slide": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-			"dev": true
+			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
 		},
 		"smart-buffer": {
 			"version": "1.1.15",
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
-			"integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
-			"dev": true
+			"integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
 		},
 		"snapdragon": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-			"dev": true,
 			"requires": {
 				"base": "^0.11.1",
 				"debug": "^2.2.0",
@@ -18840,7 +17792,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -18849,7 +17800,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -18858,7 +17808,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -18866,8 +17815,7 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -18875,7 +17823,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-			"dev": true,
 			"requires": {
 				"define-property": "^1.0.0",
 				"isobject": "^3.0.0",
@@ -18886,7 +17833,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -18895,7 +17841,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -18904,7 +17849,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -18913,7 +17857,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -18923,8 +17866,7 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -18932,7 +17874,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.2.0"
 			}
@@ -18941,7 +17882,6 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
 			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-			"dev": true,
 			"requires": {
 				"hoek": "2.x.x"
 			}
@@ -18950,7 +17890,6 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
 			"integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
-			"dev": true,
 			"requires": {
 				"debug": "^2.6.6",
 				"eventsource": "0.1.6",
@@ -18964,7 +17903,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -18975,7 +17913,6 @@
 			"version": "1.1.10",
 			"resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
 			"integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
-			"dev": true,
 			"requires": {
 				"ip": "^1.1.4",
 				"smart-buffer": "^1.0.13"
@@ -18985,7 +17922,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
 			"integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
-			"dev": true,
 			"requires": {
 				"agent-base": "^4.1.0",
 				"socks": "^1.1.10"
@@ -18995,7 +17931,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-			"dev": true,
 			"requires": {
 				"is-plain-obj": "^1.0.0"
 			}
@@ -19004,7 +17939,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/sort-on/-/sort-on-3.0.0.tgz",
 			"integrity": "sha512-e2RHeY1iM6dT9od3RoqeJSyz3O7naNFsGy34+EFEcwghjAncuOXC2/Xwq87S4FbypqLVp6PcizYEsGEGsGIDXA==",
-			"dev": true,
 			"requires": {
 				"arrify": "^1.0.0",
 				"dot-prop": "^4.1.1"
@@ -19013,14 +17947,12 @@
 		"source-list-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
-			"dev": true
+			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
 		},
 		"source-map": {
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
 			"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-			"dev": true,
 			"requires": {
 				"amdefine": ">=0.0.4"
 			}
@@ -19029,7 +17961,6 @@
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
-			"dev": true,
 			"requires": {
 				"atob": "^2.1.1",
 				"decode-uri-component": "^0.2.0",
@@ -19042,7 +17973,6 @@
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-			"dev": true,
 			"requires": {
 				"source-map": "^0.5.6"
 			},
@@ -19050,22 +17980,19 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
 		"source-map-url": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-			"dev": true
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"spawn-sync": {
 			"version": "1.0.15",
 			"resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
 			"integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-			"dev": true,
 			"requires": {
 				"concat-stream": "^1.4.7",
 				"os-shim": "^0.1.2"
@@ -19075,7 +18002,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
 			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
-			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
 				"spdx-license-ids": "^3.0.0"
@@ -19084,14 +18010,12 @@
 		"spdx-exceptions": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
-			"dev": true
+			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
@@ -19100,20 +18024,17 @@
 		"spdx-license-ids": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
-			"dev": true
+			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
 		},
 		"specificity": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/specificity/-/specificity-0.3.2.tgz",
-			"integrity": "sha512-Nc/QN/A425Qog7j9aHmwOrlwX2e7pNI47ciwxwy4jOlvbbMHkNNJchit+FX+UjF3IAdiaaV5BKeWuDUnws6G1A==",
-			"dev": true
+			"integrity": "sha512-Nc/QN/A425Qog7j9aHmwOrlwX2e7pNI47ciwxwy4jOlvbbMHkNNJchit+FX+UjF3IAdiaaV5BKeWuDUnws6G1A=="
 		},
 		"split": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
 			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
 			"requires": {
 				"through": "2"
 			}
@@ -19122,7 +18043,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.0"
 			}
@@ -19131,7 +18051,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
 			"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
-			"dev": true,
 			"requires": {
 				"through2": "^2.0.2"
 			}
@@ -19139,14 +18058,12 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
 			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
-			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -19161,8 +18078,7 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
 			}
 		},
@@ -19170,7 +18086,6 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
 			"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.1"
 			}
@@ -19178,20 +18093,17 @@
 		"stack-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
-			"dev": true
+			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
 		},
 		"state-toggle": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.1.tgz",
-			"integrity": "sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og==",
-			"dev": true
+			"integrity": "sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og=="
 		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-			"dev": true,
 			"requires": {
 				"define-property": "^0.2.5",
 				"object-copy": "^0.1.0"
@@ -19201,7 +18113,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -19211,14 +18122,12 @@
 		"statuses": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-			"dev": true
+			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
 		},
 		"stdout-stream": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
 			"integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
-			"dev": true,
 			"requires": {
 				"readable-stream": "^2.0.1"
 			}
@@ -19227,7 +18136,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
-			"dev": true,
 			"requires": {
 				"inherits": "~2.0.1",
 				"readable-stream": "^2.0.2"
@@ -19237,7 +18145,6 @@
 			"version": "0.2.2",
 			"resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
 			"integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-			"dev": true,
 			"requires": {
 				"duplexer": "~0.1.1",
 				"through": "~2.3.4"
@@ -19256,7 +18163,6 @@
 			"version": "2.8.2",
 			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.2.tgz",
 			"integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
-			"dev": true,
 			"requires": {
 				"builtin-status-codes": "^3.0.0",
 				"inherits": "^2.0.1",
@@ -19273,14 +18179,12 @@
 		"strict-uri-encode": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-			"dev": true
+			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
 		},
 		"string-length": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
-			"dev": true,
 			"requires": {
 				"astral-regex": "^1.0.0",
 				"strip-ansi": "^4.0.0"
@@ -19289,25 +18193,27 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
 		},
+		"string-template": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+			"integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
+		},
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
@@ -19316,14 +18222,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -19334,7 +18238,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
 			"integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.4.3",
@@ -19345,10 +18248,19 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/string.prototype.padstart/-/string.prototype.padstart-3.0.0.tgz",
 			"integrity": "sha1-W8+tOfRkm7LQMSkuGbzwtRDUskI=",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.4.3",
+				"function-bind": "^1.0.2"
+			}
+		},
+		"string.prototype.trim": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+			"integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.0",
 				"function-bind": "^1.0.2"
 			}
 		},
@@ -19364,7 +18276,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
 			"integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
-			"dev": true,
 			"requires": {
 				"character-entities-html4": "^1.0.0",
 				"character-entities-legacy": "^1.0.0",
@@ -19376,7 +18287,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -19384,14 +18294,12 @@
 		"strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-			"dev": true
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 		},
 		"strip-bom-buf": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
 			"integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
-			"dev": true,
 			"requires": {
 				"is-utf8": "^0.2.1"
 			}
@@ -19400,7 +18308,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
 			"integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
-			"dev": true,
 			"requires": {
 				"first-chunk-stream": "^2.0.0",
 				"strip-bom": "^2.0.0"
@@ -19410,7 +18317,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -19420,26 +18326,22 @@
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-			"dev": true
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"strip-indent": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-			"dev": true
+			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"strip-outer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
 			"integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
-			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.2"
 			}
@@ -19447,14 +18349,12 @@
 		"strip-url-auth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/strip-url-auth/-/strip-url-auth-1.0.1.tgz",
-			"integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=",
-			"dev": true
+			"integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164="
 		},
 		"strong-log-transformer": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-1.0.6.tgz",
 			"integrity": "sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=",
-			"dev": true,
 			"requires": {
 				"byline": "^5.0.0",
 				"duplexer": "^0.1.1",
@@ -19466,8 +18366,7 @@
 				"minimist": {
 					"version": "0.1.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
-					"dev": true
+					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
 				}
 			}
 		},
@@ -19475,7 +18374,6 @@
 			"version": "0.18.2",
 			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.18.2.tgz",
 			"integrity": "sha512-WPpJPZGUxWYHWIUMNNOYqql7zh85zGmr84FdTVWq52WTIkqlW9xSxD3QYWi/T31cqn9UNSsietVEgGn2aaSCzw==",
-			"dev": true,
 			"requires": {
 				"loader-utils": "^1.0.2",
 				"schema-utils": "^0.3.0"
@@ -19485,7 +18383,6 @@
 					"version": "5.5.2",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-					"dev": true,
 					"requires": {
 						"co": "^4.6.0",
 						"fast-deep-equal": "^1.0.0",
@@ -19496,14 +18393,12 @@
 				"fast-deep-equal": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-					"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-					"dev": true
+					"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
 				},
 				"schema-utils": {
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
 					"integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
-					"dev": true,
 					"requires": {
 						"ajv": "^5.0.0"
 					}
@@ -19513,14 +18408,12 @@
 		"style-search": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
-			"integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
-			"dev": true
+			"integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI="
 		},
 		"stylehacks": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-2.3.2.tgz",
 			"integrity": "sha1-ZMg+BDimjJ7fRJ6MVSp9mrYAmws=",
-			"dev": true,
 			"requires": {
 				"browserslist": "^1.1.3",
 				"chalk": "^1.1.1",
@@ -19538,14 +18431,12 @@
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -19558,7 +18449,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-					"dev": true,
 					"requires": {
 						"chalk": "^1.0.0"
 					}
@@ -19566,14 +18456,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"postcss-reporter": {
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-1.4.1.tgz",
 					"integrity": "sha1-wTbwpbFhkV83ndN2XGEHX357mvI=",
-					"dev": true,
 					"requires": {
 						"chalk": "^1.0.0",
 						"lodash": "^4.1.0",
@@ -19585,7 +18473,6 @@
 					"version": "2.2.3",
 					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
 					"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-					"dev": true,
 					"requires": {
 						"flatten": "^1.0.2",
 						"indexes-of": "^1.0.1",
@@ -19595,8 +18482,7 @@
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -19604,7 +18490,6 @@
 			"version": "7.13.0",
 			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-7.13.0.tgz",
 			"integrity": "sha1-ER+Xttpy53XICADWu29fhpmXeF0=",
-			"dev": true,
 			"requires": {
 				"autoprefixer": "^6.0.0",
 				"balanced-match": "^0.4.0",
@@ -19650,26 +18535,22 @@
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 				},
 				"balanced-match": {
 					"version": "0.4.2",
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-					"dev": true
+					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
 				},
 				"camelcase": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-					"dev": true
+					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
 				},
 				"camelcase-keys": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^2.0.0",
 						"map-obj": "^1.0.0"
@@ -19679,7 +18560,6 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1",
@@ -19690,7 +18570,6 @@
 							"version": "1.0.2",
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -19703,7 +18582,6 @@
 					"version": "2.2.2",
 					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
 					"integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
-					"dev": true,
 					"requires": {
 						"is-directory": "^0.3.1",
 						"js-yaml": "^3.4.3",
@@ -19718,7 +18596,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -19727,7 +18604,6 @@
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/doiuse/-/doiuse-2.6.0.tgz",
 					"integrity": "sha1-GJLRC2Gpo1at2/K2FJM+gfi7ODQ=",
-					"dev": true,
 					"requires": {
 						"browserslist": "^1.1.1",
 						"caniuse-db": "^1.0.30000187",
@@ -19746,14 +18622,12 @@
 				"get-stdin": {
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-					"integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
-					"dev": true
+					"integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
 				},
 				"indent-string": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-					"dev": true,
 					"requires": {
 						"repeating": "^2.0.0"
 					}
@@ -19762,7 +18636,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -19770,20 +18643,17 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"known-css-properties": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.2.0.tgz",
-					"integrity": "sha512-UTCzU28rRI9wkb8qSGoZa9pgWvxr4LjP2MEhi9XHb/1XMOJy0uTnIxaxzj8My/PORG+kQG6VzAcGvRw66eIOfA==",
-					"dev": true
+					"integrity": "sha512-UTCzU28rRI9wkb8qSGoZa9pgWvxr4LjP2MEhi9XHb/1XMOJy0uTnIxaxzj8My/PORG+kQG6VzAcGvRw66eIOfA=="
 				},
 				"log-symbols": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-					"dev": true,
 					"requires": {
 						"chalk": "^1.0.0"
 					},
@@ -19792,7 +18662,6 @@
 							"version": "1.1.3",
 							"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 							"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-							"dev": true,
 							"requires": {
 								"ansi-styles": "^2.2.1",
 								"escape-string-regexp": "^1.0.2",
@@ -19806,14 +18675,12 @@
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-					"dev": true
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
 				},
 				"meow": {
 					"version": "3.7.0",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^2.0.0",
 						"decamelize": "^1.1.2",
@@ -19830,14 +18697,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"os-locale": {
 					"version": "1.4.0",
 					"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"dev": true,
 					"requires": {
 						"lcid": "^1.0.0"
 					}
@@ -19846,7 +18711,6 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
@@ -19854,14 +18718,12 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				},
 				"postcss-less": {
 					"version": "0.14.0",
 					"resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-0.14.0.tgz",
 					"integrity": "sha1-xjGwicbM5CK5oQ86lY0r7dOBkyQ=",
-					"dev": true,
 					"requires": {
 						"postcss": "^5.0.21"
 					}
@@ -19870,7 +18732,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-3.0.0.tgz",
 					"integrity": "sha1-CeoPN6RExWk4eGBuCbAY6+/3z48=",
-					"dev": true,
 					"requires": {
 						"chalk": "^1.0.0",
 						"lodash": "^4.1.0",
@@ -19882,7 +18743,6 @@
 							"version": "1.1.3",
 							"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 							"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-							"dev": true,
 							"requires": {
 								"ansi-styles": "^2.2.1",
 								"escape-string-regexp": "^1.0.2",
@@ -19897,7 +18757,6 @@
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-0.4.1.tgz",
 					"integrity": "sha1-rXcbgfD3L19IRdCKpg+TVXZT1Uw=",
-					"dev": true,
 					"requires": {
 						"postcss": "^5.2.13"
 					}
@@ -19906,7 +18765,6 @@
 					"version": "2.2.3",
 					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
 					"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-					"dev": true,
 					"requires": {
 						"flatten": "^1.0.2",
 						"indexes-of": "^1.0.1",
@@ -19917,7 +18775,6 @@
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -19929,7 +18786,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-					"dev": true,
 					"requires": {
 						"indent-string": "^2.1.0",
 						"strip-indent": "^1.0.1"
@@ -19938,26 +18794,22 @@
 				"require-from-string": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-					"integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
-					"dev": true
+					"integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
 				},
 				"resolve-from": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-					"dev": true
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
 				},
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				},
 				"strip-indent": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-					"dev": true,
 					"requires": {
 						"get-stdin": "^4.0.1"
 					},
@@ -19965,8 +18817,7 @@
 						"get-stdin": {
 							"version": "4.0.1",
 							"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-							"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-							"dev": true
+							"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
 						}
 					}
 				},
@@ -19974,7 +18825,6 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/sugarss/-/sugarss-0.2.0.tgz",
 					"integrity": "sha1-rDQjdWMyfG/4l7ZHQr9q7BkK054=",
-					"dev": true,
 					"requires": {
 						"postcss": "^5.2.4"
 					}
@@ -19982,14 +18832,12 @@
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				},
 				"through2": {
 					"version": "0.6.5",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
 					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-					"dev": true,
 					"requires": {
 						"readable-stream": ">=1.0.33-1 <1.1.0-0",
 						"xtend": ">=4.0.0 <4.1.0-0"
@@ -19998,20 +18846,17 @@
 				"trim-newlines": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-					"dev": true
+					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
 				},
 				"window-size": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-					"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
-					"dev": true
+					"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
 				},
 				"yargs": {
 					"version": "3.32.0",
 					"resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
 					"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^2.0.1",
 						"cliui": "^3.0.3",
@@ -20026,7 +18871,6 @@
 							"version": "1.0.2",
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -20039,7 +18883,6 @@
 		},
 		"stylelint-config-primer": {
 			"version": "file:tools/stylelint-config-primer",
-			"dev": true,
 			"requires": {
 				"stylelint-no-unsupported-browser-features": "^1.0.0",
 				"stylelint-order": "^0.4.4",
@@ -20051,7 +18894,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/stylelint-no-unsupported-browser-features/-/stylelint-no-unsupported-browser-features-1.0.1.tgz",
 			"integrity": "sha512-6uaoXV/WA5BLKo9bbjERFE3oAOA0UY4FgGDaQWarV9x3qrDLS2o2SJqk0TaxwAIAgROwj9RhbQ2FF1QKRzZBNw==",
-			"dev": true,
 			"requires": {
 				"doiuse": "^4.0.0",
 				"lodash": "^4.17.4",
@@ -20063,7 +18905,6 @@
 					"version": "6.0.23",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
 					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
 						"source-map": "^0.6.1",
@@ -20073,8 +18914,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -20082,7 +18922,6 @@
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-0.4.4.tgz",
 			"integrity": "sha1-2338oFQbUGIBDH4uIedFeR/AiKw=",
-			"dev": true,
 			"requires": {
 				"lodash": "^4.17.4",
 				"postcss": "^5.2.16",
@@ -20093,7 +18932,6 @@
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-1.5.2.tgz",
 			"integrity": "sha512-0Ps/isz5HZuM9TtQiMFoeNWq6PvrJUoCWLWCD+uGqcfnAJ8CJjikBEyjtDOFNVu+7cvqOeVm/L+jGNdYQ8zu1g==",
-			"dev": true,
 			"requires": {
 				"lodash": "^4.11.1",
 				"postcss-media-query-parser": "^0.2.3",
@@ -20107,17 +18945,340 @@
 			"version": "1.8.10",
 			"resolved": "https://registry.npmjs.org/stylelint-selector-no-utility/-/stylelint-selector-no-utility-1.8.10.tgz",
 			"integrity": "sha1-1bk5qIPk+9LIElV8USX6JHumIRs=",
-			"dev": true,
 			"requires": {
 				"primer-utilities": "4.12.0",
 				"stylelint": "^7.13.0"
+			}
+		},
+		"stylelint-test-rule-tape": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/stylelint-test-rule-tape/-/stylelint-test-rule-tape-0.2.0.tgz",
+			"integrity": "sha1-NRTszoygrIq78imuSECgl5ZIqsg=",
+			"requires": {
+				"stylelint": "^6.2.0",
+				"tape": "^4.5.1"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "4.11.8",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+					"requires": {
+						"co": "^4.6.0",
+						"json-stable-stringify": "^1.0.1"
+					}
+				},
+				"ajv-keywords": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+					"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"balanced-match": {
+					"version": "0.4.2",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+				},
+				"camelcase": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
+					}
+				},
+				"cosmiconfig": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz",
+					"integrity": "sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"js-yaml": "^3.4.3",
+						"minimist": "^1.2.0",
+						"object-assign": "^4.0.1",
+						"os-homedir": "^1.0.1",
+						"parse-json": "^2.2.0",
+						"pinkie-promise": "^2.0.0",
+						"require-from-string": "^1.1.0"
+					}
+				},
+				"doiuse": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/doiuse/-/doiuse-2.6.0.tgz",
+					"integrity": "sha1-GJLRC2Gpo1at2/K2FJM+gfi7ODQ=",
+					"requires": {
+						"browserslist": "^1.1.1",
+						"caniuse-db": "^1.0.30000187",
+						"css-rule-stream": "^1.1.0",
+						"duplexer2": "0.0.2",
+						"jsonfilter": "^1.1.2",
+						"ldjson-stream": "^1.2.1",
+						"lodash": "^4.0.0",
+						"multimatch": "^2.0.0",
+						"postcss": "^5.0.8",
+						"source-map": "^0.4.2",
+						"through2": "^0.6.3",
+						"yargs": "^3.5.4"
+					}
+				},
+				"get-stdin": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+					"integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
+				},
+				"globby": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+					"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+					"requires": {
+						"array-union": "^1.0.1",
+						"arrify": "^1.0.0",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"html-tags": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-1.2.0.tgz",
+					"integrity": "sha1-x43mW1Zjqll5id0rerSSANfk25g="
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"log-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+					"requires": {
+						"chalk": "^1.0.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"os-locale": {
+					"version": "1.4.0",
+					"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+					"requires": {
+						"lcid": "^1.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"require-from-string": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+					"integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
+				},
+				"resolve-from": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+				},
+				"slice-ansi": {
+					"version": "0.0.4",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+					"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+				},
+				"specificity": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/specificity/-/specificity-0.2.1.tgz",
+					"integrity": "sha1-OnBHwqF581Ni45kHRc6lOfFRYbg="
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				},
+				"stylelint": {
+					"version": "6.9.0",
+					"resolved": "http://registry.npmjs.org/stylelint/-/stylelint-6.9.0.tgz",
+					"integrity": "sha1-LSOHCXwetU5uMjuMSGdyXaXgIUg=",
+					"requires": {
+						"autoprefixer": "^6.0.0",
+						"balanced-match": "^0.4.0",
+						"chalk": "^1.1.1",
+						"colorguard": "^1.2.0",
+						"cosmiconfig": "^1.1.0",
+						"doiuse": "^2.3.0",
+						"execall": "^1.0.0",
+						"get-stdin": "^5.0.0",
+						"globby": "^5.0.0",
+						"globjoin": "^0.1.2",
+						"html-tags": "^1.1.1",
+						"htmlparser2": "^3.9.0",
+						"lodash": "^4.0.0",
+						"log-symbols": "^1.0.2",
+						"meow": "^3.3.0",
+						"multimatch": "^2.1.0",
+						"normalize-selector": "^0.2.0",
+						"postcss": "^5.0.20",
+						"postcss-less": "^0.14.0",
+						"postcss-reporter": "^1.3.0",
+						"postcss-resolve-nested-selector": "^0.1.1",
+						"postcss-scss": "^0.1.3",
+						"postcss-selector-parser": "^2.0.0",
+						"postcss-value-parser": "^3.1.1",
+						"resolve-from": "^2.0.0",
+						"specificity": "^0.2.1",
+						"string-width": "^1.0.1",
+						"stylehacks": "^2.3.0",
+						"sugarss": "^0.1.2",
+						"svg-tags": "^1.0.0",
+						"table": "^3.7.8"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				},
+				"table": {
+					"version": "3.8.3",
+					"resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
+					"integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+					"requires": {
+						"ajv": "^4.7.0",
+						"ajv-keywords": "^1.0.0",
+						"chalk": "^1.1.1",
+						"lodash": "^4.0.0",
+						"slice-ansi": "0.0.4",
+						"string-width": "^2.0.0"
+					},
+					"dependencies": {
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+						},
+						"string-width": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+							"requires": {
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^4.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				},
+				"through2": {
+					"version": "0.6.5",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+					"requires": {
+						"readable-stream": ">=1.0.33-1 <1.1.0-0",
+						"xtend": ">=4.0.0 <4.1.0-0"
+					}
+				},
+				"window-size": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+					"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+				},
+				"yargs": {
+					"version": "3.32.0",
+					"resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+					"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+					"requires": {
+						"camelcase": "^2.0.1",
+						"cliui": "^3.0.3",
+						"decamelize": "^1.1.1",
+						"os-locale": "^1.4.0",
+						"string-width": "^1.0.1",
+						"window-size": "^0.1.4",
+						"y18n": "^3.2.0"
+					}
+				}
 			}
 		},
 		"sudo-block": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/sudo-block/-/sudo-block-1.2.0.tgz",
 			"integrity": "sha1-zFOb+BkWJNT1B9g+60W0zqJ/NGM=",
-			"dev": true,
 			"requires": {
 				"chalk": "^1.0.0",
 				"is-docker": "^1.0.0",
@@ -20127,14 +19288,12 @@
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -20146,16 +19305,22 @@
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
+			}
+		},
+		"sugarss": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/sugarss/-/sugarss-0.1.6.tgz",
+			"integrity": "sha1-/jrA4eBygq7x3oSoC3I4b/Tn6jc=",
+			"requires": {
+				"postcss": "^5.2.0"
 			}
 		},
 		"supports-color": {
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
@@ -20163,20 +19328,17 @@
 		"svg-tag-names": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/svg-tag-names/-/svg-tag-names-1.1.1.tgz",
-			"integrity": "sha1-lkGynvcQJe4JTHBD983efZn71Qo=",
-			"dev": true
+			"integrity": "sha1-lkGynvcQJe4JTHBD983efZn71Qo="
 		},
 		"svg-tags": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
-			"integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
-			"dev": true
+			"integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q="
 		},
 		"svgo": {
 			"version": "0.7.2",
 			"resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
 			"integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
-			"dev": true,
 			"requires": {
 				"coa": "~1.0.1",
 				"colors": "~1.1.2",
@@ -20190,14 +19352,12 @@
 				"esprima": {
 					"version": "2.7.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-					"dev": true
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
 				},
 				"js-yaml": {
 					"version": "3.7.0",
 					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
 					"integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-					"dev": true,
 					"requires": {
 						"argparse": "^1.0.7",
 						"esprima": "^2.6.0"
@@ -20208,14 +19368,12 @@
 		"symbol-observable": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-			"dev": true
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
 		},
 		"synesthesia": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/synesthesia/-/synesthesia-1.0.1.tgz",
 			"integrity": "sha1-XvlepUjA1cbm+btLDQcx3/hkp3c=",
-			"dev": true,
 			"requires": {
 				"css-color-names": "0.0.3"
 			},
@@ -20223,8 +19381,7 @@
 				"css-color-names": {
 					"version": "0.0.3",
 					"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz",
-					"integrity": "sha1-3gzvFvTYqoIioyDVttfpu62nufY=",
-					"dev": true
+					"integrity": "sha1-3gzvFvTYqoIioyDVttfpu62nufY="
 				}
 			}
 		},
@@ -20232,7 +19389,6 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
 			"integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
-			"dev": true,
 			"requires": {
 				"ajv": "^6.0.1",
 				"ajv-keywords": "^3.0.0",
@@ -20246,7 +19402,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/tabtab/-/tabtab-1.3.2.tgz",
 			"integrity": "sha1-u5wspjJPZZ/edjTCyvPAluEYfKc=",
-			"dev": true,
 			"requires": {
 				"debug": "^2.2.0",
 				"inquirer": "^1.0.2",
@@ -20259,20 +19414,17 @@
 				"ansi-escapes": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-					"dev": true
+					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -20285,7 +19437,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-					"dev": true,
 					"requires": {
 						"restore-cursor": "^1.0.1"
 					}
@@ -20294,7 +19445,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -20303,7 +19453,6 @@
 					"version": "1.1.1",
 					"resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
 					"integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
-					"dev": true,
 					"requires": {
 						"extend": "^3.0.0",
 						"spawn-sync": "^1.0.15",
@@ -20314,7 +19463,6 @@
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-					"dev": true,
 					"requires": {
 						"escape-string-regexp": "^1.0.5",
 						"object-assign": "^4.1.0"
@@ -20324,7 +19472,6 @@
 					"version": "1.2.7",
 					"resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
 					"integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
-					"dev": true,
 					"requires": {
 						"ansi": "^0.3.0",
 						"has-unicode": "^2.0.0",
@@ -20337,7 +19484,6 @@
 					"version": "1.2.3",
 					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
 					"integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
-					"dev": true,
 					"requires": {
 						"ansi-escapes": "^1.1.0",
 						"chalk": "^1.0.0",
@@ -20359,7 +19505,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -20367,20 +19512,17 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"mute-stream": {
 					"version": "0.0.6",
 					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
-					"integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
-					"dev": true
+					"integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s="
 				},
 				"npmlog": {
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
 					"integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
-					"dev": true,
 					"requires": {
 						"ansi": "~0.3.1",
 						"are-we-there-yet": "~1.1.2",
@@ -20390,14 +19532,12 @@
 				"onetime": {
 					"version": "1.1.0",
 					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-					"dev": true
+					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
 				},
 				"restore-cursor": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-					"dev": true,
 					"requires": {
 						"exit-hook": "^1.0.0",
 						"onetime": "^1.0.0"
@@ -20407,7 +19547,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -20417,14 +19556,12 @@
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				},
 				"tmp": {
 					"version": "0.0.29",
 					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
 					"integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
-					"dev": true,
 					"requires": {
 						"os-tmpdir": "~1.0.1"
 					}
@@ -20435,7 +19572,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/taketalk/-/taketalk-1.0.0.tgz",
 			"integrity": "sha1-tNTw3u0gauffd1sSnqLKbeUvJt0=",
-			"dev": true,
 			"requires": {
 				"get-stdin": "^4.0.1",
 				"minimist": "^1.1.0"
@@ -20444,22 +19580,62 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
 		},
 		"tapable": {
 			"version": "0.2.8",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
-			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
-			"dev": true
+			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
+		},
+		"tape": {
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/tape/-/tape-4.9.1.tgz",
+			"integrity": "sha512-6fKIXknLpoe/Jp4rzHKFPpJUHDHDqn8jus99IfPnHIjyz78HYlefTGD3b5EkbQzuLfaEvmfPK3IolLgq2xT3kw==",
+			"requires": {
+				"deep-equal": "~1.0.1",
+				"defined": "~1.0.0",
+				"for-each": "~0.3.3",
+				"function-bind": "~1.1.1",
+				"glob": "~7.1.2",
+				"has": "~1.0.3",
+				"inherits": "~2.0.3",
+				"minimist": "~1.2.0",
+				"object-inspect": "~1.6.0",
+				"resolve": "~1.7.1",
+				"resumer": "~0.0.0",
+				"string.prototype.trim": "~1.1.2",
+				"through": "~2.3.8"
+			},
+			"dependencies": {
+				"has": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+					"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+					"requires": {
+						"function-bind": "^1.1.1"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"resolve": {
+					"version": "1.7.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+					"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+					"requires": {
+						"path-parse": "^1.0.5"
+					}
+				}
+			}
 		},
 		"tar": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
 			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-			"dev": true,
 			"requires": {
 				"block-stream": "*",
 				"fstream": "^1.0.2",
@@ -20469,14 +19645,12 @@
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
-			"dev": true
+			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
 		},
 		"temp-write": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/temp-write/-/temp-write-3.4.0.tgz",
 			"integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"is-stream": "^1.1.0",
@@ -20490,7 +19664,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
 			"integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
-			"dev": true,
 			"requires": {
 				"os-tmpdir": "^1.0.0",
 				"uuid": "^2.0.1"
@@ -20499,16 +19672,23 @@
 				"uuid": {
 					"version": "2.0.3",
 					"resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-					"dev": true
+					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
 				}
+			}
+		},
+		"tempy": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/tempy/-/tempy-0.2.1.tgz",
+			"integrity": "sha512-LB83o9bfZGrntdqPuRdanIVCPReam9SOZKW0fOy5I9X3A854GGWi0tjCqoXEk84XIEYBc/x9Hq3EFop/H5wJaw==",
+			"requires": {
+				"temp-dir": "^1.0.0",
+				"unique-string": "^1.0.0"
 			}
 		},
 		"term-size": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
 			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-			"dev": true,
 			"requires": {
 				"execa": "^0.7.0"
 			},
@@ -20517,7 +19697,6 @@
 					"version": "0.7.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -20530,23 +19709,30 @@
 				}
 			}
 		},
+		"text-encoding": {
+			"version": "0.6.4",
+			"resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+		},
 		"text-extensions": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
-			"integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
-			"dev": true
+			"integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ=="
 		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-			"dev": true
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+		},
+		"textextensions": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.2.0.tgz",
+			"integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA=="
 		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-			"dev": true
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
 			"version": "2.0.3",
@@ -20561,7 +19747,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/time-require/-/time-require-0.1.2.tgz",
 			"integrity": "sha1-+eEss3D8JgXhFARYK6VO9corLZg=",
-			"dev": true,
 			"requires": {
 				"chalk": "^0.4.0",
 				"date-time": "^0.1.1",
@@ -20572,14 +19757,12 @@
 				"ansi-styles": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-					"dev": true
+					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
 				},
 				"chalk": {
 					"version": "0.4.0",
 					"resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
 					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "~1.0.0",
 						"has-color": "~0.1.0",
@@ -20589,20 +19772,17 @@
 				"date-time": {
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
-					"integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc=",
-					"dev": true
+					"integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc="
 				},
 				"parse-ms": {
 					"version": "0.1.2",
 					"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
-					"integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
-					"dev": true
+					"integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4="
 				},
 				"pretty-ms": {
 					"version": "0.2.2",
 					"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
 					"integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
-					"dev": true,
 					"requires": {
 						"parse-ms": "^0.1.0"
 					}
@@ -20610,34 +19790,29 @@
 				"strip-ansi": {
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-					"dev": true
+					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
 				}
 			}
 		},
 		"time-stamp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
-			"integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c=",
-			"dev": true
+			"integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c="
 		},
 		"time-zone": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
-			"integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
-			"dev": true
+			"integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0="
 		},
 		"timed-out": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-			"dev": true
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 		},
 		"timers-browserify": {
 			"version": "2.0.10",
 			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
 			"integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
-			"dev": true,
 			"requires": {
 				"setimmediate": "^1.0.4"
 			}
@@ -20645,14 +19820,12 @@
 		"titleize": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/titleize/-/titleize-1.0.1.tgz",
-			"integrity": "sha512-rUwGDruKq1gX+FFHbTl5qjI7teVO7eOe+C8IcQ7QT+1BK3eEUXJqbZcBOeaRP4FwSC/C1A5jDoIVta0nIQ9yew==",
-			"dev": true
+			"integrity": "sha512-rUwGDruKq1gX+FFHbTl5qjI7teVO7eOe+C8IcQ7QT+1BK3eEUXJqbZcBOeaRP4FwSC/C1A5jDoIVta0nIQ9yew=="
 		},
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}
@@ -20660,14 +19833,12 @@
 		"to-arraybuffer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
-			"dev": true
+			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
 		},
 		"to-object-path": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
@@ -20676,7 +19847,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-			"dev": true,
 			"requires": {
 				"define-property": "^2.0.2",
 				"extend-shallow": "^3.0.2",
@@ -20688,7 +19858,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
@@ -20697,8 +19866,7 @@
 		"toposort": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
-			"integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
-			"dev": true
+			"integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk="
 		},
 		"tough-cookie": {
 			"version": "2.3.4",
@@ -20711,26 +19879,22 @@
 		"trim": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
-			"dev": true
+			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
 		},
 		"trim-newlines": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-			"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-			"dev": true
+			"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
 		},
 		"trim-off-newlines": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
-			"dev": true
+			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
 		},
 		"trim-repeated": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
 			"integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
-			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.2"
 			}
@@ -20738,26 +19902,22 @@
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-			"dev": true
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
 		},
 		"trim-trailing-lines": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz",
-			"integrity": "sha512-bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg==",
-			"dev": true
+			"integrity": "sha512-bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg=="
 		},
 		"trough": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.2.tgz",
-			"integrity": "sha512-FHkoUZvG6Egrv9XZAyYGKEyb1JMsFphgPjoczkZC2y6W93U1jswcVURB8MUvtsahEPEVACyxD47JAL63vF4JsQ==",
-			"dev": true
+			"integrity": "sha512-FHkoUZvG6Egrv9XZAyYGKEyb1JMsFphgPjoczkZC2y6W93U1jswcVURB8MUvtsahEPEVACyxD47JAL63vF4JsQ=="
 		},
 		"true-case-path": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
 			"integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.1.2"
 			}
@@ -20765,20 +19925,17 @@
 		"tslib": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-			"dev": true
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
 		},
 		"tty-browserify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
-			"dev": true
+			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
 		},
 		"tunnel": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.5.tgz",
-			"integrity": "sha512-gj5sdqherx4VZKMcBA4vewER7zdK25Td+z1npBqpbDys4eJrLx+SlYjJvq1bDXs2irkuJM5pf8ktaEQVipkrbA==",
-			"dev": true
+			"integrity": "sha512-gj5sdqherx4VZKMcBA4vewER7zdK25Td+z1npBqpbDys4eJrLx+SlYjJvq1bDXs2irkuJM5pf8ktaEQVipkrbA=="
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
@@ -20792,25 +19949,35 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true,
 			"optional": true
 		},
 		"twig": {
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/twig/-/twig-1.12.0.tgz",
 			"integrity": "sha512-zm5OQXb8bQDGQUPytFgjqMKHhqcz/s6pU6Nwsy+rKPhsoOOVwYeHnziiDGFzeTDiFd28M8EVkEO8we6ikcrGjQ==",
-			"dev": true,
 			"requires": {
 				"locutus": "^2.0.5",
 				"minimatch": "3.0.x",
 				"walk": "2.3.x"
 			}
 		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"requires": {
+				"prelude-ls": "~1.1.2"
+			}
+		},
+		"type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+		},
 		"type-is": {
 			"version": "1.6.16",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
 			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
-			"dev": true,
 			"requires": {
 				"media-typer": "0.3.0",
 				"mime-types": "~2.1.18"
@@ -20824,14 +19991,12 @@
 		"ua-parser-js": {
 			"version": "0.7.18",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
-			"integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA==",
-			"dev": true
+			"integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
 		},
 		"uglify-js": {
 			"version": "2.8.29",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
 			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-			"dev": true,
 			"requires": {
 				"source-map": "~0.5.1",
 				"uglify-to-browserify": "~1.0.0",
@@ -20841,14 +20006,12 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				},
 				"yargs": {
 					"version": "3.10.0",
 					"resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
 					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^1.0.2",
 						"cliui": "^2.1.0",
@@ -20862,14 +20025,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
 			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-			"dev": true,
 			"optional": true
 		},
 		"uglifyjs-webpack-plugin": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.5.tgz",
 			"integrity": "sha512-hIQJ1yxAPhEA2yW/i7Fr+SXZVMp+VEI3d42RTHBgQd2yhp/1UdBcR3QEWPV5ahBxlqQDMEMTuTEvDHSFINfwSw==",
-			"dev": true,
 			"requires": {
 				"cacache": "^10.0.4",
 				"find-cache-dir": "^1.0.0",
@@ -20884,20 +20045,17 @@
 				"commander": {
 					"version": "2.13.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-					"dev": true
+					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"uglify-es": {
 					"version": "3.3.9",
 					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
 					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-					"dev": true,
 					"requires": {
 						"commander": "~2.13.0",
 						"source-map": "~0.6.1"
@@ -20908,20 +20066,17 @@
 		"uid2": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
-			"dev": true
+			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
 		},
 		"underscore.string": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.0.3.tgz",
-			"integrity": "sha1-Rhe4waJQz25QZPu7Nj0PqWzxRVI=",
-			"dev": true
+			"integrity": "sha1-Rhe4waJQz25QZPu7Nj0PqWzxRVI="
 		},
 		"underscore.string.fp": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/underscore.string.fp/-/underscore.string.fp-1.0.4.tgz",
 			"integrity": "sha1-BUs/GEO8rlYShsh95eiHm0/Jg2Q=",
-			"dev": true,
 			"requires": {
 				"chickencurry": "1.1.1",
 				"compose-function": "^2.0.0",
@@ -20933,7 +20088,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
 			"integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"xtend": "^4.0.1"
@@ -20943,7 +20097,6 @@
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
 			"integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
-			"dev": true,
 			"requires": {
 				"bail": "^1.0.0",
 				"extend": "^3.0.0",
@@ -20957,7 +20110,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
@@ -20969,7 +20121,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -20978,7 +20129,6 @@
 					"version": "0.4.3",
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-extendable": "^0.1.1",
@@ -20991,14 +20141,12 @@
 		"uniq": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
-			"dev": true
+			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
 		},
 		"uniqid": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
 			"integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
-			"dev": true,
 			"requires": {
 				"macaddress": "^0.2.8"
 			}
@@ -21006,8 +20154,7 @@
 		"uniqs": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
-			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
-			"dev": true
+			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
 		},
 		"unique-filename": {
 			"version": "1.1.0",
@@ -21029,7 +20176,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
 			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-			"dev": true,
 			"requires": {
 				"crypto-random-string": "^1.0.0"
 			}
@@ -21038,7 +20184,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
 			"integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
-			"dev": true,
 			"requires": {
 				"mkdirp": "^0.5.1",
 				"os-tmpdir": "^1.0.1",
@@ -21049,7 +20194,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/unist-util-find-before/-/unist-util-find-before-2.0.2.tgz",
 			"integrity": "sha512-Q84eFB/kFQKCBOgBJStU58iC/vcoAiK+GJvzogOJRdoZJq3s7krvoPsM9gAOQ0angUuOzEfqVnjWWNxoYz66FQ==",
-			"dev": true,
 			"requires": {
 				"unist-util-is": "^2.0.0"
 			}
@@ -21057,14 +20201,12 @@
 		"unist-util-is": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
-			"integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw==",
-			"dev": true
+			"integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw=="
 		},
 		"unist-util-modify-children": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.2.tgz",
 			"integrity": "sha512-GRi04yhng1WqBf5RBzPkOtWAadcZS2gvuOgNn/cyJBYNxtTuyYqTKN0eg4rC1YJwGnzrqfRB3dSKm8cNCjNirg==",
-			"dev": true,
 			"requires": {
 				"array-iterate": "^1.0.0"
 			}
@@ -21073,7 +20215,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unist-util-parents/-/unist-util-parents-1.0.0.tgz",
 			"integrity": "sha512-606ENeOBmJoEsj9WJVDP3PCsBSVH+ovBhqyUX5NnJIG2B0IuBXdg/uE5OZzPuyNKDGPdUVS2cjwEfwBc3t6XPw==",
-			"dev": true,
 			"requires": {
 				"es6-weak-map": "^2.0.1"
 			}
@@ -21082,7 +20223,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
 			"integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
-			"dev": true,
 			"requires": {
 				"unist-util-visit": "^1.1.0"
 			}
@@ -21091,7 +20231,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-1.5.0.tgz",
 			"integrity": "sha1-qTwr6MD2U4J4A7gTMa3sKqJM2TM=",
-			"dev": true,
 			"requires": {
 				"css-selector-parser": "^1.1.0",
 				"debug": "^2.2.0",
@@ -21102,7 +20241,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -21112,14 +20250,12 @@
 		"unist-util-stringify-position": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-			"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
-			"dev": true
+			"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
 		},
 		"unist-util-visit": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.1.tgz",
 			"integrity": "sha512-0fdB9EQJU0tho5tK0VzOJzAQpPv2LyLZ030b10GxuzAWEfvd54mpY7BMjQ1L69k2YNvL+SvxRzH0yUIehOO8aA==",
-			"dev": true,
 			"requires": {
 				"unist-util-is": "^2.1.1"
 			}
@@ -21127,20 +20263,17 @@
 		"universalify": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
-			"dev": true
+			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
 		},
 		"unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-			"dev": true
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
 		},
 		"unset-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-			"dev": true,
 			"requires": {
 				"has-value": "^0.3.1",
 				"isobject": "^3.0.0"
@@ -21150,7 +20283,6 @@
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-					"dev": true,
 					"requires": {
 						"get-value": "^2.0.3",
 						"has-values": "^0.1.4",
@@ -21161,7 +20293,6 @@
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-							"dev": true,
 							"requires": {
 								"isarray": "1.0.0"
 							}
@@ -21171,34 +20302,29 @@
 				"has-values": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-					"dev": true
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
 				}
 			}
 		},
 		"untildify": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
-			"integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==",
-			"dev": true
+			"integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
 		},
 		"unzip-response": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-			"dev": true
+			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
 		},
 		"upath": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.0.5.tgz",
-			"integrity": "sha512-qbKn90aDQ0YEwvXoLqj0oiuUYroLX2lVHZ+b+xwjozFasAOC4GneDq5+OaIG5Zj+jFmbz/uO+f7a9qxjktJQww==",
-			"dev": true
+			"integrity": "sha512-qbKn90aDQ0YEwvXoLqj0oiuUYroLX2lVHZ+b+xwjozFasAOC4GneDq5+OaIG5Zj+jFmbz/uO+f7a9qxjktJQww=="
 		},
 		"update-notifier": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
 			"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
-			"dev": true,
 			"requires": {
 				"boxen": "^1.2.1",
 				"chalk": "^2.0.1",
@@ -21215,22 +20341,19 @@
 				"import-lazy": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-					"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
-					"dev": true
+					"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
 				}
 			}
 		},
 		"upper-case": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
-			"dev": true
+			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
 		},
 		"uri-js": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.1.tgz",
 			"integrity": "sha512-jpKCA3HjsBfSDOEgxRDAxQCNyHfCPSbq57PqCkd3gAyBuPb3IWxw54EHncqESznIdqSetHfw3D7ylThu2Kcc9A==",
-			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			},
@@ -21238,22 +20361,19 @@
 				"punycode": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
-					"dev": true
+					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
 				}
 			}
 		},
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-			"dev": true
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
 		},
 		"url": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
 			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-			"dev": true,
 			"requires": {
 				"punycode": "1.3.2",
 				"querystring": "0.2.0"
@@ -21262,8 +20382,7 @@
 				"punycode": {
 					"version": "1.3.2",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-					"dev": true
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
 				}
 			}
 		},
@@ -21271,7 +20390,6 @@
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.6.2.tgz",
 			"integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
-			"dev": true,
 			"requires": {
 				"loader-utils": "^1.0.2",
 				"mime": "^1.4.1",
@@ -21282,7 +20400,6 @@
 					"version": "5.5.2",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-					"dev": true,
 					"requires": {
 						"co": "^4.6.0",
 						"fast-deep-equal": "^1.0.0",
@@ -21293,14 +20410,12 @@
 				"fast-deep-equal": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-					"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-					"dev": true
+					"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
 				},
 				"schema-utils": {
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
 					"integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
-					"dev": true,
 					"requires": {
 						"ajv": "^5.0.0"
 					}
@@ -21311,7 +20426,6 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
 			"integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
-			"dev": true,
 			"requires": {
 				"querystringify": "^2.0.0",
 				"requires-port": "^1.0.0"
@@ -21321,7 +20435,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
 			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-			"dev": true,
 			"requires": {
 				"prepend-http": "^1.0.1"
 			}
@@ -21329,14 +20442,12 @@
 		"url-to-options": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
-			"dev": true
+			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
 		},
 		"use": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
 			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-			"dev": true,
 			"requires": {
 				"kind-of": "^6.0.2"
 			},
@@ -21344,8 +20455,7 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -21353,7 +20463,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
 			"integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0"
 			}
@@ -21362,7 +20471,6 @@
 			"version": "0.10.3",
 			"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
 			"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-			"dev": true,
 			"requires": {
 				"inherits": "2.0.1"
 			},
@@ -21370,8 +20478,7 @@
 				"inherits": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-					"dev": true
+					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
 				}
 			}
 		},
@@ -21383,14 +20490,12 @@
 		"utila": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
-			"integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
-			"dev": true
+			"integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw="
 		},
 		"utils-merge": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-			"dev": true
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
 			"version": "3.3.2",
@@ -21401,7 +20506,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
 			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
-			"dev": true,
 			"requires": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
@@ -21410,20 +20514,17 @@
 		"vary": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-			"dev": true
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
 		},
 		"velocity-animate": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/velocity-animate/-/velocity-animate-1.5.1.tgz",
-			"integrity": "sha512-VJ3csMz5zP1ifkbBlsNYpxnoWkPHfVRQ8tUongS78W5DxSGHB68pjYHDTgUYBkVM7P/HpYdVukgVUFcxjr1gGg==",
-			"dev": true
+			"integrity": "sha512-VJ3csMz5zP1ifkbBlsNYpxnoWkPHfVRQ8tUongS78W5DxSGHB68pjYHDTgUYBkVM7P/HpYdVukgVUFcxjr1gGg=="
 		},
 		"velocity-react": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/velocity-react/-/velocity-react-1.4.1.tgz",
 			"integrity": "sha512-ZyXBm+9C/6kNUNyc+aeNKEhtTu/Mn+OfpsNBGuTxU8S2DUcis/KQL0rTN6jWL+7ygdOrun18qhheNZTA7YERmg==",
-			"dev": true,
 			"requires": {
 				"lodash": "^4.17.5",
 				"prop-types": "^15.5.8",
@@ -21434,20 +20535,17 @@
 		"vendor-prefixes": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/vendor-prefixes/-/vendor-prefixes-0.0.1.tgz",
-			"integrity": "sha1-mLQ2f4y3CZIw78IOBA9UrtAY0G0=",
-			"dev": true
+			"integrity": "sha1-mLQ2f4y3CZIw78IOBA9UrtAY0G0="
 		},
 		"vendors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz",
-			"integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ==",
-			"dev": true
+			"integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ=="
 		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -21457,8 +20555,7 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
 			}
 		},
@@ -21466,7 +20563,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
 			"integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
-			"dev": true,
 			"requires": {
 				"is-buffer": "^1.1.4",
 				"replace-ext": "1.0.0",
@@ -21477,14 +20573,12 @@
 		"vfile-location": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.3.tgz",
-			"integrity": "sha512-zM5/l4lfw1CBoPx3Jimxoc5RNDAHHpk6AM6LM0pTIkm5SUSsx8ZekZ0PVdf0WEZ7kjlhSt7ZlqbRL6Cd6dBs6A==",
-			"dev": true
+			"integrity": "sha512-zM5/l4lfw1CBoPx3Jimxoc5RNDAHHpk6AM6LM0pTIkm5SUSsx8ZekZ0PVdf0WEZ7kjlhSt7ZlqbRL6Cd6dBs6A=="
 		},
 		"vfile-message": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.1.tgz",
 			"integrity": "sha512-vSGCkhNvJzO6VcWC6AlJW4NtYOVtS+RgCaqFIYUjoGIlHnFL+i0LbtYvonDWOMcB97uTPT4PRsyYY7REWC9vug==",
-			"dev": true,
 			"requires": {
 				"unist-util-stringify-position": "^1.1.1"
 			}
@@ -21493,7 +20587,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
 			"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-			"dev": true,
 			"requires": {
 				"clone": "^1.0.0",
 				"clone-stats": "^0.0.1",
@@ -21503,8 +20596,7 @@
 				"replace-ext": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-					"dev": true
+					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
 				}
 			}
 		},
@@ -21512,7 +20604,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
 			"integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"pify": "^2.3.0",
@@ -21525,14 +20616,12 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -21543,7 +20632,6 @@
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
 			"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-			"dev": true,
 			"requires": {
 				"indexof": "0.0.1"
 			}
@@ -21552,7 +20640,6 @@
 			"version": "2.3.14",
 			"resolved": "https://registry.npmjs.org/walk/-/walk-2.3.14.tgz",
 			"integrity": "sha512-5skcWAUmySj6hkBdH6B6+3ddMjVQYH5Qy9QGbPmN8kVmLteXk+yVXg+yfk1nbX30EYakahLrr8iPcCxJQSCBeg==",
-			"dev": true,
 			"requires": {
 				"foreachasync": "^3.0.0"
 			}
@@ -21561,7 +20648,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
 			"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -21570,7 +20656,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
 			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
-			"dev": true,
 			"requires": {
 				"chokidar": "^2.0.2",
 				"graceful-fs": "^4.1.2",
@@ -21581,7 +20666,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
 			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-			"dev": true,
 			"requires": {
 				"defaults": "^1.0.3"
 			}
@@ -21590,7 +20674,6 @@
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.12.0.tgz",
 			"integrity": "sha512-Sw7MdIIOv/nkzPzee4o0EdvCuPmxT98+vVpIvwtcwcF1Q4SDSNp92vwcKc4REe7NItH9f1S4ra9FuQ7yuYZ8bQ==",
-			"dev": true,
 			"requires": {
 				"acorn": "^5.0.0",
 				"acorn-dynamic-import": "^2.0.0",
@@ -21620,7 +20703,6 @@
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
 					"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-					"dev": true,
 					"requires": {
 						"lodash": "^4.14.0"
 					}
@@ -21628,20 +20710,17 @@
 				"has-flag": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-					"dev": true
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				},
 				"supports-color": {
 					"version": "4.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-					"dev": true,
 					"requires": {
 						"has-flag": "^2.0.0"
 					}
@@ -21650,7 +20729,6 @@
 					"version": "0.4.6",
 					"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
 					"integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
-					"dev": true,
 					"requires": {
 						"source-map": "^0.5.6",
 						"uglify-js": "^2.8.29",
@@ -21663,7 +20741,6 @@
 			"version": "1.12.2",
 			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
 			"integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
-			"dev": true,
 			"requires": {
 				"memory-fs": "~0.4.1",
 				"mime": "^1.5.0",
@@ -21675,8 +20752,7 @@
 				"mime": {
 					"version": "1.6.0",
 					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-					"dev": true
+					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
 				}
 			}
 		},
@@ -21684,7 +20760,6 @@
 			"version": "2.22.1",
 			"resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.22.1.tgz",
 			"integrity": "sha512-wbjnvcc3HOPKRE/L0KmTv2MrByfLFOJlVFNKo5Svxy+1plR/bMIMYQDgB4pUOzJXhiBLU7Clp6P1SSzS89iKxA==",
-			"dev": true,
 			"requires": {
 				"ansi-html": "0.0.7",
 				"html-entities": "^1.2.0",
@@ -21696,7 +20771,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
 			"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
-			"dev": true,
 			"requires": {
 				"source-list-map": "^2.0.0",
 				"source-map": "~0.6.1"
@@ -21705,8 +20779,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -21714,7 +20787,6 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
 			"integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
-			"dev": true,
 			"requires": {
 				"http-parser-js": ">=0.4.0",
 				"websocket-extensions": ">=0.1.1"
@@ -21723,32 +20795,27 @@
 		"websocket-extensions": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-			"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
-			"dev": true
+			"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
 		},
 		"well-known-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-1.0.0.tgz",
-			"integrity": "sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg=",
-			"dev": true
+			"integrity": "sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg="
 		},
 		"whatwg-fetch": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-			"dev": true
+			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
 		},
 		"whet.extend": {
 			"version": "0.9.9",
 			"resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
-			"integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
-			"dev": true
+			"integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE="
 		},
 		"which": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
 			}
@@ -21756,14 +20823,12 @@
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-			"dev": true
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 		},
 		"wide-align": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
 			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-			"dev": true,
 			"requires": {
 				"string-width": "^1.0.2"
 			},
@@ -21772,7 +20837,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -21781,7 +20845,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -21794,7 +20857,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
 			"integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
-			"dev": true,
 			"requires": {
 				"string-width": "^2.1.1"
 			}
@@ -21803,7 +20865,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
 			"integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
-			"dev": true,
 			"requires": {
 				"semver": "^5.0.1"
 			}
@@ -21811,20 +20872,17 @@
 		"window-size": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-			"dev": true
+			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
 		},
 		"wordwrap": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-			"dev": true
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
 		},
 		"worker-farm": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
 			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
-			"dev": true,
 			"requires": {
 				"errno": "~0.1.7"
 			}
@@ -21833,7 +20891,6 @@
 			"version": "2.1.0",
 			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-			"dev": true,
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1"
@@ -21843,7 +20900,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -21852,7 +20908,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -21870,7 +20925,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-			"dev": true,
 			"requires": {
 				"mkdirp": "^0.5.1"
 			}
@@ -21879,7 +20933,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"imurmurhash": "^0.1.4",
@@ -21889,14 +20942,12 @@
 		"write-file-stdout": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/write-file-stdout/-/write-file-stdout-0.0.2.tgz",
-			"integrity": "sha1-wlLXx8WxtAKJdjDjRTx7/mkNnKE=",
-			"dev": true
+			"integrity": "sha1-wlLXx8WxtAKJdjDjRTx7/mkNnKE="
 		},
 		"write-pkg": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.1.0.tgz",
 			"integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
-			"dev": true,
 			"requires": {
 				"sort-keys": "^2.0.0",
 				"write-json-file": "^2.2.0"
@@ -21906,7 +20957,6 @@
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
 					"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
-					"dev": true,
 					"requires": {
 						"detect-indent": "^5.0.0",
 						"graceful-fs": "^4.1.2",
@@ -21921,20 +20971,17 @@
 		"x-is-string": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
-			"integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
-			"dev": true
+			"integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
 		},
 		"xdg-basedir": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-			"dev": true
+			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
 		},
 		"xmlhttprequest": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-			"integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
-			"dev": true
+			"integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
 		},
 		"xtend": {
 			"version": "4.0.1",
@@ -21944,20 +20991,17 @@
 		"y18n": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-			"dev": true
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 		},
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-			"dev": true
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yargs": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
 			"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-			"dev": true,
 			"requires": {
 				"camelcase": "^4.1.0",
 				"cliui": "^3.2.0",
@@ -21977,14 +21021,12 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"cliui": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1",
@@ -21995,7 +21037,6 @@
 							"version": "1.0.2",
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -22008,7 +21049,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -22017,7 +21057,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
 					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^2.0.0"
@@ -22029,7 +21068,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
 			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-			"dev": true,
 			"requires": {
 				"camelcase": "^4.1.0"
 			},
@@ -22037,16 +21075,19 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				}
 			}
+		},
+		"yeoman-assert": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yeoman-assert/-/yeoman-assert-3.1.1.tgz",
+			"integrity": "sha512-bCuLb/j/WzpvrJZCTdJJLFzm7KK8IYQJ3+dF9dYtNs2CUYyezFJDuULiZ2neM4eqjf45GN1KH/MzCTT3i90wUQ=="
 		},
 		"yeoman-character": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/yeoman-character/-/yeoman-character-1.1.0.tgz",
 			"integrity": "sha1-kNS1vq+SdZCGF3AVsv36LgaE18c=",
-			"dev": true,
 			"requires": {
 				"supports-color": "^3.1.2"
 			},
@@ -22054,14 +21095,12 @@
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
 					"requires": {
 						"has-flag": "^1.0.0"
 					}
@@ -22072,7 +21111,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/yeoman-doctor/-/yeoman-doctor-3.0.2.tgz",
 			"integrity": "sha512-/KbouQdKgnqxG6K3Tc8VBPAQLPbruQ7KkbinwR+ah507oOFobHnGs8kqj8oMfafY6rXInHdh7nC5YzicCR4Z0g==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.0",
 				"bin-version-check": "^3.0.0",
@@ -22090,7 +21128,6 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.3.3.tgz",
 			"integrity": "sha512-HBpXdNw8V66EwqIFt01rNhSgX33BOzgVb9CxpIvESvCI4ELeOSniB6gV6RXwrBur8kmHZCIAkYQYpib7Qxx8FQ==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.4.1",
 				"cross-spawn": "^6.0.5",
@@ -22112,20 +21149,17 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"chardet": {
 					"version": "0.7.0",
 					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-					"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-					"dev": true
+					"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
 				},
 				"cross-spawn": {
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
 						"path-key": "^2.0.1",
@@ -22138,7 +21172,6 @@
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
 					"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
-					"dev": true,
 					"requires": {
 						"chardet": "^0.7.0",
 						"iconv-lite": "^0.4.24",
@@ -22149,7 +21182,6 @@
 					"version": "8.0.1",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
 					"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
-					"dev": true,
 					"requires": {
 						"array-union": "^1.0.1",
 						"dir-glob": "^2.0.0",
@@ -22164,7 +21196,6 @@
 					"version": "0.4.24",
 					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-					"dev": true,
 					"requires": {
 						"safer-buffer": ">= 2.1.2 < 3"
 					}
@@ -22173,7 +21204,6 @@
 					"version": "6.2.0",
 					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
 					"integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
-					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.0.0",
 						"chalk": "^2.0.0",
@@ -22194,9 +21224,527 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"yeoman-generator": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-1.1.1.tgz",
+			"integrity": "sha1-QMK09s374F4ZUv3XKTPw2JJdvfU=",
+			"requires": {
+				"async": "^2.0.0",
+				"chalk": "^1.0.0",
+				"class-extend": "^0.1.0",
+				"cli-table": "^0.3.1",
+				"cross-spawn": "^5.0.1",
+				"dargs": "^5.1.0",
+				"dateformat": "^2.0.0",
+				"debug": "^2.1.0",
+				"detect-conflict": "^1.0.0",
+				"error": "^7.0.2",
+				"find-up": "^2.1.0",
+				"github-username": "^3.0.0",
+				"glob": "^7.0.3",
+				"istextorbinary": "^2.1.0",
+				"lodash": "^4.11.1",
+				"mem-fs-editor": "^3.0.0",
+				"minimist": "^1.2.0",
+				"mkdirp": "^0.5.0",
+				"path-exists": "^3.0.0",
+				"path-is-absolute": "^1.0.0",
+				"pretty-bytes": "^4.0.2",
+				"read-chunk": "^2.0.0",
+				"read-pkg-up": "^2.0.0",
+				"rimraf": "^2.2.0",
+				"run-async": "^2.0.0",
+				"shelljs": "^0.7.0",
+				"text-table": "^0.2.0",
+				"through2": "^2.0.0",
+				"user-home": "^2.0.0",
+				"yeoman-environment": "^1.1.0"
+			},
+			"dependencies": {
+				"ansi-escapes": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"cli-cursor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+					"requires": {
+						"restore-cursor": "^1.0.1"
+					}
+				},
+				"dargs": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
+					"integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk="
+				},
+				"dateformat": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+					"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"diff": {
+					"version": "2.2.3",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
+					"integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k="
+				},
+				"external-editor": {
+					"version": "1.1.1",
+					"resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+					"integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
+					"requires": {
+						"extend": "^3.0.0",
+						"spawn-sync": "^1.0.15",
+						"tmp": "^0.0.29"
+					}
+				},
+				"figures": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+					"requires": {
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
+					}
+				},
+				"globby": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
+					"integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
+					"requires": {
+						"array-union": "^1.0.1",
+						"arrify": "^1.0.0",
+						"glob": "^6.0.1",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					},
+					"dependencies": {
+						"glob": {
+							"version": "6.0.4",
+							"resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+							"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+							"requires": {
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "2 || 3",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						}
+					}
+				},
+				"inquirer": {
+					"version": "1.2.3",
+					"resolved": "http://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+					"integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
+					"requires": {
+						"ansi-escapes": "^1.1.0",
+						"chalk": "^1.0.0",
+						"cli-cursor": "^1.0.1",
+						"cli-width": "^2.0.0",
+						"external-editor": "^1.1.0",
+						"figures": "^1.3.5",
+						"lodash": "^4.3.0",
+						"mute-stream": "0.0.6",
+						"pinkie-promise": "^2.0.0",
+						"run-async": "^2.2.0",
+						"rx": "^4.1.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.0",
+						"through": "^2.3.6"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"log-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+					"requires": {
+						"chalk": "^1.0.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"mute-stream": {
+					"version": "0.0.6",
+					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
+					"integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s="
+				},
+				"onetime": {
+					"version": "1.1.0",
+					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"requires": {
+						"find-up": "^2.0.0",
+						"read-pkg": "^2.0.0"
+					}
+				},
+				"restore-cursor": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+					"requires": {
+						"exit-hook": "^1.0.0",
+						"onetime": "^1.0.0"
+					}
+				},
+				"shelljs": {
+					"version": "0.7.8",
+					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+					"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+					"requires": {
+						"glob": "^7.0.0",
+						"interpret": "^1.0.0",
+						"rechoir": "^0.6.2"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				},
+				"tmp": {
+					"version": "0.0.29",
+					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+					"integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+					"requires": {
+						"os-tmpdir": "~1.0.1"
+					}
+				},
+				"untildify": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+					"integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+					"requires": {
+						"os-homedir": "^1.0.0"
+					}
+				},
+				"yeoman-environment": {
+					"version": "1.6.6",
+					"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.6.tgz",
+					"integrity": "sha1-zYX6Z9FWBg5EDXgH1+988NLR1nE=",
+					"requires": {
+						"chalk": "^1.0.0",
+						"debug": "^2.0.0",
+						"diff": "^2.1.2",
+						"escape-string-regexp": "^1.0.2",
+						"globby": "^4.0.0",
+						"grouped-queue": "^0.3.0",
+						"inquirer": "^1.0.2",
+						"lodash": "^4.11.1",
+						"log-symbols": "^1.0.1",
+						"mem-fs": "^1.1.0",
+						"text-table": "^0.2.0",
+						"untildify": "^2.0.0"
+					}
+				}
+			}
+		},
+		"yeoman-test": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/yeoman-test/-/yeoman-test-1.9.1.tgz",
+			"integrity": "sha512-aWB8CglmjBfXd+U5g5Cm1b8KVW0uotjo521IgkepvhNXiAX/YswHYGVnbEFb0m9ZdXztELuNJn2UtuwgFZIw6Q==",
+			"requires": {
+				"inquirer": "^5.2.0",
+				"lodash": "^4.17.10",
+				"mkdirp": "^0.5.1",
+				"pinkie-promise": "^2.0.1",
+				"rimraf": "^2.4.4",
+				"sinon": "^5.0.7",
+				"yeoman-environment": "^2.3.0",
+				"yeoman-generator": "^2.0.5"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+				},
+				"clone-stats": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+				},
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"dargs": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
+					"integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk="
+				},
+				"deep-extend": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+				},
+				"gh-got": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
+					"integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
+					"requires": {
+						"got": "^7.0.0",
+						"is-plain-obj": "^1.1.0"
+					}
+				},
+				"github-username": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
+					"integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
+					"requires": {
+						"gh-got": "^6.0.0"
+					}
+				},
+				"globby": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+					"integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+					"requires": {
+						"array-union": "^1.0.1",
+						"dir-glob": "^2.0.0",
+						"glob": "^7.1.2",
+						"ignore": "^3.3.5",
+						"pify": "^3.0.0",
+						"slash": "^1.0.0"
+					}
+				},
+				"got": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+					"integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+					"requires": {
+						"decompress-response": "^3.2.0",
+						"duplexer3": "^0.1.4",
+						"get-stream": "^3.0.0",
+						"is-plain-obj": "^1.1.0",
+						"is-retry-allowed": "^1.0.0",
+						"is-stream": "^1.0.0",
+						"isurl": "^1.0.0-alpha5",
+						"lowercase-keys": "^1.0.0",
+						"p-cancelable": "^0.3.0",
+						"p-timeout": "^1.1.1",
+						"safe-buffer": "^5.0.1",
+						"timed-out": "^4.0.0",
+						"url-parse-lax": "^1.0.0",
+						"url-to-options": "^1.0.1"
+					}
+				},
+				"inquirer": {
+					"version": "5.2.0",
+					"resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+					"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+					"requires": {
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.0",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^2.1.0",
+						"figures": "^2.0.0",
+						"lodash": "^4.3.0",
+						"mute-stream": "0.0.7",
+						"run-async": "^2.2.0",
+						"rxjs": "^5.5.2",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^4.0.0",
+						"through": "^2.3.6"
+					}
+				},
+				"mem-fs-editor": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-4.0.3.tgz",
+					"integrity": "sha512-tgWmwI/+6vwu6POan82dTjxEpwAoaj0NAFnghtVo/FcLK2/7IhPUtFUUYlwou4MOY6OtjTUJtwpfH1h+eSUziw==",
+					"requires": {
+						"commondir": "^1.0.1",
+						"deep-extend": "^0.6.0",
+						"ejs": "^2.5.9",
+						"glob": "^7.0.3",
+						"globby": "^7.1.1",
+						"isbinaryfile": "^3.0.2",
+						"mkdirp": "^0.5.0",
+						"multimatch": "^2.0.0",
+						"rimraf": "^2.2.8",
+						"through2": "^2.0.0",
+						"vinyl": "^2.0.1"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"p-cancelable": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+					"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+				},
+				"p-timeout": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+					"integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+					"requires": {
+						"p-finally": "^1.0.0"
+					}
+				},
+				"read-pkg": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"requires": {
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+					"requires": {
+						"find-up": "^2.0.0",
+						"read-pkg": "^3.0.0"
+					}
+				},
+				"rxjs": {
+					"version": "5.5.12",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+					"integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+					"requires": {
+						"symbol-observable": "1.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"symbol-observable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+					"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
+				},
+				"vinyl": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+					"requires": {
+						"clone": "^2.1.1",
+						"clone-buffer": "^1.0.0",
+						"clone-stats": "^1.0.0",
+						"cloneable-readable": "^1.0.0",
+						"remove-trailing-separator": "^1.0.1",
+						"replace-ext": "^1.0.0"
+					}
+				},
+				"yeoman-generator": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.5.tgz",
+					"integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
+					"requires": {
+						"async": "^2.6.0",
+						"chalk": "^2.3.0",
+						"cli-table": "^0.3.1",
+						"cross-spawn": "^6.0.5",
+						"dargs": "^5.1.0",
+						"dateformat": "^3.0.3",
+						"debug": "^3.1.0",
+						"detect-conflict": "^1.0.0",
+						"error": "^7.0.2",
+						"find-up": "^2.1.0",
+						"github-username": "^4.0.0",
+						"istextorbinary": "^2.2.1",
+						"lodash": "^4.17.10",
+						"make-dir": "^1.1.0",
+						"mem-fs-editor": "^4.0.0",
+						"minimist": "^1.2.0",
+						"pretty-bytes": "^4.0.2",
+						"read-chunk": "^2.1.0",
+						"read-pkg-up": "^3.0.0",
+						"rimraf": "^2.6.2",
+						"run-async": "^2.0.0",
+						"shelljs": "^0.8.0",
+						"text-table": "^0.2.0",
+						"through2": "^2.0.0",
+						"yeoman-environment": "^2.0.5"
 					}
 				}
 			}
@@ -22205,7 +21753,6 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/yo/-/yo-2.0.5.tgz",
 			"integrity": "sha512-PLyTNZSJjHkks/FIln+QE5PxV224MsekCzbROVhZEW0MvLyj/6ghWIVkdBmrwdAbapH8H9q21F1/pQ9Q0Lk9UA==",
-			"dev": true,
 			"requires": {
 				"async": "^2.6.1",
 				"chalk": "^2.4.1",
@@ -22242,20 +21789,17 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"chardet": {
 					"version": "0.7.0",
 					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-					"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-					"dev": true
+					"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
 				},
 				"cross-spawn": {
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
 						"path-key": "^2.0.1",
@@ -22268,7 +21812,6 @@
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
 					"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
-					"dev": true,
 					"requires": {
 						"chardet": "^0.7.0",
 						"iconv-lite": "^0.4.24",
@@ -22279,7 +21822,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
 					"requires": {
 						"locate-path": "^3.0.0"
 					}
@@ -22288,7 +21830,6 @@
 					"version": "8.3.2",
 					"resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
 					"integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
-					"dev": true,
 					"requires": {
 						"@sindresorhus/is": "^0.7.0",
 						"cacheable-request": "^2.1.1",
@@ -22313,7 +21854,6 @@
 					"version": "0.4.24",
 					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-					"dev": true,
 					"requires": {
 						"safer-buffer": ">= 2.1.2 < 3"
 					}
@@ -22322,7 +21862,6 @@
 					"version": "6.2.0",
 					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
 					"integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
-					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.0.0",
 						"chalk": "^2.0.0",
@@ -22343,7 +21882,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -22355,7 +21893,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
 					"requires": {
 						"p-locate": "^3.0.0",
 						"path-exists": "^3.0.0"
@@ -22365,7 +21902,6 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
 					"integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
-					"dev": true,
 					"requires": {
 						"is-wsl": "^1.1.0"
 					}
@@ -22374,7 +21910,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
 					"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
-					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
 					}
@@ -22383,7 +21918,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
 					"requires": {
 						"p-limit": "^2.0.0"
 					}
@@ -22391,14 +21925,12 @@
 				"p-try": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
-					"dev": true
+					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
 				},
 				"package-json": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/package-json/-/package-json-5.0.0.tgz",
 					"integrity": "sha512-EeHQFFTlEmLrkIQoxbE9w0FuAWHoc1XpthDqnZ/i9keOt701cteyXwAxQFLpVqVjj3feh2TodkihjLaRUtIgLg==",
-					"dev": true,
 					"requires": {
 						"got": "^8.3.1",
 						"registry-auth-token": "^3.3.2",
@@ -22409,14 +21941,12 @@
 				"prepend-http": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-					"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-					"dev": true
+					"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -22427,7 +21957,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
 					"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-					"dev": true,
 					"requires": {
 						"find-up": "^3.0.0",
 						"read-pkg": "^3.0.0"
@@ -22437,7 +21966,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -22446,7 +21974,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
 					"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-					"dev": true,
 					"requires": {
 						"prepend-http": "^2.0.0"
 					}
@@ -22457,7 +21984,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/yosay/-/yosay-2.0.2.tgz",
 			"integrity": "sha512-avX6nz2esp7IMXGag4gu6OyQBsMh/SEn+ZybGu3yKPlOTE6z9qJrzG/0X5vCq/e0rPFy0CUYCze0G5hL310ibA==",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0",
 				"ansi-styles": "^3.0.0",
@@ -22474,7 +22000,6 @@
 					"version": "1.1.3",
 					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -22486,16 +22011,14 @@
 						"ansi-styles": {
 							"version": "2.2.1",
 							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-							"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-							"dev": true
+							"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 						}
 					}
 				},
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,22 +85,6 @@
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
 			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
 		},
-		"@sinonjs/formatio": {
-			"version": "2.0.0",
-			"resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-			"integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
-			"requires": {
-				"samsam": "1.3.0"
-			}
-		},
-		"@sinonjs/samsam": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
-			"integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
-			"requires": {
-				"array-from": "^2.1.1"
-			}
-		},
 		"@storybook/addon-actions": {
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.4.3.tgz",
@@ -480,21 +464,6 @@
 				}
 			}
 		},
-		"acorn-jsx": {
-			"version": "3.0.1",
-			"resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-			"requires": {
-				"acorn": "^3.0.4"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "3.3.0",
-					"resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
-				}
-			}
-		},
 		"add-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
@@ -728,11 +697,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-		},
-		"array-from": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-			"integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
 		},
 		"array-ify": {
 			"version": "1.0.0",
@@ -2665,11 +2629,6 @@
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
 			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
 		},
-		"binaryextensions": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.1.tgz",
-			"integrity": "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA=="
-		},
 		"block-stream": {
 			"version": "0.0.9",
 			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -2903,25 +2862,6 @@
 				"isarray": "^1.0.0"
 			}
 		},
-		"buffer-alloc": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-			"requires": {
-				"buffer-alloc-unsafe": "^1.1.0",
-				"buffer-fill": "^1.0.0"
-			}
-		},
-		"buffer-alloc-unsafe": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
-		},
-		"buffer-fill": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
-		},
 		"buffer-from": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
@@ -3091,19 +3031,6 @@
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
 			"integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY="
-		},
-		"caller-path": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-			"requires": {
-				"callsites": "^0.2.0"
-			}
-		},
-		"callsites": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
 		},
 		"camel-case": {
 			"version": "3.0.0",
@@ -3311,21 +3238,6 @@
 				}
 			}
 		},
-		"class-extend": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/class-extend/-/class-extend-0.1.2.tgz",
-			"integrity": "sha1-gFeoKwD1P4Kl1ixQ74z/3sb6vDQ=",
-			"requires": {
-				"object-assign": "^2.0.0"
-			},
-			"dependencies": {
-				"object-assign": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-					"integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
-				}
-			}
-		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -3400,21 +3312,6 @@
 			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
 			"integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg=="
 		},
-		"cli-table": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-			"integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-			"requires": {
-				"colors": "1.0.3"
-			},
-			"dependencies": {
-				"colors": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-				}
-			}
-		},
 		"cli-truncate": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
@@ -3450,11 +3347,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
 			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-		},
-		"clone-buffer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
 		},
 		"clone-deep": {
 			"version": "2.0.2",
@@ -3503,16 +3395,6 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
 			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
-		},
-		"cloneable-readable": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
-			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
-			"requires": {
-				"inherits": "^2.0.1",
-				"process-nextick-args": "^2.0.0",
-				"readable-stream": "^2.3.5"
-			}
 		},
 		"cmd-shim": {
 			"version": "2.0.2",
@@ -3889,11 +3771,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
 			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
-		},
-		"contains-path": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
 		},
 		"content-disposition": {
 			"version": "0.5.2",
@@ -4866,11 +4743,6 @@
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
 			"integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
 		},
-		"deep-is": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
-		},
 		"default-uid": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/default-uid/-/default-uid-1.0.0.tgz",
@@ -5002,11 +4874,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
 			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-		},
-		"detect-conflict": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.1.tgz",
-			"integrity": "sha1-CIZXpmqWHAUBnbfEIwiDsca0F24="
 		},
 		"detect-indent": {
 			"version": "5.0.0",
@@ -5333,20 +5200,10 @@
 				"jsbn": "~0.1.0"
 			}
 		},
-		"editions": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-			"integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
-		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-		},
-		"ejs": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
-			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
 		},
 		"electron-to-chromium": {
 			"version": "1.3.45",
@@ -5439,15 +5296,6 @@
 			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 			"requires": {
 				"prr": "~1.0.1"
-			}
-		},
-		"error": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
-			"integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
-			"requires": {
-				"string-template": "~0.2.1",
-				"xtend": "~4.0.0"
 			}
 		},
 		"error-ex": {
@@ -5638,364 +5486,6 @@
 				"estraverse": "^4.1.1"
 			}
 		},
-		"eslint": {
-			"version": "3.19.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-			"integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
-			"requires": {
-				"babel-code-frame": "^6.16.0",
-				"chalk": "^1.1.3",
-				"concat-stream": "^1.5.2",
-				"debug": "^2.1.1",
-				"doctrine": "^2.0.0",
-				"escope": "^3.6.0",
-				"espree": "^3.4.0",
-				"esquery": "^1.0.0",
-				"estraverse": "^4.2.0",
-				"esutils": "^2.0.2",
-				"file-entry-cache": "^2.0.0",
-				"glob": "^7.0.3",
-				"globals": "^9.14.0",
-				"ignore": "^3.2.0",
-				"imurmurhash": "^0.1.4",
-				"inquirer": "^0.12.0",
-				"is-my-json-valid": "^2.10.0",
-				"is-resolvable": "^1.0.0",
-				"js-yaml": "^3.5.1",
-				"json-stable-stringify": "^1.0.0",
-				"levn": "^0.3.0",
-				"lodash": "^4.0.0",
-				"mkdirp": "^0.5.0",
-				"natural-compare": "^1.4.0",
-				"optionator": "^0.8.2",
-				"path-is-inside": "^1.0.1",
-				"pluralize": "^1.2.1",
-				"progress": "^1.1.8",
-				"require-uncached": "^1.0.2",
-				"shelljs": "^0.7.5",
-				"strip-bom": "^3.0.0",
-				"strip-json-comments": "~2.0.1",
-				"table": "^3.7.8",
-				"text-table": "~0.2.0",
-				"user-home": "^2.0.0"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "4.11.8",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-					"requires": {
-						"co": "^4.6.0",
-						"json-stable-stringify": "^1.0.1"
-					}
-				},
-				"ajv-keywords": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-					"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
-				},
-				"ansi-escapes": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"cli-cursor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-					"requires": {
-						"restore-cursor": "^1.0.1"
-					}
-				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"figures": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-					"requires": {
-						"escape-string-regexp": "^1.0.5",
-						"object-assign": "^4.1.0"
-					}
-				},
-				"inquirer": {
-					"version": "0.12.0",
-					"resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-					"integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-					"requires": {
-						"ansi-escapes": "^1.1.0",
-						"ansi-regex": "^2.0.0",
-						"chalk": "^1.0.0",
-						"cli-cursor": "^1.0.1",
-						"cli-width": "^2.0.0",
-						"figures": "^1.3.5",
-						"lodash": "^4.3.0",
-						"readline2": "^1.0.1",
-						"run-async": "^0.1.0",
-						"rx-lite": "^3.1.2",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.0",
-						"through": "^2.3.6"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"onetime": {
-					"version": "1.1.0",
-					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
-				},
-				"restore-cursor": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-					"requires": {
-						"exit-hook": "^1.0.0",
-						"onetime": "^1.0.0"
-					}
-				},
-				"run-async": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-					"integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-					"requires": {
-						"once": "^1.3.0"
-					}
-				},
-				"rx-lite": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-					"integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
-				},
-				"shelljs": {
-					"version": "0.7.8",
-					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-					"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-					"requires": {
-						"glob": "^7.0.0",
-						"interpret": "^1.0.0",
-						"rechoir": "^0.6.2"
-					}
-				},
-				"slice-ansi": {
-					"version": "0.0.4",
-					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-					"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				},
-				"table": {
-					"version": "3.8.3",
-					"resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
-					"integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
-					"requires": {
-						"ajv": "^4.7.0",
-						"ajv-keywords": "^1.0.0",
-						"chalk": "^1.1.1",
-						"lodash": "^4.0.0",
-						"slice-ansi": "0.0.4",
-						"string-width": "^2.0.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-						},
-						"is-fullwidth-code-point": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-						},
-						"string-width": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-							"requires": {
-								"is-fullwidth-code-point": "^2.0.0",
-								"strip-ansi": "^4.0.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-							"requires": {
-								"ansi-regex": "^3.0.0"
-							}
-						}
-					}
-				}
-			}
-		},
-		"eslint-import-resolver-node": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
-			"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
-			"requires": {
-				"debug": "^2.6.9",
-				"resolve": "^1.5.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
-			}
-		},
-		"eslint-module-utils": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
-			"integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
-			"requires": {
-				"debug": "^2.6.8",
-				"pkg-dir": "^1.0.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"pkg-dir": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-					"requires": {
-						"find-up": "^1.0.0"
-					}
-				}
-			}
-		},
-		"eslint-plugin-github": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-0.12.0.tgz",
-			"integrity": "sha1-qWFCtlz2XBPAlyC+Uwjke1Z9O78="
-		},
-		"eslint-plugin-import": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
-			"integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
-			"requires": {
-				"contains-path": "^0.1.0",
-				"debug": "^2.6.8",
-				"doctrine": "1.5.0",
-				"eslint-import-resolver-node": "^0.3.1",
-				"eslint-module-utils": "^2.2.0",
-				"has": "^1.0.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.3",
-				"read-pkg-up": "^2.0.0",
-				"resolve": "^1.6.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"doctrine": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-					"requires": {
-						"esutils": "^2.0.2",
-						"isarray": "^1.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^2.0.0"
-					}
-				},
-				"resolve": {
-					"version": "1.8.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-					"requires": {
-						"path-parse": "^1.0.5"
-					}
-				}
-			}
-		},
-		"eslint-rule-documentation": {
-			"version": "1.0.21",
-			"resolved": "https://registry.npmjs.org/eslint-rule-documentation/-/eslint-rule-documentation-1.0.21.tgz",
-			"integrity": "sha512-XW/SKOQnvyg6SJQ7BcM4R5vJ6N5ivA6Jqbh4GPPjBwee4Jj1Bne9R1JM5duMObtNiYfeQt/yYIAsHCDttFbTsA=="
-		},
 		"espower-location-detector": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/espower-location-detector/-/espower-location-detector-1.0.0.tgz",
@@ -6014,15 +5504,6 @@
 				}
 			}
 		},
-		"espree": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
-			"requires": {
-				"acorn": "^5.5.0",
-				"acorn-jsx": "^3.0.0"
-			}
-		},
 		"esprima": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
@@ -6034,14 +5515,6 @@
 			"integrity": "sha512-jdkJG9jswjKCCDmEridNUuIQei9algr+o66ZZ19610ZoBsiWLRsQGNYS4HGez3Z/DsR0lhANGAqiwBUclPuNag==",
 			"requires": {
 				"core-js": "^2.0.0"
-			}
-		},
-		"esquery": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
-			"requires": {
-				"estraverse": "^4.0.0"
 			}
 		},
 		"esrecurse": {
@@ -6484,11 +5957,6 @@
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
 			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
 		},
-		"fast-levenshtein": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-		},
 		"fast-memoize": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.3.2.tgz",
@@ -6702,14 +6170,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
 			"integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc="
-		},
-		"for-each": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-			"requires": {
-				"is-callable": "^1.1.3"
-			}
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -7437,22 +6897,6 @@
 				"globule": "^1.0.0"
 			}
 		},
-		"generate-function": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
-			"integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-			"requires": {
-				"is-property": "^1.0.2"
-			}
-		},
-		"generate-object-property": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-			"requires": {
-				"is-property": "^1.0.0"
-			}
-		},
 		"get-caller-file": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -7503,15 +6947,6 @@
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
-			}
-		},
-		"gh-got": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz",
-			"integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
-			"requires": {
-				"got": "^6.2.0",
-				"is-plain-obj": "^1.1.0"
 			}
 		},
 		"gh-pages": {
@@ -7691,14 +7126,6 @@
 				"ini": "^1.3.2"
 			}
 		},
-		"github-username": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz",
-			"integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
-			"requires": {
-				"gh-got": "^5.0.0"
-			}
-		},
 		"glamor": {
 			"version": "2.20.40",
 			"resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.40.tgz",
@@ -7834,11 +7261,6 @@
 				"npm-conf": "^1.1.3",
 				"tunnel": "^0.0.5"
 			}
-		},
-		"globals": {
-			"version": "9.18.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
 		},
 		"globby": {
 			"version": "6.1.0",
@@ -8118,6 +7540,17 @@
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.0"
+			}
+		},
+		"hawk": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+			"requires": {
+				"boom": "2.x.x",
+				"cryptiles": "2.x.x",
+				"hoek": "2.x.x",
+				"sntp": "1.x.x"
 			}
 		},
 		"he": {
@@ -8903,23 +8336,6 @@
 				"is-path-inside": "^1.0.0"
 			}
 		},
-		"is-my-ip-valid": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-			"integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
-		},
-		"is-my-json-valid": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
-			"integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
-			"requires": {
-				"generate-function": "^2.0.0",
-				"generate-object-property": "^1.1.0",
-				"is-my-ip-valid": "^1.0.0",
-				"jsonpointer": "^4.0.0",
-				"xtend": "^4.0.0"
-			}
-		},
 		"is-npm": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -9041,11 +8457,6 @@
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
 			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
 		},
-		"is-property": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
-		},
 		"is-redirect": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
@@ -9063,11 +8474,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
 			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
-		},
-		"is-resolvable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
 		},
 		"is-retry-allowed": {
 			"version": "1.1.0",
@@ -9181,14 +8587,6 @@
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
-		"isbinaryfile": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
-			"integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
-			"requires": {
-				"buffer-alloc": "^1.2.0"
-			}
-		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -9212,16 +8610,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-		},
-		"istextorbinary": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",
-			"integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
-			"requires": {
-				"binaryextensions": "2",
-				"editions": "^1.3.3",
-				"textextensions": "2"
-			}
 		},
 		"isurl": {
 			"version": "1.0.0",
@@ -9395,11 +8783,6 @@
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
 			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
 		},
-		"jsonpointer": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
-		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -9417,11 +8800,6 @@
 					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
 			}
-		},
-		"just-extend": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
-			"integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ=="
 		},
 		"keycode": {
 			"version": "2.2.0",
@@ -9768,26 +9146,6 @@
 				}
 			}
 		},
-		"levn": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-			"requires": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
-			}
-		},
-		"load-json-file": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"parse-json": "^4.0.0",
-				"pify": "^3.0.0",
-				"strip-bom": "^3.0.0"
-			}
-		},
 		"loader-runner": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
@@ -9876,11 +9234,6 @@
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
 			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
-		},
-		"lodash.get": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
 		},
 		"lodash.isarguments": {
 			"version": "3.1.0",
@@ -9996,11 +9349,6 @@
 			"requires": {
 				"chalk": "^2.0.1"
 			}
-		},
-		"lolex": {
-			"version": "2.7.5",
-			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
-			"integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q=="
 		},
 		"longest": {
 			"version": "1.0.1",
@@ -10239,53 +9587,6 @@
 				"through2": "^2.0.0",
 				"vinyl": "^1.1.0",
 				"vinyl-file": "^2.0.0"
-			}
-		},
-		"mem-fs-editor": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz",
-			"integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
-			"requires": {
-				"commondir": "^1.0.1",
-				"deep-extend": "^0.4.0",
-				"ejs": "^2.3.1",
-				"glob": "^7.0.3",
-				"globby": "^6.1.0",
-				"mkdirp": "^0.5.0",
-				"multimatch": "^2.0.0",
-				"rimraf": "^2.2.8",
-				"through2": "^2.0.0",
-				"vinyl": "^2.0.1"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
-				},
-				"clone-stats": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-				},
-				"deep-extend": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-					"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-				},
-				"vinyl": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-					"requires": {
-						"clone": "^2.1.1",
-						"clone-buffer": "^1.0.0",
-						"clone-stats": "^1.0.0",
-						"cloneable-readable": "^1.0.0",
-						"remove-trailing-separator": "^1.0.1",
-						"replace-ext": "^1.0.0"
-					}
-				}
 			}
 		},
 		"memory-fs": {
@@ -10676,11 +9977,6 @@
 				}
 			}
 		},
-		"natural-compare": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
-		},
 		"negotiator": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -10700,41 +9996,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
 			"integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
-		},
-		"nise": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.6.tgz",
-			"integrity": "sha512-1GedetLKzmqmgwabuMSqPsT7oumdR77SBpDfNNJhADRIeA3LN/2RVqR4fFqwvzhAqcTef6PPCzQwITE/YQ8S8A==",
-			"requires": {
-				"@sinonjs/formatio": "3.0.0",
-				"just-extend": "^3.0.0",
-				"lolex": "^2.3.2",
-				"path-to-regexp": "^1.7.0",
-				"text-encoding": "^0.6.4"
-			},
-			"dependencies": {
-				"@sinonjs/formatio": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
-					"integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
-					"requires": {
-						"@sinonjs/samsam": "2.1.0"
-					}
-				},
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"path-to-regexp": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-					"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-					"requires": {
-						"isarray": "0.0.1"
-					}
-				}
-			}
 		},
 		"no-case": {
 			"version": "2.3.2",
@@ -11179,16 +10440,6 @@
 					"requires": {
 						"co": "^4.6.0",
 						"json-stable-stringify": "^1.0.1"
-					},
-					"dependencies": {
-						"json-stable-stringify": {
-							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-							"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-							"requires": {
-								"jsonify": "~0.0.0"
-							}
-						}
 					}
 				},
 				"ansi-align": {
@@ -11216,6 +10467,11 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
 					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+				},
+				"aws-sign2": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+					"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
 				},
 				"balanced-match": {
 					"version": "1.0.0",
@@ -11431,6 +10687,16 @@
 						"locate-path": "^2.0.0"
 					}
 				},
+				"form-data": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.5",
+						"mime-types": "^2.1.12"
+					}
+				},
 				"fs.realpath": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -11495,6 +10761,15 @@
 					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
 					"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
 				},
+				"har-validator": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+					"requires": {
+						"ajv": "^4.9.1",
+						"har-schema": "^1.0.5"
+					}
+				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -11504,6 +10779,16 @@
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
 					"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+				},
+				"http-signature": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+					"requires": {
+						"assert-plus": "^0.2.0",
+						"jsprim": "^1.2.2",
+						"sshpk": "^1.7.0"
+					}
 				},
 				"import-lazy": {
 					"version": "2.1.0",
@@ -13287,68 +12572,6 @@
 								"tough-cookie": "~2.3.0",
 								"tunnel-agent": "^0.6.0",
 								"uuid": "^3.0.0"
-							},
-							"dependencies": {
-								"aws-sign2": {
-									"version": "0.6.0",
-									"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-									"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-								},
-								"form-data": {
-									"version": "2.1.4",
-									"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-									"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-									"requires": {
-										"asynckit": "^0.4.0",
-										"combined-stream": "^1.0.5",
-										"mime-types": "^2.1.12"
-									}
-								},
-								"har-validator": {
-									"version": "4.2.1",
-									"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-									"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-									"requires": {
-										"ajv": "^4.9.1",
-										"har-schema": "^1.0.5"
-									}
-								},
-								"hawk": {
-									"version": "3.1.3",
-									"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-									"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-									"requires": {
-										"boom": "2.x.x",
-										"cryptiles": "2.x.x",
-										"hoek": "2.x.x",
-										"sntp": "1.x.x"
-									}
-								},
-								"http-signature": {
-									"version": "1.1.1",
-									"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-									"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-									"requires": {
-										"assert-plus": "^0.2.0",
-										"jsprim": "^1.2.2",
-										"sshpk": "^1.7.0"
-									}
-								},
-								"performance-now": {
-									"version": "0.2.0",
-									"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-									"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-								},
-								"qs": {
-									"version": "6.4.0",
-									"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-									"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
-								},
-								"stringstream": {
-									"version": "0.0.6",
-									"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-									"integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
-								}
 							}
 						},
 						"retry": {
@@ -14256,6 +13479,11 @@
 					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
 					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 				},
+				"performance-now": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+					"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+				},
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -14280,10 +13508,14 @@
 						"once": "^1.3.1"
 					}
 				},
+				"qs": {
+					"version": "6.4.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+					"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+				},
 				"rc": {
 					"version": "1.2.6",
-					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
-					"integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
+					"resolved": "",
 					"requires": {
 						"deep-extend": "~0.4.0",
 						"ini": "~1.3.0",
@@ -14313,17 +13545,25 @@
 					"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
 					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
 					"requires": {
+						"aws-sign2": "~0.6.0",
 						"aws4": "^1.2.1",
 						"caseless": "~0.12.0",
 						"combined-stream": "~1.0.5",
 						"extend": "~3.0.0",
 						"forever-agent": "~0.6.1",
+						"form-data": "~2.1.1",
+						"har-validator": "~4.2.1",
+						"hawk": "~3.1.3",
+						"http-signature": "~1.1.0",
 						"is-typedarray": "~1.0.0",
 						"isstream": "~0.1.2",
 						"json-stringify-safe": "~5.0.1",
 						"mime-types": "~2.1.7",
 						"oauth-sign": "~0.8.1",
+						"performance-now": "^0.2.0",
+						"qs": "~6.4.0",
 						"safe-buffer": "^5.0.1",
+						"stringstream": "~0.0.4",
 						"tough-cookie": "~2.3.0",
 						"tunnel-agent": "^0.6.0",
 						"uuid": "^3.0.0"
@@ -14667,11 +13907,6 @@
 				}
 			}
 		},
-		"object-inspect": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-			"integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
-		},
 		"object-keys": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
@@ -14814,26 +14049,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/option-chain/-/option-chain-1.0.0.tgz",
 			"integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI="
-		},
-		"optionator": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-			"requires": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
-			},
-			"dependencies": {
-				"wordwrap": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-				}
-			}
 		},
 		"original": {
 			"version": "1.0.2",
@@ -15317,11 +14532,6 @@
 				"irregular-plurals": "^1.0.0"
 			}
 		},
-		"pluralize": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-			"integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU="
-		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -15484,14 +14694,6 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
-			}
-		},
-		"postcss-less": {
-			"version": "0.14.0",
-			"resolved": "http://registry.npmjs.org/postcss-less/-/postcss-less-0.14.0.tgz",
-			"integrity": "sha1-xjGwicbM5CK5oQ86lY0r7dOBkyQ=",
-			"requires": {
-				"postcss": "^5.0.21"
 			}
 		},
 		"postcss-load-config": {
@@ -15916,49 +15118,6 @@
 				"postcss-value-parser": "^3.0.1"
 			}
 		},
-		"postcss-reporter": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-1.4.1.tgz",
-			"integrity": "sha1-wTbwpbFhkV83ndN2XGEHX357mvI=",
-			"requires": {
-				"chalk": "^1.0.0",
-				"lodash": "^4.1.0",
-				"log-symbols": "^1.0.2",
-				"postcss": "^5.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"log-symbols": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-					"requires": {
-						"chalk": "^1.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				}
-			}
-		},
 		"postcss-resolve-nested-selector": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
@@ -15970,14 +15129,6 @@
 			"integrity": "sha1-Oz0cS0OiTDlC4vC+eWE4KzSLOxM=",
 			"requires": {
 				"postcss": "^5.2.16"
-			}
-		},
-		"postcss-scss": {
-			"version": "0.1.9",
-			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-0.1.9.tgz",
-			"integrity": "sha1-dgbK/2S7SzS3YFq3SVdM942Iawg=",
-			"requires": {
-				"postcss": "^5.1.0"
 			}
 		},
 		"postcss-selector-parser": {
@@ -16026,11 +15177,6 @@
 				"uniqs": "^2.0.0"
 			}
 		},
-		"prelude-ls": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-		},
 		"prepend-http": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
@@ -16040,11 +15186,6 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-		},
-		"pretty-bytes": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
-			"integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
 		},
 		"pretty-error": {
 			"version": "2.1.1",
@@ -16610,15 +15751,6 @@
 				"velocity-react": "^1.3.1"
 			}
 		},
-		"read-chunk": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
-			"integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
-			"requires": {
-				"pify": "^3.0.0",
-				"safe-buffer": "^5.1.1"
-			}
-		},
 		"read-cmd-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
@@ -16783,31 +15915,6 @@
 				"minimatch": "^3.0.2",
 				"readable-stream": "^2.0.2",
 				"set-immediate-shim": "^1.0.1"
-			}
-		},
-		"readline2": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-			"integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-			"requires": {
-				"code-point-at": "^1.0.0",
-				"is-fullwidth-code-point": "^1.0.0",
-				"mute-stream": "0.0.5"
-			},
-			"dependencies": {
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"mute-stream": {
-					"version": "0.0.5",
-					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-					"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
-				}
 			}
 		},
 		"recast": {
@@ -17194,15 +16301,6 @@
 			"resolved": "https://registry.npmjs.org/require-precompiled/-/require-precompiled-0.1.0.tgz",
 			"integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo="
 		},
-		"require-uncached": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-			"requires": {
-				"caller-path": "^0.1.0",
-				"resolve-from": "^1.0.0"
-			}
-		},
 		"requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -17240,11 +16338,6 @@
 				"global-modules": "^1.0.0"
 			}
 		},
-		"resolve-from": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
-		},
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -17265,14 +16358,6 @@
 			"requires": {
 				"onetime": "^2.0.0",
 				"signal-exit": "^3.0.2"
-			}
-		},
-		"resumer": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
-			"integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
-			"requires": {
-				"through": "~2.3.4"
 			}
 		},
 		"ret": {
@@ -17393,11 +16478,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-		},
-		"samsam": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
 		},
 		"sass-graph": {
 			"version": "2.2.4",
@@ -17735,20 +16815,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-		},
-		"sinon": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-5.1.1.tgz",
-			"integrity": "sha512-h/3uHscbt5pQNxkf7Y/Lb9/OM44YNCicHakcq73ncbrIS8lXg+ZGOZbtuU+/km4YnyiCYfQQEwANaReJz7KDfw==",
-			"requires": {
-				"@sinonjs/formatio": "^2.0.0",
-				"diff": "^3.5.0",
-				"lodash.get": "^4.4.2",
-				"lolex": "^2.4.2",
-				"nise": "^1.3.3",
-				"supports-color": "^5.4.0",
-				"type-detect": "^4.0.8"
-			}
 		},
 		"slash": {
 			"version": "1.0.0",
@@ -18205,11 +17271,6 @@
 				}
 			}
 		},
-		"string-template": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
-			"integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
-		},
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -18254,16 +17315,6 @@
 				"function-bind": "^1.0.2"
 			}
 		},
-		"string.prototype.trim": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
-			"integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
-			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.5.0",
-				"function-bind": "^1.0.2"
-			}
-		},
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -18282,6 +17333,11 @@
 				"is-alphanumerical": "^1.0.0",
 				"is-hexadecimal": "^1.0.0"
 			}
+		},
+		"stringstream": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+			"integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
@@ -18950,331 +18006,6 @@
 				"stylelint": "^7.13.0"
 			}
 		},
-		"stylelint-test-rule-tape": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/stylelint-test-rule-tape/-/stylelint-test-rule-tape-0.2.0.tgz",
-			"integrity": "sha1-NRTszoygrIq78imuSECgl5ZIqsg=",
-			"requires": {
-				"stylelint": "^6.2.0",
-				"tape": "^4.5.1"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "4.11.8",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-					"requires": {
-						"co": "^4.6.0",
-						"json-stable-stringify": "^1.0.1"
-					}
-				},
-				"ajv-keywords": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-					"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
-				},
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-				},
-				"camelcase": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"cosmiconfig": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz",
-					"integrity": "sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"js-yaml": "^3.4.3",
-						"minimist": "^1.2.0",
-						"object-assign": "^4.0.1",
-						"os-homedir": "^1.0.1",
-						"parse-json": "^2.2.0",
-						"pinkie-promise": "^2.0.0",
-						"require-from-string": "^1.1.0"
-					}
-				},
-				"doiuse": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/doiuse/-/doiuse-2.6.0.tgz",
-					"integrity": "sha1-GJLRC2Gpo1at2/K2FJM+gfi7ODQ=",
-					"requires": {
-						"browserslist": "^1.1.1",
-						"caniuse-db": "^1.0.30000187",
-						"css-rule-stream": "^1.1.0",
-						"duplexer2": "0.0.2",
-						"jsonfilter": "^1.1.2",
-						"ldjson-stream": "^1.2.1",
-						"lodash": "^4.0.0",
-						"multimatch": "^2.0.0",
-						"postcss": "^5.0.8",
-						"source-map": "^0.4.2",
-						"through2": "^0.6.3",
-						"yargs": "^3.5.4"
-					}
-				},
-				"get-stdin": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-					"integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
-				},
-				"globby": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-					"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-					"requires": {
-						"array-union": "^1.0.1",
-						"arrify": "^1.0.0",
-						"glob": "^7.0.3",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"html-tags": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-1.2.0.tgz",
-					"integrity": "sha1-x43mW1Zjqll5id0rerSSANfk25g="
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"log-symbols": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-					"requires": {
-						"chalk": "^1.0.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "^1.0.0"
-					}
-				},
-				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"requires": {
-						"error-ex": "^1.2.0"
-					}
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-				},
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"require-from-string": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-					"integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
-				},
-				"resolve-from": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
-				},
-				"slice-ansi": {
-					"version": "0.0.4",
-					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-					"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
-				},
-				"specificity": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/specificity/-/specificity-0.2.1.tgz",
-					"integrity": "sha1-OnBHwqF581Ni45kHRc6lOfFRYbg="
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-				},
-				"stylelint": {
-					"version": "6.9.0",
-					"resolved": "http://registry.npmjs.org/stylelint/-/stylelint-6.9.0.tgz",
-					"integrity": "sha1-LSOHCXwetU5uMjuMSGdyXaXgIUg=",
-					"requires": {
-						"autoprefixer": "^6.0.0",
-						"balanced-match": "^0.4.0",
-						"chalk": "^1.1.1",
-						"colorguard": "^1.2.0",
-						"cosmiconfig": "^1.1.0",
-						"doiuse": "^2.3.0",
-						"execall": "^1.0.0",
-						"get-stdin": "^5.0.0",
-						"globby": "^5.0.0",
-						"globjoin": "^0.1.2",
-						"html-tags": "^1.1.1",
-						"htmlparser2": "^3.9.0",
-						"lodash": "^4.0.0",
-						"log-symbols": "^1.0.2",
-						"meow": "^3.3.0",
-						"multimatch": "^2.1.0",
-						"normalize-selector": "^0.2.0",
-						"postcss": "^5.0.20",
-						"postcss-less": "^0.14.0",
-						"postcss-reporter": "^1.3.0",
-						"postcss-resolve-nested-selector": "^0.1.1",
-						"postcss-scss": "^0.1.3",
-						"postcss-selector-parser": "^2.0.0",
-						"postcss-value-parser": "^3.1.1",
-						"resolve-from": "^2.0.0",
-						"specificity": "^0.2.1",
-						"string-width": "^1.0.1",
-						"stylehacks": "^2.3.0",
-						"sugarss": "^0.1.2",
-						"svg-tags": "^1.0.0",
-						"table": "^3.7.8"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				},
-				"table": {
-					"version": "3.8.3",
-					"resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
-					"integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
-					"requires": {
-						"ajv": "^4.7.0",
-						"ajv-keywords": "^1.0.0",
-						"chalk": "^1.1.1",
-						"lodash": "^4.0.0",
-						"slice-ansi": "0.0.4",
-						"string-width": "^2.0.0"
-					},
-					"dependencies": {
-						"is-fullwidth-code-point": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-						},
-						"string-width": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-							"requires": {
-								"is-fullwidth-code-point": "^2.0.0",
-								"strip-ansi": "^4.0.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-							"requires": {
-								"ansi-regex": "^3.0.0"
-							}
-						}
-					}
-				},
-				"through2": {
-					"version": "0.6.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-					"requires": {
-						"readable-stream": ">=1.0.33-1 <1.1.0-0",
-						"xtend": ">=4.0.0 <4.1.0-0"
-					}
-				},
-				"window-size": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-					"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
-				},
-				"yargs": {
-					"version": "3.32.0",
-					"resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-					"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-					"requires": {
-						"camelcase": "^2.0.1",
-						"cliui": "^3.0.3",
-						"decamelize": "^1.1.1",
-						"os-locale": "^1.4.0",
-						"string-width": "^1.0.1",
-						"window-size": "^0.1.4",
-						"y18n": "^3.2.0"
-					}
-				}
-			}
-		},
 		"sudo-block": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/sudo-block/-/sudo-block-1.2.0.tgz",
@@ -19307,14 +18038,6 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
-			}
-		},
-		"sugarss": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/sugarss/-/sugarss-0.1.6.tgz",
-			"integrity": "sha1-/jrA4eBygq7x3oSoC3I4b/Tn6jc=",
-			"requires": {
-				"postcss": "^5.2.0"
 			}
 		},
 		"supports-color": {
@@ -19589,49 +18312,6 @@
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
 			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
 		},
-		"tape": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/tape/-/tape-4.9.1.tgz",
-			"integrity": "sha512-6fKIXknLpoe/Jp4rzHKFPpJUHDHDqn8jus99IfPnHIjyz78HYlefTGD3b5EkbQzuLfaEvmfPK3IolLgq2xT3kw==",
-			"requires": {
-				"deep-equal": "~1.0.1",
-				"defined": "~1.0.0",
-				"for-each": "~0.3.3",
-				"function-bind": "~1.1.1",
-				"glob": "~7.1.2",
-				"has": "~1.0.3",
-				"inherits": "~2.0.3",
-				"minimist": "~1.2.0",
-				"object-inspect": "~1.6.0",
-				"resolve": "~1.7.1",
-				"resumer": "~0.0.0",
-				"string.prototype.trim": "~1.1.2",
-				"through": "~2.3.8"
-			},
-			"dependencies": {
-				"has": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-					"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-					"requires": {
-						"function-bind": "^1.1.1"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				},
-				"resolve": {
-					"version": "1.7.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-					"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
-					"requires": {
-						"path-parse": "^1.0.5"
-					}
-				}
-			}
-		},
 		"tar": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
@@ -19676,15 +18356,6 @@
 				}
 			}
 		},
-		"tempy": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/tempy/-/tempy-0.2.1.tgz",
-			"integrity": "sha512-LB83o9bfZGrntdqPuRdanIVCPReam9SOZKW0fOy5I9X3A854GGWi0tjCqoXEk84XIEYBc/x9Hq3EFop/H5wJaw==",
-			"requires": {
-				"temp-dir": "^1.0.0",
-				"unique-string": "^1.0.0"
-			}
-		},
 		"term-size": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -19709,11 +18380,6 @@
 				}
 			}
 		},
-		"text-encoding": {
-			"version": "0.6.4",
-			"resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
-		},
 		"text-extensions": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -19723,11 +18389,6 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
-		},
-		"textextensions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.2.0.tgz",
-			"integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA=="
 		},
 		"through": {
 			"version": "2.3.8",
@@ -19960,19 +18621,6 @@
 				"minimatch": "3.0.x",
 				"walk": "2.3.x"
 			}
-		},
-		"type-check": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-			"requires": {
-				"prelude-ls": "~1.1.2"
-			}
-		},
-		"type-detect": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
 		},
 		"type-is": {
 			"version": "1.6.16",
@@ -21079,11 +19727,6 @@
 				}
 			}
 		},
-		"yeoman-assert": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yeoman-assert/-/yeoman-assert-3.1.1.tgz",
-			"integrity": "sha512-bCuLb/j/WzpvrJZCTdJJLFzm7KK8IYQJ3+dF9dYtNs2CUYyezFJDuULiZ2neM4eqjf45GN1KH/MzCTT3i90wUQ=="
-		},
 		"yeoman-character": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/yeoman-character/-/yeoman-character-1.1.0.tgz",
@@ -21226,525 +19869,6 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
 						"ansi-regex": "^3.0.0"
-					}
-				}
-			}
-		},
-		"yeoman-generator": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-1.1.1.tgz",
-			"integrity": "sha1-QMK09s374F4ZUv3XKTPw2JJdvfU=",
-			"requires": {
-				"async": "^2.0.0",
-				"chalk": "^1.0.0",
-				"class-extend": "^0.1.0",
-				"cli-table": "^0.3.1",
-				"cross-spawn": "^5.0.1",
-				"dargs": "^5.1.0",
-				"dateformat": "^2.0.0",
-				"debug": "^2.1.0",
-				"detect-conflict": "^1.0.0",
-				"error": "^7.0.2",
-				"find-up": "^2.1.0",
-				"github-username": "^3.0.0",
-				"glob": "^7.0.3",
-				"istextorbinary": "^2.1.0",
-				"lodash": "^4.11.1",
-				"mem-fs-editor": "^3.0.0",
-				"minimist": "^1.2.0",
-				"mkdirp": "^0.5.0",
-				"path-exists": "^3.0.0",
-				"path-is-absolute": "^1.0.0",
-				"pretty-bytes": "^4.0.2",
-				"read-chunk": "^2.0.0",
-				"read-pkg-up": "^2.0.0",
-				"rimraf": "^2.2.0",
-				"run-async": "^2.0.0",
-				"shelljs": "^0.7.0",
-				"text-table": "^0.2.0",
-				"through2": "^2.0.0",
-				"user-home": "^2.0.0",
-				"yeoman-environment": "^1.1.0"
-			},
-			"dependencies": {
-				"ansi-escapes": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"cli-cursor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-					"requires": {
-						"restore-cursor": "^1.0.1"
-					}
-				},
-				"dargs": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
-					"integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk="
-				},
-				"dateformat": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-					"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
-				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"diff": {
-					"version": "2.2.3",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
-					"integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k="
-				},
-				"external-editor": {
-					"version": "1.1.1",
-					"resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
-					"integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
-					"requires": {
-						"extend": "^3.0.0",
-						"spawn-sync": "^1.0.15",
-						"tmp": "^0.0.29"
-					}
-				},
-				"figures": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-					"requires": {
-						"escape-string-regexp": "^1.0.5",
-						"object-assign": "^4.1.0"
-					}
-				},
-				"globby": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
-					"integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
-					"requires": {
-						"array-union": "^1.0.1",
-						"arrify": "^1.0.0",
-						"glob": "^6.0.1",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					},
-					"dependencies": {
-						"glob": {
-							"version": "6.0.4",
-							"resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-							"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-							"requires": {
-								"inflight": "^1.0.4",
-								"inherits": "2",
-								"minimatch": "2 || 3",
-								"once": "^1.3.0",
-								"path-is-absolute": "^1.0.0"
-							}
-						}
-					}
-				},
-				"inquirer": {
-					"version": "1.2.3",
-					"resolved": "http://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
-					"integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
-					"requires": {
-						"ansi-escapes": "^1.1.0",
-						"chalk": "^1.0.0",
-						"cli-cursor": "^1.0.1",
-						"cli-width": "^2.0.0",
-						"external-editor": "^1.1.0",
-						"figures": "^1.3.5",
-						"lodash": "^4.3.0",
-						"mute-stream": "0.0.6",
-						"pinkie-promise": "^2.0.0",
-						"run-async": "^2.2.0",
-						"rx": "^4.1.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.0",
-						"through": "^2.3.6"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"log-symbols": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-					"requires": {
-						"chalk": "^1.0.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				},
-				"mute-stream": {
-					"version": "0.0.6",
-					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
-					"integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s="
-				},
-				"onetime": {
-					"version": "1.1.0",
-					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-				},
-				"read-pkg-up": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^2.0.0"
-					}
-				},
-				"restore-cursor": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-					"requires": {
-						"exit-hook": "^1.0.0",
-						"onetime": "^1.0.0"
-					}
-				},
-				"shelljs": {
-					"version": "0.7.8",
-					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-					"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-					"requires": {
-						"glob": "^7.0.0",
-						"interpret": "^1.0.0",
-						"rechoir": "^0.6.2"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				},
-				"tmp": {
-					"version": "0.0.29",
-					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-					"integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
-					"requires": {
-						"os-tmpdir": "~1.0.1"
-					}
-				},
-				"untildify": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
-					"integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
-					"requires": {
-						"os-homedir": "^1.0.0"
-					}
-				},
-				"yeoman-environment": {
-					"version": "1.6.6",
-					"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.6.tgz",
-					"integrity": "sha1-zYX6Z9FWBg5EDXgH1+988NLR1nE=",
-					"requires": {
-						"chalk": "^1.0.0",
-						"debug": "^2.0.0",
-						"diff": "^2.1.2",
-						"escape-string-regexp": "^1.0.2",
-						"globby": "^4.0.0",
-						"grouped-queue": "^0.3.0",
-						"inquirer": "^1.0.2",
-						"lodash": "^4.11.1",
-						"log-symbols": "^1.0.1",
-						"mem-fs": "^1.1.0",
-						"text-table": "^0.2.0",
-						"untildify": "^2.0.0"
-					}
-				}
-			}
-		},
-		"yeoman-test": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/yeoman-test/-/yeoman-test-1.9.1.tgz",
-			"integrity": "sha512-aWB8CglmjBfXd+U5g5Cm1b8KVW0uotjo521IgkepvhNXiAX/YswHYGVnbEFb0m9ZdXztELuNJn2UtuwgFZIw6Q==",
-			"requires": {
-				"inquirer": "^5.2.0",
-				"lodash": "^4.17.10",
-				"mkdirp": "^0.5.1",
-				"pinkie-promise": "^2.0.1",
-				"rimraf": "^2.4.4",
-				"sinon": "^5.0.7",
-				"yeoman-environment": "^2.3.0",
-				"yeoman-generator": "^2.0.5"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"clone": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
-				},
-				"clone-stats": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-				},
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"dargs": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
-					"integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk="
-				},
-				"deep-extend": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-				},
-				"gh-got": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
-					"integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
-					"requires": {
-						"got": "^7.0.0",
-						"is-plain-obj": "^1.1.0"
-					}
-				},
-				"github-username": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
-					"integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
-					"requires": {
-						"gh-got": "^6.0.0"
-					}
-				},
-				"globby": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-					"integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
-					"requires": {
-						"array-union": "^1.0.1",
-						"dir-glob": "^2.0.0",
-						"glob": "^7.1.2",
-						"ignore": "^3.3.5",
-						"pify": "^3.0.0",
-						"slash": "^1.0.0"
-					}
-				},
-				"got": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-					"integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-					"requires": {
-						"decompress-response": "^3.2.0",
-						"duplexer3": "^0.1.4",
-						"get-stream": "^3.0.0",
-						"is-plain-obj": "^1.1.0",
-						"is-retry-allowed": "^1.0.0",
-						"is-stream": "^1.0.0",
-						"isurl": "^1.0.0-alpha5",
-						"lowercase-keys": "^1.0.0",
-						"p-cancelable": "^0.3.0",
-						"p-timeout": "^1.1.1",
-						"safe-buffer": "^5.0.1",
-						"timed-out": "^4.0.0",
-						"url-parse-lax": "^1.0.0",
-						"url-to-options": "^1.0.1"
-					}
-				},
-				"inquirer": {
-					"version": "5.2.0",
-					"resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
-					"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
-					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.0",
-						"cli-cursor": "^2.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^2.1.0",
-						"figures": "^2.0.0",
-						"lodash": "^4.3.0",
-						"mute-stream": "0.0.7",
-						"run-async": "^2.2.0",
-						"rxjs": "^5.5.2",
-						"string-width": "^2.1.0",
-						"strip-ansi": "^4.0.0",
-						"through": "^2.3.6"
-					}
-				},
-				"mem-fs-editor": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-4.0.3.tgz",
-					"integrity": "sha512-tgWmwI/+6vwu6POan82dTjxEpwAoaj0NAFnghtVo/FcLK2/7IhPUtFUUYlwou4MOY6OtjTUJtwpfH1h+eSUziw==",
-					"requires": {
-						"commondir": "^1.0.1",
-						"deep-extend": "^0.6.0",
-						"ejs": "^2.5.9",
-						"glob": "^7.0.3",
-						"globby": "^7.1.1",
-						"isbinaryfile": "^3.0.2",
-						"mkdirp": "^0.5.0",
-						"multimatch": "^2.0.0",
-						"rimraf": "^2.2.8",
-						"through2": "^2.0.0",
-						"vinyl": "^2.0.1"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				},
-				"p-cancelable": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-					"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
-				},
-				"p-timeout": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
-					"integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
-					"requires": {
-						"p-finally": "^1.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"requires": {
-						"load-json-file": "^4.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^3.0.0"
-					}
-				},
-				"rxjs": {
-					"version": "5.5.12",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-					"integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-					"requires": {
-						"symbol-observable": "1.0.1"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				},
-				"symbol-observable": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-					"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
-				},
-				"vinyl": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-					"requires": {
-						"clone": "^2.1.1",
-						"clone-buffer": "^1.0.0",
-						"clone-stats": "^1.0.0",
-						"cloneable-readable": "^1.0.0",
-						"remove-trailing-separator": "^1.0.1",
-						"replace-ext": "^1.0.0"
-					}
-				},
-				"yeoman-generator": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.5.tgz",
-					"integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
-					"requires": {
-						"async": "^2.6.0",
-						"chalk": "^2.3.0",
-						"cli-table": "^0.3.1",
-						"cross-spawn": "^6.0.5",
-						"dargs": "^5.1.0",
-						"dateformat": "^3.0.3",
-						"debug": "^3.1.0",
-						"detect-conflict": "^1.0.0",
-						"error": "^7.0.2",
-						"find-up": "^2.1.0",
-						"github-username": "^4.0.0",
-						"istextorbinary": "^2.2.1",
-						"lodash": "^4.17.10",
-						"make-dir": "^1.1.0",
-						"mem-fs-editor": "^4.0.0",
-						"minimist": "^1.2.0",
-						"pretty-bytes": "^4.0.2",
-						"read-chunk": "^2.1.0",
-						"read-pkg-up": "^3.0.0",
-						"rimraf": "^2.6.2",
-						"run-async": "^2.0.0",
-						"shelljs": "^0.8.0",
-						"text-table": "^0.2.0",
-						"through2": "^2.0.0",
-						"yeoman-environment": "^2.0.5"
 					}
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -690,8 +690,7 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-			"dev": true
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 		},
 		"are-we-there-yet": {
 			"version": "1.1.4",
@@ -864,8 +863,7 @@
 		"asn1": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-			"dev": true
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
 		},
 		"asn1.js": {
 			"version": "4.10.1",
@@ -935,8 +933,7 @@
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-			"dev": true
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"atob": {
 			"version": "2.1.1",
@@ -1281,8 +1278,7 @@
 		"aws4": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-			"dev": true
+			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -2801,8 +2797,7 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"base": {
 			"version": "0.11.2",
@@ -2875,7 +2870,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
@@ -2939,8 +2933,7 @@
 		"bluebird": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-			"dev": true
+			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
 		},
 		"bn.js": {
 			"version": "4.11.8",
@@ -3005,7 +2998,6 @@
 			"version": "2.10.1",
 			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
 			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-			"dev": true,
 			"requires": {
 				"hoek": "2.x.x"
 			}
@@ -3043,7 +3035,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -3190,8 +3181,7 @@
 		"buffer-from": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-			"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
-			"dev": true
+			"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
 		},
 		"buffer-xor": {
 			"version": "1.0.3",
@@ -3451,8 +3441,7 @@
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-			"dev": true
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"ccount": {
 			"version": "1.0.3",
@@ -3551,8 +3540,7 @@
 		"chownr": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-			"dev": true
+			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
 		},
 		"ci-info": {
 			"version": "1.1.3",
@@ -3805,8 +3793,7 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-			"dev": true
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
 		},
 		"co-with-promise": {
 			"version": "4.6.0",
@@ -4026,7 +4013,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -4112,14 +4098,12 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"inherits": "^2.0.3",
@@ -4368,7 +4352,7 @@
 			"dependencies": {
 				"load-json-file": {
 					"version": "1.1.0",
-					"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
@@ -4690,7 +4674,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
 			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1",
 				"fs-write-stream-atomic": "^1.0.8",
@@ -4725,8 +4708,7 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cosmiconfig": {
 			"version": "4.0.0",
@@ -4822,7 +4804,6 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
 			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-			"dev": true,
 			"requires": {
 				"boom": "2.x.x"
 			}
@@ -5166,8 +5147,7 @@
 		"cyclist": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
-			"dev": true
+			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
 		},
 		"d": {
 			"version": "1.0.0",
@@ -5191,7 +5171,6 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			},
@@ -5199,8 +5178,7 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
 			}
 		},
@@ -5409,8 +5387,7 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
 		"delegates": {
 			"version": "1.0.0",
@@ -5771,7 +5748,6 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
 			"integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.0.0",
 				"inherits": "^2.0.1",
@@ -5801,7 +5777,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"jsbn": "~0.1.0"
@@ -5869,7 +5844,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -6472,8 +6446,7 @@
 		"extend": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-			"dev": true
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -6581,8 +6554,7 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fast-deep-equal": {
 			"version": "2.0.1",
@@ -6881,7 +6853,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
 			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.4"
@@ -6923,8 +6894,7 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"dev": true
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
 			"version": "2.3.2",
@@ -6968,7 +6938,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
@@ -6989,7 +6958,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
 			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"iferr": "^0.1.5",
@@ -7000,8 +6968,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "1.2.3",
@@ -7298,7 +7265,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.9.1",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-8RwHUW3ZL4cZnbx+GDjqt81WyeA=",
 					"dev": true,
 					"optional": true,
@@ -7757,7 +7724,6 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			},
@@ -7765,8 +7731,7 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
 			}
 		},
@@ -7997,7 +7962,6 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -8174,8 +8138,7 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-			"dev": true
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
 		},
 		"grouped-queue": {
 			"version": "0.3.3",
@@ -8433,7 +8396,6 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
 			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-			"dev": true,
 			"requires": {
 				"boom": "2.x.x",
 				"cryptiles": "2.x.x",
@@ -8467,8 +8429,7 @@
 		"hoek": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-			"dev": true
+			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
 		},
 		"hoist-non-react-statics": {
 			"version": "1.2.0",
@@ -8663,9 +8624,9 @@
 			}
 		},
 		"http-parser-js": {
-			"version": "0.4.12",
-			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.12.tgz",
-			"integrity": "sha1-uc+/Sizybw/DSxDKFImid3HjR08=",
+			"version": "0.4.13",
+			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
+			"integrity": "sha1-O9bW/ebjFyyTNMOzO2wZPYD+ETc=",
 			"dev": true
 		},
 		"http-proxy-agent": {
@@ -8830,8 +8791,7 @@
 		"iferr": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-			"dev": true
+			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
 		},
 		"ignore": {
 			"version": "3.3.8",
@@ -8864,8 +8824,7 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-			"dev": true
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
 		},
 		"in-publish": {
 			"version": "2.0.0",
@@ -8895,7 +8854,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -8904,8 +8862,7 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-			"dev": true
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"ini": {
 			"version": "1.3.5",
@@ -9563,8 +9520,7 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
 		"is-url": {
 			"version": "1.2.4",
@@ -9620,8 +9576,7 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -9648,8 +9603,7 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"dev": true
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"isurl": {
 			"version": "1.0.0",
@@ -9693,7 +9647,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true,
 			"optional": true
 		},
 		"jsesc": {
@@ -9723,8 +9676,7 @@
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-			"dev": true
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
@@ -9736,7 +9688,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"dev": true,
 			"requires": {
 				"jsonify": "~0.0.0"
 			}
@@ -9744,8 +9695,7 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"json3": {
 			"version": "3.3.2",
@@ -9841,8 +9791,7 @@
 		"jsonify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-			"dev": true
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
 		"jsonparse": {
 			"version": "1.3.1",
@@ -9854,7 +9803,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -9865,8 +9813,7 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
 			}
 		},
@@ -10978,14 +10925,12 @@
 		"mime-db": {
 			"version": "1.33.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
-			"dev": true
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
 		},
 		"mime-types": {
 			"version": "2.1.18",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
 			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-			"dev": true,
 			"requires": {
 				"mime-db": "~1.33.0"
 			}
@@ -11027,7 +10972,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -11035,8 +10979,7 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"dev": true
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"minimist-options": {
 			"version": "3.0.2",
@@ -11109,7 +11052,6 @@
 			"version": "0.5.1",
 			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -11130,7 +11072,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
 			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1",
 				"copy-concurrently": "^1.0.0",
@@ -11704,7 +11645,6 @@
 					"version": "4.11.8",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
 					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-					"dev": true,
 					"requires": {
 						"co": "^4.6.0",
 						"json-stable-stringify": "^1.0.1"
@@ -11737,20 +11677,17 @@
 				"assert-plus": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-					"dev": true
+					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
 				},
 				"aws-sign2": {
 					"version": "0.6.0",
 					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-					"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-					"dev": true
+					"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
 				},
 				"balanced-match": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-					"dev": true
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 				},
 				"boxen": {
 					"version": "1.3.0",
@@ -11771,7 +11708,6 @@
 					"version": "1.1.11",
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -11787,7 +11723,6 @@
 					"version": "9.2.9",
 					"resolved": "https://registry.npmjs.org/cacache/-/cacache-9.2.9.tgz",
 					"integrity": "sha512-ghg1j5OyTJ6qsrqU++dN23QiTDxb5AZCFGsF3oB+v9v/gY+F4X8L/0gdQMEjd+8Ot3D29M2etX5PKozHRn2JQw==",
-					"dev": true,
 					"requires": {
 						"bluebird": "^3.5.0",
 						"chownr": "^1.0.1",
@@ -11807,8 +11742,7 @@
 						"y18n": {
 							"version": "3.2.1",
 							"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-							"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-							"dev": true
+							"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 						}
 					}
 				},
@@ -11882,8 +11816,7 @@
 				"concat-map": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-					"dev": true
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 				},
 				"configstore": {
 					"version": "3.1.2",
@@ -11992,7 +11925,6 @@
 					"version": "2.1.4",
 					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
 					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-					"dev": true,
 					"requires": {
 						"asynckit": "^0.4.0",
 						"combined-stream": "^1.0.5",
@@ -12002,8 +11934,7 @@
 				"fs.realpath": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-					"dev": true
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
@@ -12021,7 +11952,6 @@
 					"version": "7.1.2",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -12062,20 +11992,17 @@
 				"graceful-fs": {
 					"version": "4.1.11",
 					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-					"dev": true
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
 				},
 				"har-schema": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-					"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-					"dev": true
+					"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
 				},
 				"har-validator": {
 					"version": "4.2.1",
 					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
 					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-					"dev": true,
 					"requires": {
 						"ajv": "^4.9.1",
 						"har-schema": "^1.0.5"
@@ -12097,7 +12024,6 @@
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
 					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-					"dev": true,
 					"requires": {
 						"assert-plus": "^0.2.0",
 						"jsprim": "^1.2.2",
@@ -12120,7 +12046,6 @@
 					"version": "1.0.6",
 					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-					"dev": true,
 					"requires": {
 						"once": "^1.3.0",
 						"wrappy": "1"
@@ -12129,8 +12054,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"dev": true
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -12268,7 +12192,6 @@
 					"version": "4.1.2",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
 					"integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
-					"dev": true,
 					"requires": {
 						"pseudomap": "^1.0.2",
 						"yallist": "^2.1.2"
@@ -12383,7 +12306,6 @@
 					"version": "3.0.4",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -12398,7 +12320,6 @@
 					"version": "1.3.1",
 					"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.1.tgz",
 					"integrity": "sha512-/6rB8YXFbAtsUVRphIRQqB0+9c7VaPHCjVtvto+JqwVxgz8Zz+I+f68/JgQ+Pb4VlZb2svA9OtdXnHHsZz7ltg==",
-					"dev": true,
 					"requires": {
 						"concat-stream": "^1.5.0",
 						"duplexify": "^3.4.2",
@@ -12581,6 +12502,27 @@
 							"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
 							"integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
 							"dev": true
+						},
+						"cacache": {
+							"version": "9.2.9",
+							"resolved": "https://registry.npmjs.org/cacache/-/cacache-9.2.9.tgz",
+							"integrity": "sha512-ghg1j5OyTJ6qsrqU++dN23QiTDxb5AZCFGsF3oB+v9v/gY+F4X8L/0gdQMEjd+8Ot3D29M2etX5PKozHRn2JQw==",
+							"dev": true,
+							"requires": {
+								"bluebird": "^3.5.0",
+								"chownr": "^1.0.1",
+								"glob": "^7.1.2",
+								"graceful-fs": "^4.1.11",
+								"lru-cache": "^4.1.1",
+								"mississippi": "^1.3.0",
+								"mkdirp": "^0.5.1",
+								"move-concurrently": "^1.0.1",
+								"promise-inflight": "^1.0.1",
+								"rimraf": "^2.6.1",
+								"ssri": "^4.1.6",
+								"unique-filename": "^1.1.0",
+								"y18n": "^3.2.1"
+							}
 						},
 						"call-limit": {
 							"version": "1.1.0",
@@ -14040,6 +13982,36 @@
 								"once": "^1.3.0"
 							}
 						},
+						"request": {
+							"version": "2.81.0",
+							"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+							"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+							"dev": true,
+							"requires": {
+								"aws-sign2": "~0.6.0",
+								"aws4": "^1.2.1",
+								"caseless": "~0.12.0",
+								"combined-stream": "~1.0.5",
+								"extend": "~3.0.0",
+								"forever-agent": "~0.6.1",
+								"form-data": "~2.1.1",
+								"har-validator": "~4.2.1",
+								"hawk": "~3.1.3",
+								"http-signature": "~1.1.0",
+								"is-typedarray": "~1.0.0",
+								"isstream": "~0.1.2",
+								"json-stringify-safe": "~5.0.1",
+								"mime-types": "~2.1.7",
+								"oauth-sign": "~0.8.1",
+								"performance-now": "^0.2.0",
+								"qs": "~6.4.0",
+								"safe-buffer": "^5.0.1",
+								"stringstream": "~0.0.4",
+								"tough-cookie": "~2.3.0",
+								"tunnel-agent": "^0.6.0",
+								"uuid": "^3.0.0"
+							}
+						},
 						"retry": {
 							"version": "0.10.1",
 							"resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
@@ -14920,6 +14892,12 @@
 								"imurmurhash": "^0.1.4",
 								"slide": "^1.1.5"
 							}
+						},
+						"y18n": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+							"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+							"dev": true
 						}
 					}
 				},
@@ -14954,7 +14932,6 @@
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-					"dev": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -15043,8 +15020,7 @@
 				"path-is-absolute": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-					"dev": true
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 				},
 				"path-is-inside": {
 					"version": "1.0.2",
@@ -15061,8 +15037,7 @@
 				"performance-now": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-					"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-					"dev": true
+					"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
 				},
 				"pify": {
 					"version": "3.0.0",
@@ -15079,14 +15054,12 @@
 				"pseudomap": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-					"dev": true
+					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 				},
 				"pump": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
 					"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -15095,8 +15068,7 @@
 				"qs": {
 					"version": "6.4.0",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-					"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-					"dev": true
+					"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
 				},
 				"rc": {
 					"version": "1.2.6",
@@ -15133,7 +15105,6 @@
 					"version": "2.81.0",
 					"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
 					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-					"dev": true,
 					"requires": {
 						"aws-sign2": "~0.6.0",
 						"aws4": "^1.2.1",
@@ -15175,7 +15146,6 @@
 					"version": "2.6.2",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-					"dev": true,
 					"requires": {
 						"glob": "^7.0.5"
 					}
@@ -15183,8 +15153,7 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-					"dev": true
+					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
 				},
 				"semver": {
 					"version": "5.5.0",
@@ -15232,7 +15201,6 @@
 					"version": "4.1.6",
 					"resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
 					"integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "^5.1.0"
 					}
@@ -15417,8 +15385,7 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-					"dev": true
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 				},
 				"write-file-atomic": {
 					"version": "2.3.0",
@@ -15446,8 +15413,7 @@
 				"yallist": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-					"dev": true
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 				},
 				"yargs": {
 					"version": "11.0.0",
@@ -15512,8 +15478,7 @@
 		"oauth-sign": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-			"dev": true
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -15659,7 +15624,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -15705,24 +15669,12 @@
 			"dev": true
 		},
 		"original": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
-			"integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+			"integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
 			"dev": true,
 			"requires": {
-				"url-parse": "1.0.x"
-			},
-			"dependencies": {
-				"url-parse": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
-					"integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
-					"dev": true,
-					"requires": {
-						"querystringify": "0.0.x",
-						"requires-port": "1.0.x"
-					}
-				}
+				"url-parse": "^1.4.3"
 			}
 		},
 		"os-browserify": {
@@ -15912,7 +15864,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
 			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
-			"dev": true,
 			"requires": {
 				"cyclist": "~0.2.2",
 				"inherits": "^2.0.3",
@@ -16117,8 +16068,7 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
@@ -17029,10 +16979,14 @@
 		},
 		"primer-support": {
 			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.6.0.tgz",
+			"integrity": "sha1-Qq0w6+ox9/q7UpEnsyhk1sv8Kzw=",
 			"dev": true
 		},
 		"primer-utilities": {
 			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/primer-utilities/-/primer-utilities-4.12.0.tgz",
+			"integrity": "sha1-eu5Y11ouIzJvas/kG1W7ySjSJE4=",
 			"dev": true,
 			"requires": {
 				"primer-support": "4.6.0"
@@ -17053,8 +17007,7 @@
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-			"dev": true
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
 		"progress": {
 			"version": "1.1.8",
@@ -17074,8 +17027,7 @@
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
-			"dev": true
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
 		},
 		"promise-retry": {
 			"version": "1.1.1",
@@ -17175,7 +17127,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
 			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -17185,7 +17136,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.0.tgz",
 			"integrity": "sha512-UWi0klDoq8xtVzlMRgENV9F7iCTZExaJQSQL187UXsxpk9NnrKGqTqqUNYAKGOzucSOxs2+jUnRNI+rLviPhJg==",
-			"dev": true,
 			"requires": {
 				"duplexify": "^3.6.0",
 				"inherits": "^2.0.3",
@@ -17195,8 +17145,7 @@
 		"punycode": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-			"dev": true
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
 		},
 		"q": {
 			"version": "1.5.1",
@@ -17233,9 +17182,9 @@
 			"dev": true
 		},
 		"querystringify": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
-			"integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
+			"integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==",
 			"dev": true
 		},
 		"quick-lru": {
@@ -17414,9 +17363,9 @@
 			}
 		},
 		"react-dev-utils": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-5.0.1.tgz",
-			"integrity": "sha512-+y92rG6pmXt3cpcg/NGmG4w/W309tWNSmyyPL8hCMxuCSg2UP/hUg3npACj2UZc8UKVSXexyLrCnxowizGoAsw==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-5.0.3.tgz",
+			"integrity": "sha512-Mvs6ofsc2xTjeZIrMaIfbXfsPVrbdVy/cVqq6SAacnqfMlcBpDuivhWZ1ODGeJ8HgmyWTLH971PYjj/EPCDVAw==",
 			"dev": true,
 			"requires": {
 				"address": "1.0.3",
@@ -17431,10 +17380,10 @@
 				"inquirer": "3.3.0",
 				"is-root": "1.0.0",
 				"opn": "5.2.0",
-				"react-error-overlay": "^4.0.0",
+				"react-error-overlay": "^4.0.1",
 				"recursive-readdir": "2.2.1",
 				"shell-quote": "1.6.1",
-				"sockjs-client": "1.1.4",
+				"sockjs-client": "1.1.5",
 				"strip-ansi": "3.0.1",
 				"text-table": "0.2.0"
 			},
@@ -17511,9 +17460,9 @@
 			}
 		},
 		"react-error-overlay": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-4.0.0.tgz",
-			"integrity": "sha512-FlsPxavEyMuR6TjVbSSywovXSEyOg6ZDj5+Z8nbsRl9EkOzAhEIcS+GLoQDC5fz/t9suhUXWmUrOBrgeUvrMxw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-4.0.1.tgz",
+			"integrity": "sha512-xXUbDAZkU08aAkjtUvldqbvI04ogv+a1XdHxvYuHPYKIVk/42BIOD0zSKTHAWV4+gDy3yGm283z2072rA2gdtw==",
 			"dev": true
 		},
 		"react-fuzzy": {
@@ -17786,7 +17735,6 @@
 			"version": "2.3.6",
 			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -18347,7 +18295,6 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.0.5"
 			}
@@ -18385,7 +18332,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
 			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1"
 			}
@@ -18423,8 +18369,7 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -18966,15 +18911,14 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
 			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-			"dev": true,
 			"requires": {
 				"hoek": "2.x.x"
 			}
 		},
 		"sockjs-client": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
-			"integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
+			"integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
 			"dev": true,
 			"requires": {
 				"debug": "^2.6.6",
@@ -19171,7 +19115,6 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
 			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
-			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -19186,8 +19129,7 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
 			}
 		},
@@ -19272,7 +19214,6 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
 			"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"stream-shift": "^1.0.0"
@@ -19294,8 +19235,7 @@
 		"stream-shift": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-			"dev": true
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
 		},
 		"strict-uri-encode": {
 			"version": "1.1.0",
@@ -19383,7 +19323,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -19403,8 +19342,7 @@
 		"stringstream": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-			"integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
-			"dev": true
+			"integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
@@ -20072,7 +20010,7 @@
 			}
 		},
 		"stylelint-config-primer": {
-			"version": "2.2.10",
+			"version": "file:tools/stylelint-config-primer",
 			"dev": true,
 			"requires": {
 				"stylelint-no-unsupported-browser-features": "^1.0.0",
@@ -20139,6 +20077,8 @@
 		},
 		"stylelint-selector-no-utility": {
 			"version": "1.8.10",
+			"resolved": "https://registry.npmjs.org/stylelint-selector-no-utility/-/stylelint-selector-no-utility-1.8.10.tgz",
+			"integrity": "sha1-1bk5qIPk+9LIElV8USX6JHumIRs=",
 			"dev": true,
 			"requires": {
 				"primer-utilities": "4.12.0",
@@ -20584,7 +20524,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "^2.1.5",
 				"xtend": "~4.0.1"
@@ -20737,7 +20676,6 @@
 			"version": "2.3.4",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
 			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-			"dev": true,
 			"requires": {
 				"punycode": "^1.4.1"
 			}
@@ -20818,7 +20756,6 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -20827,7 +20764,6 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true,
 			"optional": true
 		},
 		"twig": {
@@ -20854,8 +20790,7 @@
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-			"dev": true
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
 		"ua-parser-js": {
 			"version": "0.7.18",
@@ -21049,7 +20984,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
 			"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
-			"dev": true,
 			"requires": {
 				"unique-slug": "^2.0.0"
 			}
@@ -21058,7 +20992,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
 			"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
-			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4"
 			}
@@ -21346,21 +21279,13 @@
 			}
 		},
 		"url-parse": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
-			"integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+			"integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
 			"dev": true,
 			"requires": {
 				"querystringify": "^2.0.0",
 				"requires-port": "^1.0.0"
-			},
-			"dependencies": {
-				"querystringify": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
-					"integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==",
-					"dev": true
-				}
 			}
 		},
 		"url-parse-lax": {
@@ -21424,8 +21349,7 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"utila": {
 			"version": "0.4.0",
@@ -21442,8 +21366,7 @@
 		"uuid": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-			"dev": true
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.3",
@@ -21495,7 +21418,6 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -21505,8 +21427,7 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
 			}
 		},
@@ -21912,8 +21833,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "0.2.1",
@@ -21988,8 +21908,7 @@
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-			"dev": true
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 		},
 		"y18n": {
 			"version": "3.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -863,7 +863,8 @@
 		"asn1": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+			"dev": true
 		},
 		"asn1.js": {
 			"version": "4.10.1",
@@ -933,7 +934,8 @@
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
 		},
 		"atob": {
 			"version": "2.1.1",
@@ -2870,6 +2872,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
@@ -2998,6 +3001,7 @@
 			"version": "2.10.1",
 			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
 			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+			"dev": true,
 			"requires": {
 				"hoek": "2.x.x"
 			}
@@ -3793,7 +3797,8 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"co-with-promise": {
 			"version": "4.6.0",
@@ -4804,6 +4809,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
 			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+			"dev": true,
 			"requires": {
 				"boom": "2.x.x"
 			}
@@ -5171,6 +5177,7 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			},
@@ -5178,7 +5185,8 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
@@ -5777,6 +5785,7 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"jsbn": "~0.1.0"
@@ -6554,7 +6563,8 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
 		},
 		"fast-deep-equal": {
 			"version": "2.0.1",
@@ -7724,6 +7734,7 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			},
@@ -7731,7 +7742,8 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
@@ -8392,17 +8404,6 @@
 				"minimalistic-assert": "^1.0.0"
 			}
 		},
-		"hawk": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-			"requires": {
-				"boom": "2.x.x",
-				"cryptiles": "2.x.x",
-				"hoek": "2.x.x",
-				"sntp": "1.x.x"
-			}
-		},
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -8429,7 +8430,8 @@
 		"hoek": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+			"dev": true
 		},
 		"hoist-non-react-statics": {
 			"version": "1.2.0",
@@ -9647,6 +9649,7 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true,
 			"optional": true
 		},
 		"jsesc": {
@@ -9676,21 +9679,14 @@
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
 			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
 			"dev": true
-		},
-		"json-stable-stringify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"requires": {
-				"jsonify": "~0.0.0"
-			}
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
@@ -9791,7 +9787,8 @@
 		"jsonify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
 		},
 		"jsonparse": {
 			"version": "1.3.1",
@@ -9803,6 +9800,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -9813,7 +9811,8 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
@@ -11645,9 +11644,21 @@
 					"version": "4.11.8",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
 					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+					"dev": true,
 					"requires": {
 						"co": "^4.6.0",
 						"json-stable-stringify": "^1.0.1"
+					},
+					"dependencies": {
+						"json-stable-stringify": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+							"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+							"dev": true,
+							"requires": {
+								"jsonify": "~0.0.0"
+							}
+						}
 					}
 				},
 				"ansi-align": {
@@ -11677,12 +11688,8 @@
 				"assert-plus": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-				},
-				"aws-sign2": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-					"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+					"dev": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
@@ -11921,16 +11928,6 @@
 						"locate-path": "^2.0.0"
 					}
 				},
-				"form-data": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.5",
-						"mime-types": "^2.1.12"
-					}
-				},
 				"fs.realpath": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -11997,16 +11994,8 @@
 				"har-schema": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-					"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
-				},
-				"har-validator": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-					"requires": {
-						"ajv": "^4.9.1",
-						"har-schema": "^1.0.5"
-					}
+					"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+					"dev": true
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -12019,16 +12008,6 @@
 					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
 					"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
 					"dev": true
-				},
-				"http-signature": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-					"requires": {
-						"assert-plus": "^0.2.0",
-						"jsprim": "^1.2.2",
-						"sshpk": "^1.7.0"
-					}
 				},
 				"import-lazy": {
 					"version": "2.1.0",
@@ -14010,6 +13989,76 @@
 								"tough-cookie": "~2.3.0",
 								"tunnel-agent": "^0.6.0",
 								"uuid": "^3.0.0"
+							},
+							"dependencies": {
+								"aws-sign2": {
+									"version": "0.6.0",
+									"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+									"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+									"dev": true
+								},
+								"form-data": {
+									"version": "2.1.4",
+									"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+									"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+									"dev": true,
+									"requires": {
+										"asynckit": "^0.4.0",
+										"combined-stream": "^1.0.5",
+										"mime-types": "^2.1.12"
+									}
+								},
+								"har-validator": {
+									"version": "4.2.1",
+									"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+									"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+									"dev": true,
+									"requires": {
+										"ajv": "^4.9.1",
+										"har-schema": "^1.0.5"
+									}
+								},
+								"hawk": {
+									"version": "3.1.3",
+									"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+									"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+									"dev": true,
+									"requires": {
+										"boom": "2.x.x",
+										"cryptiles": "2.x.x",
+										"hoek": "2.x.x",
+										"sntp": "1.x.x"
+									}
+								},
+								"http-signature": {
+									"version": "1.1.1",
+									"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+									"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+									"dev": true,
+									"requires": {
+										"assert-plus": "^0.2.0",
+										"jsprim": "^1.2.2",
+										"sshpk": "^1.7.0"
+									}
+								},
+								"performance-now": {
+									"version": "0.2.0",
+									"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+									"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+									"dev": true
+								},
+								"qs": {
+									"version": "6.4.0",
+									"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+									"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+									"dev": true
+								},
+								"stringstream": {
+									"version": "0.0.6",
+									"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+									"integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+									"dev": true
+								}
 							}
 						},
 						"retry": {
@@ -15034,11 +15083,6 @@
 					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
 					"dev": true
 				},
-				"performance-now": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-					"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-				},
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -15065,15 +15109,9 @@
 						"once": "^1.3.1"
 					}
 				},
-				"qs": {
-					"version": "6.4.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-					"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
-				},
 				"rc": {
 					"version": "1.2.6",
-					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
-					"integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
+					"resolved": "",
 					"dev": true,
 					"requires": {
 						"deep-extend": "~0.4.0",
@@ -15106,25 +15144,17 @@
 					"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
 					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
 					"requires": {
-						"aws-sign2": "~0.6.0",
 						"aws4": "^1.2.1",
 						"caseless": "~0.12.0",
 						"combined-stream": "~1.0.5",
 						"extend": "~3.0.0",
 						"forever-agent": "~0.6.1",
-						"form-data": "~2.1.1",
-						"har-validator": "~4.2.1",
-						"hawk": "~3.1.3",
-						"http-signature": "~1.1.0",
 						"is-typedarray": "~1.0.0",
 						"isstream": "~0.1.2",
 						"json-stringify-safe": "~5.0.1",
 						"mime-types": "~2.1.7",
 						"oauth-sign": "~0.8.1",
-						"performance-now": "^0.2.0",
-						"qs": "~6.4.0",
 						"safe-buffer": "^5.0.1",
-						"stringstream": "~0.0.4",
 						"tough-cookie": "~2.3.0",
 						"tunnel-agent": "^0.6.0",
 						"uuid": "^3.0.0"
@@ -18911,6 +18941,7 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
 			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+			"dev": true,
 			"requires": {
 				"hoek": "2.x.x"
 			}
@@ -19115,6 +19146,7 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
 			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -19129,7 +19161,8 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
@@ -19338,11 +19371,6 @@
 				"is-alphanumerical": "^1.0.0",
 				"is-hexadecimal": "^1.0.0"
 			}
-		},
-		"stringstream": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-			"integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
@@ -20764,6 +20792,7 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true,
 			"optional": true
 		},
 		"twig": {
@@ -21418,6 +21447,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -21427,7 +21457,8 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "primer-module-build": "file:tools/primer-module-build",
-    "stylelint-config-primer": "^2.2.6",
+    "stylelint-config-primer": "file:tools/stylelint-config-primer",
     "@storybook/addon-options": "3.4.3",
     "@storybook/addons": "3.4.3",
     "@storybook/react": "3.4.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "globby": "^6.1.0",
     "html-to-react": "^1.2.11",
     "isomorphic-fetch": "^2.2.1",
-    "lerna": "2.4.0",
+    "lerna": "2.11.0",
     "lerna-changelog": "^0.7.0",
     "minimatch": "^3.0.4",
     "node-sass": "^4.9.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "npm run test-all-modules && lerna run test",
     "test-all-modules": "ava --verbose tests/test-*.js"
   },
-  "devDependencies": {
+  "dependencies": {
     "primer-module-build": "file:tools/primer-module-build",
     "stylelint-config-primer": "file:tools/stylelint-config-primer",
     "@storybook/addon-options": "3.4.3",


### PR DESCRIPTION
This is an attempt to get Travis (and local!) bootstraps of the monorepo working again by:

1. Upgrading to the latest 2.x release of Lerna ([v2.11.0](https://github.com/lerna/lerna/releases/tag/v2.11.0))
1. Renaming the root `package.json` dependencies field from `devDependencies` to `dependencies`
1. Rebuilding `package-lock.json`
1. Running `npm audit fix` to deal with some security issues

🤞 

/cc @primer/ds-core
