### PR TITLE
Hiding .Counter component when it's empty.

### DIFF
--- a/modules/primer-labels/README.md
+++ b/modules/primer-labels/README.md
@@ -129,7 +129,7 @@ Use `State--small` for a state label with reduced padding a smaller font size. T
 
 ## Counters
 
-Use the `Counter` component to add a count to navigational elements and buttons. Counters come in 3 variations: the default `Counter` with a light gray background, `Counter--gray` with a dark-gray background and inverse white text, and `Counter--gray-light` with a light-gray background and dark gray text.
+Use the `Counter` component to add a count to navigational elements and buttons. Counters come in 3 variations: the default `Counter` with a light gray background, `Counter--gray` with a dark-gray background and inverse white text, and `Counter--gray-light` with a light-gray background and dark gray text. When a counter is empty, it's visibility will be hidden.
 
 ```html title="Counter"
 <span class="Counter">16</span>

--- a/modules/primer-labels/lib/counters.scss
+++ b/modules/primer-labels/lib/counters.scss
@@ -8,6 +8,10 @@
   color: $gray-600;
   background-color: rgba($black, 0.08);
   border-radius: 20px;
+
+  &:empty {
+    visibility: hidden;
+  }
 }
 
 .Counter--gray-light {


### PR DESCRIPTION
This change will apply `visibility: hidden;` to `.Counter` components when they are empty.

**Before**
<img width="288" alt="image" src="https://user-images.githubusercontent.com/54012/47235739-cb094800-d38e-11e8-9dd4-7a928bdb570a.png">

**After**
<img width="283" alt="image" src="https://user-images.githubusercontent.com/54012/47235781-ea07da00-d38e-11e8-99de-ee2c9c749eeb.png">

Fixes: https://github.com/github/design-systems/issues/330

/cc @primer/ds-core