### PR TITLE
Button group focus ring fix (again)

### DIFF
--- a/modules/primer-buttons/lib/button-group.scss
+++ b/modules/primer-buttons/lib/button-group.scss
@@ -12,7 +12,7 @@
   // Proper spacing for multiple button groups (a la, gollum editor)
   + .BtnGroup,
   + .btn {
-    margin-left: 5px;
+    margin-left: $spacer-1;
   }
 }
 
@@ -23,21 +23,21 @@
   border-radius: 0;
 
   &:first-child {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-top-left-radius: $border-radius;
+    border-bottom-left-radius: $border-radius;
   }
 
   &:last-child {
-    border-right-width: 1px;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-right-width: $border-width;
+    border-top-right-radius: $border-radius;
+    border-bottom-right-radius: $border-radius;
   }
 
   &.selected,
   &:focus,
   &:active,
   &:hover {
-    border-right-width: 1px;
+    border-right-width: $border-width;
 
     + .BtnGroup-item,
     + .BtnGroup-parent .BtnGroup-item,
@@ -52,14 +52,14 @@
   float: left;
 
   &:first-child .BtnGroup-item {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-top-left-radius: $border-radius;
+    border-bottom-left-radius: $border-radius;
   }
 
   &:last-child .BtnGroup-item {
-    border-right-width: 1px;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-right-width: $border-width;
+    border-top-right-radius: $border-radius;
+    border-bottom-right-radius: $border-radius;
   }
 
   .BtnGroup-item {
@@ -72,7 +72,7 @@
   &:active,
   &:hover {
     .BtnGroup-item {
-      border-right-width: 1px;
+      border-right-width: $border-width;
     }
 
     + .BtnGroup-item,

--- a/modules/primer-buttons/lib/button-group.scss
+++ b/modules/primer-buttons/lib/button-group.scss
@@ -82,3 +82,13 @@
     }
   }
 }
+
+// ensure that the focus ring sits above the adjacent buttons
+.BtnGroup-item,
+.BtnGroup-parent,
+.BtnGroup-form {
+  &:focus,
+  &:active {
+    z-index: 1;
+  }
+}


### PR DESCRIPTION
Re-applies the fixes from #601, minus the inline-flex update. The diff between that PR and this one is [here](https://github.com/primer/primer/compare/button-stories...more-btngroup-fixes#diff-9a0d8f3df27d9a8ca7170fb44e64e75b).

Note: the `margin-left: $spacer-1` diff is another fix, as `$spacer-2` would've produced an 8px margin between button groups rather than 4px, which is closer to the original 5px. (I'm trying to avoid any button groups on this site from wrapping unexpectedly!)