### PR TITLE
New buttons styles for marketing

### DIFF
--- a/modules/primer-marketing-buttons/lib/button.scss
+++ b/modules/primer-marketing-buttons/lib/button.scss
@@ -22,3 +22,72 @@
     @include btn-transparent-active;
   }
 }
+
+// Buttons
+
+.btn-mktg {
+  display: inline-block;
+  padding: $spacer-3 $spacer-4;
+  font-size: $h5-size;
+  font-weight: $font-weight-semibold;
+  color: $white;
+  white-space: nowrap;
+  vertical-align: middle;
+  cursor: pointer;
+  user-select: none;
+  background-color: $blue-450;
+  border: 1px solid $blue-450;
+  border-radius: $border-radius;
+  transition: $transition-time / 2;
+  appearance: none; // Corrects inability to style clickable `input` types in iOS.
+
+  &:hover {
+    text-decoration: none;
+    background-color: $blue-500;
+    border-color: $blue-500;
+  }
+
+  &:focus {
+    outline: 0;
+    box-shadow: 0 0 0 0.2em rgba($blue-500, 0.3);
+  }
+
+  &:disabled,
+  &.disabled {
+    pointer-events: none; // Disable hover styles
+    cursor: default;
+    opacity: 0.65;
+  }
+}
+
+.btn-primary-mktg {
+  background-color: $green-450;
+  border-color: $green-450;
+
+  &:hover {
+    background-color: $green-500;
+    border-color: $green-500;
+  }
+
+  &:focus {
+    box-shadow: 0 0 0 0.2em rgba($green-500, 0.3);
+  }
+}
+
+.btn-large-mktg {
+  padding: 20px $spacer-5;
+  font-size: $h4-size;
+}
+
+.btn-outline-mktg {
+  color: $blue-450;
+  background-color: $white;
+  border-color: rgba($blue-450, 0.5);
+
+  &:hover {
+    color: $blue-500;
+    text-decoration: none;
+    background-color: $white;
+    border-color: rgba($blue-450, 1);
+  }
+}

--- a/modules/primer-marketing-support/lib/variables.scss
+++ b/modules/primer-marketing-support/lib/variables.scss
@@ -12,3 +12,7 @@ $spacer-11: $spacer * 14; // 112px
 $spacer-12: $spacer * 16; // 128px
 
 $marketingSpacers: $spacer-7, $spacer-8, $spacer-9, $spacer-10, $spacer-11, $spacer-12;
+
+// Colors
+$blue-450: mix($blue-500, $blue-400, 50%);
+$green-450: mix($green-500, $green-400, 50%);


### PR DESCRIPTION
This PR adds new styles for buttons used for marketing. With this are two new color variables that sit between blue-400 and 500, and green-400 and 500. `$blue-450` and `$green-450`.

/cc @primer/ds-core
