### PR TITLE
Add responsive variants & `!important` to grid offset classes

### DIFF
--- a/modules/primer-layout/lib/grid-offset.scss
+++ b/modules/primer-layout/lib/grid-offset.scss
@@ -1,30 +1,19 @@
 // Optional offset options to work with grid.scss
 
 // Offset Columns
-.offset-1 { margin-left: (1 / 12 * 100%); }
-.offset-2 { margin-left: (2 / 12 * 100%); }
-.offset-3 { margin-left: (3 / 12 * 100%); }
-.offset-4 { margin-left: (4 / 12 * 100%); }
-.offset-5 { margin-left: (5 / 12 * 100%); }
-.offset-6 { margin-left: (6 / 12 * 100%); }
-.offset-7 { margin-left: (7 / 12 * 100%); }
-.offset-8 { margin-left: (8 / 12 * 100%); }
-.offset-9 { margin-left: (9 / 12 * 100%); }
-.offset-10 { margin-left: (10 / 12 * 100%); }
-.offset-11 { margin-left: (11 / 12 * 100%); }
 
-@each $breakpoint in map-keys($breakpoints) {
+@each $breakpoint, $variant in $responsive-variants {
   @include breakpoint($breakpoint) {
-    .offset-#{$breakpoint}-1 { margin-left: (1 / 12 * 100%); }
-    .offset-#{$breakpoint}-2 { margin-left: (2 / 12 * 100%); }
-    .offset-#{$breakpoint}-3 { margin-left: (3 / 12 * 100%); }
-    .offset-#{$breakpoint}-4 { margin-left: (4 / 12 * 100%); }
-    .offset-#{$breakpoint}-5 { margin-left: (5 / 12 * 100%); }
-    .offset-#{$breakpoint}-6 { margin-left: (6 / 12 * 100%); }
-    .offset-#{$breakpoint}-7 { margin-left: (7 / 12 * 100%); }
-    .offset-#{$breakpoint}-8 { margin-left: (8 / 12 * 100%); }
-    .offset-#{$breakpoint}-9 { margin-left: (9 / 12 * 100%); }
-    .offset-#{$breakpoint}-10 { margin-left: (10 / 12 * 100%); }
-    .offset-#{$breakpoint}-11 { margin-left: (11 / 12 * 100%); }
+    .offset#{$variant}-1 { margin-left: (1 / 12 * 100%) !important; }
+    .offset#{$variant}-2 { margin-left: (2 / 12 * 100%) !important; }
+    .offset#{$variant}-3 { margin-left: (3 / 12 * 100%) !important; }
+    .offset#{$variant}-4 { margin-left: (4 / 12 * 100%) !important; }
+    .offset#{$variant}-5 { margin-left: (5 / 12 * 100%) !important; }
+    .offset#{$variant}-6 { margin-left: (6 / 12 * 100%) !important; }
+    .offset#{$variant}-7 { margin-left: (7 / 12 * 100%) !important; }
+    .offset#{$variant}-8 { margin-left: (8 / 12 * 100%) !important; }
+    .offset#{$variant}-9 { margin-left: (9 / 12 * 100%) !important; }
+    .offset#{$variant}-10 { margin-left: (10 / 12 * 100%) !important; }
+    .offset#{$variant}-11 { margin-left: (11 / 12 * 100%) !important; }
   }
 }


### PR DESCRIPTION
As outlined in [this issue](https://github.com/primer/primer/issues/576), I recently tried to override mx-auto with an offset class and I couldn't, because mx-auto has !important, but offset- doesn't. This PR fixes that.

This replaces [this previous PR](https://github.com/primer/primer/pull/578) so that it works with the updates coming from https://github.com/primer/primer/pull/545

(Fixes #576)

/cc @primer/ds-core