### PR TITLE
Revert "Make .container responsive"

### DIFF
--- a/modules/primer-layout/lib/container.scss
+++ b/modules/primer-layout/lib/container.scss
@@ -1,7 +1,7 @@
 // Fixed-width, centered column for site content.
 // This will be deprecated and replaced with container-lg in future
 .container {
-  max-width: $container-width;
+  width: $container-width;
   margin-right: auto;
   margin-left: auto;
   @include clearfix;


### PR DESCRIPTION
Reverts primer/primer#571. @crhallberg, this was my bad for merging. Turns out we _need_ `.container` to have a fixed width, but the sized variants can be flexible.