### PR TITLE
Update releasing docs

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,9 @@
 
 1. Go through the tracking PR and make sure everything listed is merged in.
 
-2. To update the change log for your release, click on the details links for the continuous-integration/travis-ci/push build.  Expand the `Deploying application` output and copy the change log content. Update the [CHANGELOG.md](https://github.com/primer/primer/blob/master/CHANGELOG.md) file with the change log content from the build.
+2. To update the change log for your release, click on the details links for the continuous-integration/travis-ci/push build.  Expand the `Deploying application` output and copy the change log content. Update the [CHANGELOG.md](https://github.com/primer/primer/blob/master/CHANGELOG.md) file with the change log content from build
+
+    **Note**: the CHANGELOG contents may be hidden within a collapsed section of the Travis logs under `Deploying the application`. Click the ▶ to the left of that section to expand it, then scroll to the bottom of the page, and copy all of the text between the `Unreleased (YYYY-MM-DD)` heading and the exit status message (e.g. `Done. Your build exited with 0.`). You may need to copy _before_ releasing your mouse to prevent Travis from collapsing that section of the logs first.
 
 3. Bump the package versions in your terminal:
 
@@ -14,46 +16,53 @@
   npm run bump
   ```
 
-4. Run `script/check-versions` to catch any cross-module version mismatches. You may need to update peer dependencies in `primer-popover` and `primer-marketing-buttons`.
+4. Run `script/check-versions` to catch any cross-module version mismatches. (This will run on Travis, too.)
 
 5. Test your changes with the latest release candidate version in the appropriate places (styleguide, storybook, github/github).
 
 6. Once the release PR is approved and you've done necessary testing, merge to `master`. This will trigger publishing to npm.
 
-7. Create a new release branch for the next release from `master` and name it `release-<version>`. Please use the following template for the PR description:
+7. Create a new release branch for the next release from `master` and name it `release-<version>`. Please use the following template for the PR description, linking to pull the relevant issues and/or pull requests for each change, and removing irrelevant headings:
 
     ```md
     # Primer [Major|Minor|Patch] Release
 
-    Tracking Issue for next release: 📦 **0.0.0**
+    Version: 📦 **0.0.0**
     Approximate release date: 📆 DD/MM/YY
 
-    ### Must
+    ### :boom: Breaking Change
+    - [ ] Description #
 
-    - [ ]
+    ### :rocket: Enhancement
+    - [ ] Description #
 
-    ### Should
-
-    - [ ]
-
-    ### Could
-
-    - [ ]
+    ### :bug: Bug Fix
+    - [ ] Description #
+    
+    ### :nail_care: Polish
+    - [ ] Description #
+    
+    ### :memo: Documentation
+    - [ ] Description #
+    
+    ### :house: Internal
+    - [ ] Description #
 
     ----
 
     ### Ship checklist
 
-    - [ ] Update CHANGELOG
+    - [ ] Update `CHANGELOG.md`
     - [ ] Run version bump
-    - [ ] Update primer.github.io
-    - [ ] Update github/github
-    - [ ] Update the style guide
-    - [ ] Update the release tag note
+    - [ ] Create a [new release](https://github.com/primer/primer/releases/new)
+    - [ ] Update github/github with released version
+    - [ ] Update github/styleguide with released version
     - [ ] Create a new pull request for the next release
 
     /cc @primer/ds-core
     ```
+
+
 
 
 ### In `github/github`:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,9 +12,9 @@
 
 3. Bump the package versions in your terminal:
 
-  ```sh
-  npm run bump
-  ```
+   ```sh
+   npm run bump
+   ```
 
 4. Run `script/check-versions` to catch any cross-module version mismatches. (This will run on Travis, too.)
 
@@ -63,8 +63,6 @@
     ```
 
 
-
-
 ### In `github/github`:
 
 1. Create a new branch
@@ -88,17 +86,9 @@
 
 #### Update the Style Guide
 
-1. In [github/styleguide](https://github.com/github/styleguide), update `primer` to your newly released version in your terminal:
+1. In [github/styleguide](https://github.com/github/styleguide), update `primer` by following [these instructions](https://github.com/github/styleguide/#adding-new-content-from-primer).
 
-  `npm install primer@latest`
-
-2. Then  run: `script/update-primer-docs`.
-
-3. Commit changes, make PR, get it approved, merge! 🚀
-
-#### Update [primer.github.io](primer.github.io)
-
-1. Edit  [index.html](https://github.com/primer/primer.github.io/blob/master/index.html) to include the latest version.
+2. Commit your changes, make a pull request, get it approved, and merge! 🚀
 
 
 #### Publish release tag

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,7 +22,7 @@
 
 6. Once the release PR is approved and you've done necessary testing, merge to `master`. This will trigger publishing to npm.
 
-7. Create a new release branch for the next release from `master` and name it `release-<version>`. Please use the following template for the PR description, linking to pull the relevant issues and/or pull requests for each change, and removing irrelevant headings:
+7. Create a new release branch for the next release from `master` and name it `release-<version>`. Please use the following template for the PR description, linking to the relevant issues and/or pull requests for each change, and removing irrelevant headings:
 
     ```md
     # Primer [Major|Minor|Patch] Release


### PR DESCRIPTION
This makes some much-needed updates to our release docs, per a walkthrough with @emilybrick:

- add all the change category headings to the release PR template
- remove task to update primer.github.io, as this is just redirects to `primer.style` now
- link to the new release page from the checklist
- provide better guidance on copying the CHANGELOG text from Travis build output

[:eyes: Rendered](https://github.com/primer/primer/blob/release-doc-updates/RELEASING.md)

### 🏠 Internal
* Improve release documentation

/cc @primer/ds-core
