### PR TITLE
fix path to script/try-publish

### DIFF
--- a/script/compare-published
+++ b/script/compare-published
@@ -15,8 +15,10 @@ echo "📦  Comparing Primer modules published @${tag}..."
     echo "module${s}tag${s}published${s}local"
     for package in $packages; do
         module=$(jq -r .name "$package/package.json")
-        v_published=$(npm info "$module@$tag" .version)
-        v_local=$(jq -Mr .version "$package/package.json")
-        echo "${module}${s}${tag}${s}${v_published:-x}${s}${v_local}"
+        if [[ "$(jq -r .private $package/package.json)" != "true" ]]; then
+            v_published=$(npm info "$module@$tag" .version || echo '0.0.0')
+            v_local=$(jq -Mr .version "$package/package.json")
+            echo "${module}${s}${tag}${s}${v_published:-x}${s}${v_local}"
+        fi
     done
 ) | column -t -s=${s}

--- a/script/release
+++ b/script/release
@@ -5,7 +5,7 @@ echo "📦  Publishing latest release..."
 
 # note: try-publish should exit cleanly if it detects a duplicate
 # published version
-npx lerna exec $@ -- script/try-publish
+npx lerna exec $@ -- $(dirname $0)/try-publish
 
 # Build and publish storybook
 npx build-storybook -o build

--- a/script/release
+++ b/script/release
@@ -3,9 +3,8 @@ set -e
 
 echo "📦  Publishing latest release..."
 
-# note: try-publish should exit cleanly if it detects a duplicate
-# published version
-npx lerna exec $@ -- $(dirname $0)/try-publish
+# note: try-publish should exit cleanly if it hits a published version
+npx lerna exec --ignore='@primer/css-docs' $@ -- $(pwd)/script/try-publish
 
 # Build and publish storybook
 npx build-storybook -o build


### PR DESCRIPTION
The #625 build on `master` failed. I didn't change the `script/try-publish` path, but this _should_ fix it not being found.