### PR TITLE
Add default stories.js to module template

### DIFF
--- a/tools/generator-primer-module/app/templates/stories.js
+++ b/tools/generator-primer-module/app/templates/stories.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import storiesFromMarkdown from '../../.storybook/lib/storiesFromMarkdown'
+
+const stories = storiesOf('<%= title %>', module)
+
+storiesFromMarkdown(require.context('.', true, /\.md$/))
+  .forEach(({title, story}) => {
+    stories.add(title, story)
+  })
+

--- a/tools/generator-primer-module/test/generator.spec.js
+++ b/tools/generator-primer-module/test/generator.spec.js
@@ -26,6 +26,9 @@ test("file scaffolding", t => {
       assert.fileContent(readme, `npmjs.org/package/${module}`)
       assert.fileContent(readme, `npm install --save ${module}`)
 
+      // default Storybook config
+      assert.fileContent(path("stories.js"), `storiesOf('Test'`)
+
       assert.file(path("lib/test.scss"))
 
       t.pass("All the files exist.")


### PR DESCRIPTION
This adds a `stories.js` to the new module template that defaults to pulling in stories from any `.md` file. @emilybrick, I believe that we had to add this manually when you started on `primer-progress`, right?