### PR TITLE
Sandboxed code examples

### DIFF
--- a/docs/lib/config.js
+++ b/docs/lib/config.js
@@ -2,9 +2,6 @@
 const sync = require('./sync')
 const {CI, NODE_ENV, NOW_URL} = process.env
 
-const PRIMER_SCSS = 'primer/index.scss$'
-const PRIMER_STATIC_CSS = require.resolve('primer/build/build.css')
-
 module.exports = (nextConfig = {}) => {
   const {assetPrefix = NOW_URL || ''} = nextConfig
 
@@ -45,18 +42,6 @@ module.exports = (nextConfig = {}) => {
           require.resolve('./mdx-loader')
         ]
       })
-
-      /**
-       * in production we don't have access to ../modules, so we need to
-       * rewrite the 'primer/index.scss' import to the static CSS build
-       */
-      if (!dev) {
-        config.resolve.alias[PRIMER_SCSS] = PRIMER_STATIC_CSS
-        // only log the aliasing once
-        if (!configured) {
-          console.warn(`*** rewriting ${PRIMER_SCSS} to ${PRIMER_STATIC_CSS}`)
-        }
-      }
 
       configured = true
       if (typeof nextConfig.webpack === 'function') {

--- a/docs/lib/config.js
+++ b/docs/lib/config.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 const sync = require('./sync')
+const cssLoaderConfig = require('@zeit/next-css/css-loader-config')
 const {CI, NODE_ENV, NOW_URL} = process.env
 
 module.exports = (nextConfig = {}) => {
@@ -23,7 +24,7 @@ module.exports = (nextConfig = {}) => {
         )
       }
 
-      const {dev} = options
+      const {dev, isServer} = options
 
       // only attempt to sync locally and in CI
       if (dev && !configured) {
@@ -34,6 +35,16 @@ module.exports = (nextConfig = {}) => {
       // the CSS build!
       if (!dev) {
         config.resolve.alias['primer/index.scss$'] = require.resolve('primer/build/build.css')
+
+        const cssLoader = cssLoaderConfig(config, {
+          dev,
+          isServer
+        })
+        options.defaultLoaders.css = cssLoader
+        config.module.rules.push({
+          test: /\.css$/,
+          loader: cssLoader
+        })
       }
 
       config.module.rules.push({

--- a/docs/lib/config.js
+++ b/docs/lib/config.js
@@ -30,6 +30,12 @@ module.exports = (nextConfig = {}) => {
         sync({watch: !CI})
       }
 
+      // in production, we don't need to compile Primer from SCSS; just inline
+      // the CSS build!
+      if (!dev) {
+        config.resolve.alias['primer/index.scss$'] = require.resolve('primer/build/build.css')
+      }
+
       config.module.rules.push({
         test: /\.svg$/,
         use: '@svgr/webpack'

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -1,9 +1,9 @@
 const {join, resolve} = require('path')
-const sass = require('@zeit/next-sass')
+const withSass = require('@zeit/next-sass')
 const configure = require('./lib/config')
 
 module.exports = configure(
-  sass({
+  withSass({
     sassLoaderOptions: {
       includePaths: [
         resolve(__dirname, '../modules'),

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -1,16 +1,14 @@
 const {join, resolve} = require('path')
-const css = require('@zeit/next-css')
 const sass = require('@zeit/next-sass')
 const configure = require('./lib/config')
 
 module.exports = configure(
-  css(
-    sass({
-      sassLoaderOptions: {
-        includePaths: [
-          resolve(__dirname, '../modules')
-        ]
-      }
-    })
-  )
+  sass({
+    sassLoaderOptions: {
+      includePaths: [
+        resolve(__dirname, '../modules'),
+        resolve(__dirname, 'node_modules')
+      ]
+    }
+  })
 )

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -784,31 +784,6 @@
         "to-fast-properties": "2.0.0"
       }
     },
-    "@emotion/babel-utils": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-utils/-/babel-utils-0.6.10.tgz",
-      "integrity": "sha512-/fnkM/LTEp3jKe++T0KyTszVGWNKPNOUJfjNKLO17BzQ6QPxgbg3whayom1Qr2oLFH3V92tDymU+dT5q676uow==",
-      "requires": {
-        "@emotion/hash": "0.6.6",
-        "@emotion/memoize": "0.6.6",
-        "@emotion/serialize": "0.9.1",
-        "convert-source-map": "1.6.0",
-        "find-root": "1.1.0",
-        "source-map": "0.7.3"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
-        }
-      }
-    },
-    "@emotion/hash": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.6.tgz",
-      "integrity": "sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ=="
-    },
     "@emotion/is-prop-valid": {
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.6.8.tgz",
@@ -821,32 +796,6 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
       "integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
-    },
-    "@emotion/serialize": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.9.1.tgz",
-      "integrity": "sha512-zTuAFtyPvCctHBEL8KZ5lJuwBanGSutFEncqLn/m9T1a6a93smBStK+bZzcNPgj4QS8Rkw9VTwJGhRIUVO8zsQ==",
-      "requires": {
-        "@emotion/hash": "0.6.6",
-        "@emotion/memoize": "0.6.6",
-        "@emotion/unitless": "0.6.7",
-        "@emotion/utils": "0.8.2"
-      }
-    },
-    "@emotion/stylis": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.7.1.tgz",
-      "integrity": "sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ=="
-    },
-    "@emotion/unitless": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.6.7.tgz",
-      "integrity": "sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg=="
-    },
-    "@emotion/utils": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.2.tgz",
-      "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw=="
     },
     "@githubprimer/octicons-react": {
       "version": "8.2.0",
@@ -1675,25 +1624,6 @@
         "util.promisify": "1.0.0"
       }
     },
-    "babel-plugin-emotion": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-9.2.11.tgz",
-      "integrity": "sha512-dgCImifnOPPSeXod2znAmgc64NhaaOjGEHROR/M+lmStb3841yK1sgaDYAYMnlvWNz8GnpwIPN0VmNpbWYZ+VQ==",
-      "requires": {
-        "@babel/helper-module-imports": "7.0.0",
-        "@emotion/babel-utils": "0.6.10",
-        "@emotion/hash": "0.6.6",
-        "@emotion/memoize": "0.6.6",
-        "@emotion/stylis": "0.7.1",
-        "babel-plugin-macros": "2.4.2",
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "convert-source-map": "1.6.0",
-        "find-root": "1.1.0",
-        "mkdirp": "0.5.1",
-        "source-map": "0.5.7",
-        "touch": "2.0.2"
-      }
-    },
     "babel-plugin-macros": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.4.2.tgz",
@@ -2165,11 +2095,6 @@
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         }
       }
-    },
-    "buffer-from": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
-      "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -2897,38 +2822,6 @@
         "elliptic": "6.4.1"
       }
     },
-    "create-emotion": {
-      "version": "9.2.12",
-      "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-9.2.12.tgz",
-      "integrity": "sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==",
-      "requires": {
-        "@emotion/hash": "0.6.6",
-        "@emotion/memoize": "0.6.6",
-        "@emotion/stylis": "0.7.1",
-        "@emotion/unitless": "0.6.7",
-        "csstype": "2.5.8",
-        "stylis": "3.5.4",
-        "stylis-rule-sheet": "0.0.10"
-      }
-    },
-    "create-emotion-server": {
-      "version": "9.2.12",
-      "resolved": "https://registry.npmjs.org/create-emotion-server/-/create-emotion-server-9.2.12.tgz",
-      "integrity": "sha512-ET+E6A5MkQTEBNDYAnjh6+0cB33qStFXhtflkZNPEaOmvzYlB/xcPnpUk4J7ul3MVa8PCQx2Ei5g2MGY/y1n+g==",
-      "requires": {
-        "html-tokenize": "2.0.0",
-        "multipipe": "1.0.2",
-        "through": "2.3.8"
-      }
-    },
-    "create-emotion-styled": {
-      "version": "9.2.8",
-      "resolved": "https://registry.npmjs.org/create-emotion-styled/-/create-emotion-styled-9.2.8.tgz",
-      "integrity": "sha512-2LrNM5MREWzI5hZK+LyiBHglwE18WE3AEbBQgpHQ1+zmyLSm/dJsUZBeFAwuIMb+TjNZP0KsMZlV776ufOtFdg==",
-      "requires": {
-        "@emotion/is-prop-valid": "0.6.8"
-      }
-    },
     "create-hash": {
       "version": "1.2.0",
       "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -3162,11 +3055,6 @@
       "requires": {
         "cssom": "0.3.4"
       }
-    },
-    "csstype": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.8.tgz",
-      "integrity": "sha512-r4DbsyNJ7slwBSKoGesxDubRWJ71ghG8W2+1HcsDlAo12KGca9dDLv0u98tfdFw7ldBdoA7XmCnI6Q8LpAJXaQ=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -3452,43 +3340,6 @@
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
-    "duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-      "requires": {
-        "readable-stream": "2.3.6"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "5.1.2"
-          }
-        }
-      }
-    },
     "duplexify": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
@@ -3576,23 +3427,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
-    },
-    "emotion": {
-      "version": "9.2.8",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-9.2.8.tgz",
-      "integrity": "sha512-4CT7S2+TDcd9qTSosd3VibERAsaZjhraeLxLWRuV6epX5XdHQjeLFqAlion/iT8M3UNQx9bqmlOTd+KaUj2M8Q==",
-      "requires": {
-        "babel-plugin-emotion": "9.2.11",
-        "create-emotion": "9.2.12"
-      }
-    },
-    "emotion-server": {
-      "version": "9.2.8",
-      "resolved": "https://registry.npmjs.org/emotion-server/-/emotion-server-9.2.8.tgz",
-      "integrity": "sha512-BIZlF++OwNdryoht5hBNDKo6YPtUILQq1/LxF3djGcJ5OuYOOGxQdymdySLd1Y6wXVCGo323d6asAN59cSWpiA==",
-      "requires": {
-        "create-emotion-server": "9.2.12"
-      }
     },
     "enable": {
       "version": "1.3.2",
@@ -4373,11 +4207,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/find-insert-index/-/find-insert-index-0.0.1.tgz",
       "integrity": "sha1-Fs00ZkwqwjOQWrKzl0W87HITYt4="
-    },
-    "find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
     },
     "find-up": {
       "version": "2.1.0",
@@ -5684,18 +5513,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
-    },
-    "html-tokenize": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/html-tokenize/-/html-tokenize-2.0.0.tgz",
-      "integrity": "sha1-izqaXetHXK5qb5ZxYA0sIKspglE=",
-      "requires": {
-        "buffer-from": "0.1.2",
-        "inherits": "2.0.3",
-        "minimist": "0.0.8",
-        "readable-stream": "1.0.34",
-        "through2": "0.4.2"
-      }
     },
     "html-void-elements": {
       "version": "1.0.3",
@@ -7327,15 +7144,6 @@
         "minimatch": "3.0.4"
       }
     },
-    "multipipe": {
-      "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
-      "integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
-      "requires": {
-        "duplexer2": "0.1.4",
-        "object-assign": "4.1.1"
-      }
-    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -7579,7 +7387,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "resolve": {
@@ -7816,14 +7624,6 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
-      }
-    },
-    "nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-      "requires": {
-        "abbrev": "1.1.1"
       }
     },
     "nopter": {
@@ -8624,10 +8424,256 @@
       "resolved": "https://registry.npmjs.org/pretty-time/-/pretty-time-1.1.0.tgz",
       "integrity": "sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA=="
     },
+    "primer": {
+      "version": "10.10.4",
+      "resolved": "https://registry.npmjs.org/primer/-/primer-10.10.4.tgz",
+      "integrity": "sha512-JslEj4o7n1kJMGPQvCkrZphBnTlJ+oXmDEB4zBc3fOgt0INWO8Y5vgsW2VutvoFbuiXbY0ydQfGPOcL5/J452Q==",
+      "requires": {
+        "primer-alerts": "1.5.13",
+        "primer-avatars": "1.5.10",
+        "primer-base": "1.9.2",
+        "primer-blankslate": "1.5.2",
+        "primer-box": "2.5.13",
+        "primer-branch-name": "1.0.11",
+        "primer-breadcrumb": "1.5.9",
+        "primer-buttons": "2.6.4",
+        "primer-core": "6.10.8",
+        "primer-forms": "2.1.8",
+        "primer-labels": "1.5.13",
+        "primer-layout": "1.6.2",
+        "primer-markdown": "3.7.13",
+        "primer-marketing": "6.3.3",
+        "primer-marketing-buttons": "1.0.13",
+        "primer-marketing-support": "1.5.6",
+        "primer-marketing-type": "1.4.13",
+        "primer-marketing-utilities": "1.7.3",
+        "primer-navigation": "1.5.11",
+        "primer-page-headers": "1.5.3",
+        "primer-page-sections": "1.5.3",
+        "primer-pagination": "1.0.7",
+        "primer-popover": "0.1.8",
+        "primer-product": "5.8.3",
+        "primer-progress": "0.1.3",
+        "primer-subhead": "1.0.11",
+        "primer-support": "4.7.2",
+        "primer-table-object": "1.4.13",
+        "primer-tables": "1.5.3",
+        "primer-tooltips": "1.5.11",
+        "primer-truncate": "1.4.13",
+        "primer-utilities": "4.14.3"
+      },
+      "dependencies": {
+        "primer-markdown": {
+          "version": "3.7.13",
+          "resolved": "https://registry.npmjs.org/primer-markdown/-/primer-markdown-3.7.13.tgz",
+          "integrity": "sha512-8GficlbmQ8GIFDzsD9JiFdlgAdeZR66sZa1CTBYbu26osM55/8NyTM7cobRId/MT6uutpRu0J8LlQ2sYuNAIng==",
+          "requires": {
+            "primer-support": "4.7.2"
+          }
+        },
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-alerts": {
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/primer-alerts/-/primer-alerts-1.5.13.tgz",
+      "integrity": "sha512-RmpYBKhpclKD9doGnH0ehLKZOS25amEkgC3Cwtq8Utxq2BJieeSuVbDcTTPL3ktFA9wez1mxR2vk2CCF3Rl9oQ==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-avatars": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/primer-avatars/-/primer-avatars-1.5.10.tgz",
+      "integrity": "sha512-gn5JO8AHlTvR2z15mDBJsVpMfs3eNoT60fNSF/N+ixFNRCfe4CIgHO8S3R1iCB6MpmkMxsPT38HNkiFUCyKN7w==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-base": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/primer-base/-/primer-base-1.9.2.tgz",
+      "integrity": "sha512-KgZP0cGq0rdgyK5ozw7UbyqG52o0sbzAfRP3iEeoRhDwCJ3X0XaHeCINty7QhcIzWCccXkdamMe/P6HBwWM12g==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-blankslate": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/primer-blankslate/-/primer-blankslate-1.5.2.tgz",
+      "integrity": "sha512-7raUk+G/FSvU3S7TmJchLw7zkepLOh3F523eWRdMwR5N1DAhCm4VqgehXO1kDCbMj5tuBGfZ6FQ2OzFF0LPOIw==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-box": {
+      "version": "2.5.13",
+      "resolved": "https://registry.npmjs.org/primer-box/-/primer-box-2.5.13.tgz",
+      "integrity": "sha512-ZNZ8TFU05gqZx1oSk6DVdjACOOPsdJZqn0qYBcfsEu+AQQiKJ7HVH8pgODlH5tqj8Ihtoz3Q1CxCmrZhVnjnbA==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-branch-name": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/primer-branch-name/-/primer-branch-name-1.0.11.tgz",
+      "integrity": "sha512-zhLcTVn7zXmHkz57KQcgzc8I7mMHdL2R5VfGpIrHHJqxT3t4SDNbW4g+o3Ap85hnU1sxTXvAWGBAgzAHw0zmCA==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-breadcrumb": {
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/primer-breadcrumb/-/primer-breadcrumb-1.5.9.tgz",
+      "integrity": "sha512-A2+rm3Gi2vk4LYr8yWrNwYNc2i59gcnfAGyT/QJ7G66R0kLD8M3rIPDw2vmRY5LagTvZ8KnY6wRwc5GSSKVBDQ==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-buttons": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/primer-buttons/-/primer-buttons-2.6.4.tgz",
+      "integrity": "sha512-6+wFjXKGk76qZmUrnUTXm8Zo6viiNlcGcSSiW89OeAW2qkHHlTvyMqoKwExg8nGNFbLIGxhvqb9V++nx20Pq1Q==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
     "primer-colors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/primer-colors/-/primer-colors-1.0.1.tgz",
       "integrity": "sha512-bxo3OPoIO1F/C07RpKbLjPzuSsTkOMzo9Yl9OJFHGD7/UxA+JvNdZK0GbJzWtz5Y8H6KabbHadxwVWRp1xl08A=="
+    },
+    "primer-core": {
+      "version": "6.10.8",
+      "resolved": "https://registry.npmjs.org/primer-core/-/primer-core-6.10.8.tgz",
+      "integrity": "sha512-yeAAWxb7Ro+PYk1MN2mqvSA4XoCaX/KjwfEgJc0l+6qmQA74KZR0tLf9t/zzSyJRgLwKthWbcwZzzjrffEph4A==",
+      "requires": {
+        "primer-base": "1.9.2",
+        "primer-box": "2.5.13",
+        "primer-breadcrumb": "1.5.9",
+        "primer-buttons": "2.6.4",
+        "primer-forms": "2.1.8",
+        "primer-layout": "1.6.2",
+        "primer-navigation": "1.5.11",
+        "primer-pagination": "1.0.7",
+        "primer-support": "4.7.2",
+        "primer-table-object": "1.4.13",
+        "primer-tooltips": "1.5.11",
+        "primer-truncate": "1.4.13",
+        "primer-utilities": "4.14.3"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-forms": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/primer-forms/-/primer-forms-2.1.8.tgz",
+      "integrity": "sha512-bAobB7DUWphIjdcXfPD6CPWwvWBp5hbH65seO0OT+KkYbCLrDZCeFxLfRs9u1LyYN07DJR/vf4k8wom0Bksr4A==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-labels": {
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/primer-labels/-/primer-labels-1.5.13.tgz",
+      "integrity": "sha512-fy74yluNWsAxl+gXQeCel0Wi0zrFFr6DDXp4HIkghTPLhVed9H/oCNiELWcoAM1NxxmJCUR34GAW1ASL/hqlKA==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-layout": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/primer-layout/-/primer-layout-1.6.2.tgz",
+      "integrity": "sha512-Ov/g9GiAaKhRAXku2wxsTlmJXhQPAjWpCwibJ+Ooxu0X8n6BA52y/ScZUPFdde+vZYhbFGFQwozU8y2bzuw3dg==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
     },
     "primer-markdown": {
       "version": "3.7.9",
@@ -8637,15 +8683,304 @@
         "primer-support": "4.6.0"
       }
     },
+    "primer-marketing": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/primer-marketing/-/primer-marketing-6.3.3.tgz",
+      "integrity": "sha512-vmR/YkOlFnQVQSxluXe5lbkH+B7Z2tirgCDGVp+SD9Zs+FJ6YRELmw6cjm0okVkH9205qcMvy9INOunkhKrktw==",
+      "requires": {
+        "primer-marketing-buttons": "1.0.13",
+        "primer-marketing-support": "1.5.6",
+        "primer-marketing-type": "1.4.13",
+        "primer-marketing-utilities": "1.7.3",
+        "primer-page-headers": "1.5.3",
+        "primer-page-sections": "1.5.3",
+        "primer-support": "4.7.2",
+        "primer-tables": "1.5.3"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-marketing-buttons": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/primer-marketing-buttons/-/primer-marketing-buttons-1.0.13.tgz",
+      "integrity": "sha512-1MzzrG/68zaEcQypG50uELwQ4MHH9b8aTy3jXxayZRc1qvZaLh5SEcSIHWe5lMIZk8qrtYhr22py9+kibyTKIQ==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-marketing-support": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/primer-marketing-support/-/primer-marketing-support-1.5.6.tgz",
+      "integrity": "sha512-YU8ein52s/W+s4a4hHZZJbHURfz2FLI5ItrUxqaqJjcT0O2bALP/JbuCZDrbvWxuOSK4kbF22ANmmMGWFIzp/Q=="
+    },
+    "primer-marketing-type": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/primer-marketing-type/-/primer-marketing-type-1.4.13.tgz",
+      "integrity": "sha512-ke6l3zgc4mF5ArDzZB1TJ5VHbZG2/uwekVROLQOK4v7XI0MkYZWA9tI+k8UhaFLSsw0vGqxM2ibKUzsQH61C8g==",
+      "requires": {
+        "primer-marketing-support": "1.5.6",
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-marketing-utilities": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/primer-marketing-utilities/-/primer-marketing-utilities-1.7.3.tgz",
+      "integrity": "sha512-YYDPgyC0G65tPHwZ6ktxfEAqUkJlU2sZjzdcH7thlcg83/UqiZfgmgiiBAxdMjrACY7Q2X9HaHicr5F4rmPhPw==",
+      "requires": {
+        "primer-marketing-support": "1.5.6",
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-navigation": {
+      "version": "1.5.11",
+      "resolved": "https://registry.npmjs.org/primer-navigation/-/primer-navigation-1.5.11.tgz",
+      "integrity": "sha512-Fykn/zuJX8z8kEIkzxnbwZhbCbYbuQF7Iv+03yzBeesOfN4VaQKgpTtaAXW26NB1BjOo3omrhVivYoejTFXbuw==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-page-headers": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/primer-page-headers/-/primer-page-headers-1.5.3.tgz",
+      "integrity": "sha512-SVgAnr1jz/8qNhr+LsQayHGGICi1pCfBJV2R+zhcooDJC29ddSoTW+LpwvBj1P68c7sJfaMPRmlcq0hUGGG/Pw==",
+      "requires": {
+        "primer-marketing-support": "1.5.6",
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-page-sections": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/primer-page-sections/-/primer-page-sections-1.5.3.tgz",
+      "integrity": "sha512-xaj6v+v3FvaSMVFDZAYsrObkvOviPwxYZt0rrkMeoyhrMVG2uB3nD3Kmu3st9UbwobdXjMTSKPkKBcarckwhuw==",
+      "requires": {
+        "primer-marketing-support": "1.5.6",
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-pagination": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/primer-pagination/-/primer-pagination-1.0.7.tgz",
+      "integrity": "sha512-c0Vmc3ZYspn+JdY6nmH626c+bxkuJLToYueksEMOrET4da05xwnC8dF7v6fh7UlBZ+qNArf+SsFWqXJPW5C8IA==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-popover": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/primer-popover/-/primer-popover-0.1.8.tgz",
+      "integrity": "sha512-9v07joxBbnoY7bbdyGmuqqmRyVdAwm94Ek0SSuJXFX93UDtWQsgl4/61ko57WOZw2U7A3nMfY4uISIw+VPh2Lg==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-product": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/primer-product/-/primer-product-5.8.3.tgz",
+      "integrity": "sha512-PhB7L0xclE1wwrv+o7TFvKV2LCwPn8znjGSjxgj4wB+X9JIbUEmVL8my6iL/FrLogOfzdk7ykZozDBNSW2OL+A==",
+      "requires": {
+        "primer-alerts": "1.5.13",
+        "primer-avatars": "1.5.10",
+        "primer-blankslate": "1.5.2",
+        "primer-branch-name": "1.0.11",
+        "primer-labels": "1.5.13",
+        "primer-markdown": "3.7.13",
+        "primer-popover": "0.1.8",
+        "primer-progress": "0.1.3",
+        "primer-subhead": "1.0.11",
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-markdown": {
+          "version": "3.7.13",
+          "resolved": "https://registry.npmjs.org/primer-markdown/-/primer-markdown-3.7.13.tgz",
+          "integrity": "sha512-8GficlbmQ8GIFDzsD9JiFdlgAdeZR66sZa1CTBYbu26osM55/8NyTM7cobRId/MT6uutpRu0J8LlQ2sYuNAIng==",
+          "requires": {
+            "primer-support": "4.7.2"
+          }
+        },
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-progress": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/primer-progress/-/primer-progress-0.1.3.tgz",
+      "integrity": "sha512-F9e3D9P/jP8Y5EuASS0czcB0P62v4AhuTdJZHZTYL1hMP3kpbQaUjMYf4QjekxxJgDY4Rf8X3ewkVlvnvjg5ug==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-subhead": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/primer-subhead/-/primer-subhead-1.0.11.tgz",
+      "integrity": "sha512-YDazpiTs4UMQaWYBRr3HWn5Ac1bRhhZUPxdYzbfQapZWL2XOLqgDF4Xvshmd29v6smmno5/Mel8WNXePXx9JyA==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
     "primer-support": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.6.0.tgz",
       "integrity": "sha1-Qq0w6+ox9/q7UpEnsyhk1sv8Kzw="
     },
+    "primer-table-object": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/primer-table-object/-/primer-table-object-1.4.13.tgz",
+      "integrity": "sha512-JoU/T1aubSg3cvEXh5K95X63W5bJLFlvDflVWMc8QJKiHBPmICH7yccsGI+ybhEUnd7MUD+BEXKgQwM+Iinv5g==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-tables": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/primer-tables/-/primer-tables-1.5.3.tgz",
+      "integrity": "sha512-ZTBG2qQvE9qKI8N7sdN39F8y5sckDRSFR4JkTVQqujrXwoK7kGeqdNXirKFSuzSyW9MnBt02tOTQ65xC0xl3sg==",
+      "requires": {
+        "primer-marketing-support": "1.5.6",
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-tooltips": {
+      "version": "1.5.11",
+      "resolved": "https://registry.npmjs.org/primer-tooltips/-/primer-tooltips-1.5.11.tgz",
+      "integrity": "sha512-r0C4gnzg8hChoKVU5hC+e7BlKM3gkO+W8L1o91RCDiguN9S0u/yo3DQwlVL68igvAP34NEYzchsZ82BkQkd1Dg==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
+    "primer-truncate": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/primer-truncate/-/primer-truncate-1.4.13.tgz",
+      "integrity": "sha512-/3saQDL8n77nGJ7zMT05PKTKeMTFrR2QVjZsD5XnOblMiglND95ozOKef0sDcyrgR7fv+qLMXr56+QS/FWFSsw==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
+    },
     "primer-typography": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/primer-typography/-/primer-typography-1.0.1.tgz",
       "integrity": "sha512-9f1MNOMYOWemosmJIG8FToqZoL7YKQW3KHNsMS3DddTUzJefnVzeqmiiTBPc2ok0yE7fE2PgobG9iRY+itgdVg=="
+    },
+    "primer-utilities": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/primer-utilities/-/primer-utilities-4.14.3.tgz",
+      "integrity": "sha512-VZsoYjEOQrnrW2x09dgXSKvwLtuo/BwSCKIVW0KtHbq1p6/i3IoeKglNF+7oQH+uTE9F6iSOuNFRNoitcnWKJg==",
+      "requires": {
+        "primer-support": "4.7.2"
+      },
+      "dependencies": {
+        "primer-support": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.2.tgz",
+          "integrity": "sha512-WbfjjITtGV6iXQeaVPL+AzHj1Jv9RHJRp7kIu5ebFXwolWmCqTBpA/8VmWmssyeTfv8zR7iuCoT0UoBF+uGHww=="
+        }
+      }
     },
     "prism-github": {
       "version": "1.1.0",
@@ -8861,15 +9196,6 @@
         "object-assign": "4.1.1",
         "prop-types": "15.6.2",
         "scheduler": "0.11.3"
-      }
-    },
-    "react-emotion": {
-      "version": "9.2.8",
-      "resolved": "https://registry.npmjs.org/react-emotion/-/react-emotion-9.2.8.tgz",
-      "integrity": "sha512-wBtVqGLQR49QG8hl5KDxIMBZtRR6W7n39bk9tq+YU1bfh0RmfLfr5Uatz5NDg86A+XDVX5jFhtXaKxHuKQDCaw==",
-      "requires": {
-        "babel-plugin-emotion": "9.2.11",
-        "create-emotion-styled": "9.2.8"
       }
     },
     "react-error-overlay": {
@@ -10846,30 +11172,6 @@
       "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
-    "through2": {
-      "version": "0.4.2",
-      "resolved": "http://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-      "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
-      "requires": {
-        "readable-stream": "1.0.34",
-        "xtend": "2.1.2"
-      },
-      "dependencies": {
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "requires": {
-            "object-keys": "0.4.0"
-          }
-        }
-      }
-    },
     "through2-sink": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/through2-sink/-/through2-sink-1.0.0.tgz",
@@ -11063,14 +11365,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
       "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA=="
-    },
-    "touch": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-2.0.2.tgz",
-      "integrity": "sha512-qjNtvsFXTRq7IuMLweVgFxmEuQ6gLbRs2jQxL80TtZ31dEKWYIxRXquij6w6VimyDek5hD3PytljHmEtAs2u0A==",
-      "requires": {
-        "nopt": "1.0.10"
-      }
     },
     "tough-cookie": {
       "version": "2.5.0",
@@ -11341,7 +11635,7 @@
       "dependencies": {
         "cacache": {
           "version": "10.0.4",
-          "resolved": "http://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
           "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
           "requires": {
             "bluebird": "3.5.3",
@@ -12054,7 +12348,7 @@
       "dependencies": {
         "table": {
           "version": "4.0.3",
-          "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
           "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
           "requires": {
             "ajv": "6.6.2",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2963,12 +2963,12 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         },
         "regexpu-core": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
           "requires": {
             "regenerate": "1.4.0",
@@ -2978,12 +2978,12 @@
         },
         "regjsgen": {
           "version": "0.2.0",
-          "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
           "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
         },
         "regjsparser": {
           "version": "0.1.5",
-          "resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
           "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
           "requires": {
             "jsesc": "0.5.0"
@@ -8340,25 +8340,53 @@
       "integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
       "requires": {
         "loader-utils": "1.1.0",
-        "postcss": "7.0.7",
+        "postcss": "7.0.13",
         "postcss-load-config": "2.0.0",
         "schema-utils": "1.0.0"
       },
       "dependencies": {
-        "postcss": {
-          "version": "7.0.7",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
-          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "chalk": "2.4.1",
-            "source-map": "0.6.1",
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
             "supports-color": "5.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "3.0.0"
+              }
+            }
+          }
+        },
+        "postcss": {
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
+          "requires": {
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "requires": {
+            "has-flag": "3.0.0"
+          }
         }
       }
     },

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -832,9 +832,9 @@
       }
     },
     "@primer/components": {
-      "version": "8.0.0-beta",
-      "resolved": "https://registry.npmjs.org/@primer/components/-/components-8.0.0-beta.tgz",
-      "integrity": "sha512-ypL3Am787gXtaNmCAiv2Q3mQbOYJ+x8X5H++toFwyxLaOeKaVZE/PdNCGf+5m5tX/apBTg4D4pBDlmabw75fjw==",
+      "version": "8.2.0-beta",
+      "resolved": "https://registry.npmjs.org/@primer/components/-/components-8.2.0-beta.tgz",
+      "integrity": "sha512-EnZDWjOWUDOQvQan1SbW/t10wr6pNA521fZnPcEDMaUbznKM6E4RKC0dmnDFUTP+7DPHL5mjShDzBvCJ6D4C8w==",
       "requires": {
         "@githubprimer/octicons-react": "8.1.2",
         "babel-plugin-macros": "2.4.2",
@@ -846,6 +846,7 @@
         "primer-typography": "1.0.1",
         "react": "16.4.2",
         "react-dom": "16.4.2",
+        "styled-components": "4.1.2",
         "styled-system": "3.1.3",
         "system-components": "3.0.1"
       },

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,7 @@
     "@mdx-js/tag": "0.15.0",
     "@primer/components": "^8.2.0-beta",
     "@svgr/webpack": "2.4.1",
+    "@zeit/next-css": "^1.0.1",
     "@zeit/next-sass": "^1.0.1",
     "babel-core": "7.0.0-bridge.0",
     "broken-link-checker": "^0.7.8",

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,7 @@
     "@githubprimer/octicons-react": "^8.1.3",
     "@mdx-js/mdx": "^0.16.6",
     "@mdx-js/tag": "0.15.0",
-    "@primer/components": "^8.0.0-beta",
+    "@primer/components": "^8.2.0-beta",
     "@svgr/webpack": "2.4.1",
     "@zeit/next-sass": "^1.0.1",
     "babel-core": "7.0.0-bridge.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,6 @@
     "sync": "script/sync",
     "watch": "script/sync --watch",
     "dev": "next",
-    "prebuild": "cp node_modules/primer/build/build.css static/primer.css",
     "build": "next build",
     "start": "next start"
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,7 +19,6 @@
     "@mdx-js/tag": "0.15.0",
     "@primer/components": "^8.0.0-beta",
     "@svgr/webpack": "2.4.1",
-    "@zeit/next-css": "^1.0.1",
     "@zeit/next-sass": "^1.0.1",
     "babel-core": "7.0.0-bridge.0",
     "broken-link-checker": "^0.7.8",

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -3,34 +3,12 @@ import App, {Container} from 'next/app'
 import {MDXProvider} from '@mdx-js/tag'
 import Head from 'next/head'
 import {BaseStyles, BorderBox, Box, Flex, theme} from '@primer/components'
-import {createGlobalStyle} from 'styled-components'
 import {Header, PackageHeader, SideNav} from '../src/components'
 import getComponents from '../src/markdown'
 import {config, requirePage, rootPage} from '../src/utils'
 import {CONTENT_MAX_WIDTH} from '../src/constants'
 
 import 'primer/index.scss'
-import 'prism-github'
-
-// XXX undo .markdown-body .rule (:facepalm:)
-const GlobalStyles = createGlobalStyle`
-  .markdown-body .rule.token {
-    height: auto;
-    margin: 0;
-    overflow: visible;
-    border-bottom: none;
-  }
-
-  .markdown-body .rule.token::before,
-  .markdown-body .rule.token::after {
-    display: none;
-  }
-
-  .language-html .token {
-    color: ${theme.colors.gray[8]} !important;
-  }
-}
-`
 
 export default class MyApp extends App {
   static async getInitialProps({Component, ctx}) {
@@ -56,7 +34,6 @@ export default class MyApp extends App {
 
     return (
       <BaseStyles fontSize={2} style={{fontFamily: theme.fonts.normal}}>
-        <GlobalStyles />
         <Container>
           <Head>
             <title>Primer CSS{meta.title ? ` / ${meta.title}` : null}</title>

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -9,6 +9,7 @@ import {config, requirePage, rootPage} from '../src/utils'
 import {CONTENT_MAX_WIDTH} from '../src/constants'
 
 import 'primer/index.scss'
+import 'prism-github'
 
 export default class MyApp extends App {
   static async getInitialProps({Component, ctx}) {

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -9,7 +9,6 @@ import {config, requirePage, rootPage} from '../src/utils'
 import {CONTENT_MAX_WIDTH} from '../src/constants'
 
 import 'primer/index.scss'
-import 'prism-github'
 
 export default class MyApp extends App {
   static async getInitialProps({Component, ctx}) {

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -40,7 +40,7 @@ export default class MyDocument extends Document {
           <CommonStyles />
           {renderedStyles}
         </Head>
-        <body data-context={JSON.stringify({files})}>
+        <body data-files={JSON.stringify(files)}>
           <Main />
           <NextScript />
           <CommonScripts />

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import Document, {Main, NextScript} from 'next/document'
+import Document, {Head, Main, NextScript} from 'next/document'
 import {ServerStyleSheet} from 'styled-components'
 import {config, getAssetPath, CommonStyles, CommonScripts} from '../src/utils'
 
@@ -18,8 +18,7 @@ export default class MyDocument extends Document {
 
     return (
       <html lang="en">
-        <head>
-          <title>Primer CSS</title>
+        <Head>
           <script async src="https://www.googletagmanager.com/gtag/js?id=UA-126681523-2" />
           <script async href={getAssetPath('analytics.js')} />
           <meta charSet="utf8" />
@@ -40,7 +39,7 @@ export default class MyDocument extends Document {
           <meta property="twitter:site" content="@githubprimer" />
           <CommonStyles />
           {renderedStyles}
-        </head>
+        </Head>
         <body>
           <Main />
           <NextScript />

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -14,7 +14,7 @@ export default class MyDocument extends Document {
   }
 
   render() {
-    const {renderedStyles} = this.props
+    const {files, renderedStyles} = this.props
 
     return (
       <html lang="en">
@@ -40,7 +40,7 @@ export default class MyDocument extends Document {
           <CommonStyles />
           {renderedStyles}
         </Head>
-        <body>
+        <body data-context={JSON.stringify({files})}>
           <Main />
           <NextScript />
           <CommonScripts />

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Document, {Main, NextScript} from 'next/document'
 import {ServerStyleSheet} from 'styled-components'
-import {config, getAssetPath} from '../src/utils'
+import {config, getAssetPath, CommonStyles, CommonScripts} from '../src/utils'
 
 export default class MyDocument extends Document {
   static getInitialProps({renderPage}) {
@@ -9,12 +9,12 @@ export default class MyDocument extends Document {
     const page = renderPage(App => props => sheet.collectStyles(<App {...props} />))
     return {
       ...page,
-      styleTags: sheet.getStyleElement()
+      renderedStyles: sheet.getStyleElement()
     }
   }
 
   render() {
-    const {styleTags} = this.props
+    const {renderedStyles} = this.props
 
     return (
       <html lang="en">
@@ -38,17 +38,13 @@ export default class MyDocument extends Document {
           <meta property="og:image:height" content="630" />
           <meta property="twitter:card" content="summary_large_image" />
           <meta property="twitter:site" content="@githubprimer" />
-          <link rel="stylesheet" href={getAssetPath('github/styleguide.css')} />
-          <link
-            rel="stylesheet"
-            href={config.production ? getAssetPath('primer.css') : '/_next/static/css/styles.chunk.css'}
-          />
-          {styleTags}
+          <CommonStyles />
+          {renderedStyles}
         </head>
         <body>
           <Main />
           <NextScript />
-          <script src={getAssetPath('github/styleguide.js')} />
+          <CommonScripts />
         </body>
       </html>
     )

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Document, {Head, Main, NextScript} from 'next/document'
 import {ServerStyleSheet} from 'styled-components'
-import {config, getAssetPath, CommonStyles, CommonScripts} from '../src/utils'
+import {getAssetPath, CommonStyles, CommonScripts} from '../src/utils'
 
 export default class MyDocument extends Document {
   static getInitialProps({renderPage}) {

--- a/docs/pages/css/principles/html.md
+++ b/docs/pages/css/principles/html.md
@@ -15,8 +15,8 @@ title: HTML
 * Avoid trailing slashes in self-closing elements. For example, `<br>`, `<hr>`, `<img>`, and `<input>`.
 * Don't set `tabindex` manually—rely on the browser to set the order.
 
-```html
-<p class="line-note" data-attribute="106">
+```html dead={true}
+<p class="line-note m-0" data-attribute="106">
   This is my paragraph of special text.
 </p>
 ```
@@ -25,7 +25,7 @@ title: HTML
 
 Many attributes don't require a value to be set, like `disabled` or `checked`, so don't set them.
 
-```html
+```html dead={true}
 <input type="text" disabled>
 
 <input type="checkbox" value="1" checked>
@@ -41,7 +41,7 @@ For more information, [read the WhatWG section](http://www.whatwg.org/specs/web-
 
 Whenever possible, avoid superfluous parent elements when writing HTML. Many times this requires iteration and refactoring, but produces less HTML. For example:
 
-```html
+```html dead={true}
 <!-- Not so great -->
 <span class="avatar">
   <img src="https://github.com/github.png">
@@ -62,7 +62,7 @@ Whenever possible, avoid superfluous parent elements when writing HTML. Many tim
 
 Make use of `<thead>`, `<tfoot>`, `<tbody>`, and `<th>` tags (and `scope` attribute) when appropriate. (Note: `<tfoot>` goes above `<tbody>` for speed reasons. You want the browser to load the footer before a table full of data.)
 
-```html
+```html dead={true}
 <table summary="This is a chart of invoices for 2011.">
   <thead>
     <tr>

--- a/docs/pages/css/principles/scss.md
+++ b/docs/pages/css/principles/scss.md
@@ -16,7 +16,7 @@ title: SCSS
 
 ## Formatting
 
-* Use hex color codes `#000` unless using `rgba()` in raw CSS (SCSS' `rgba()` function is overloaded to accept hex colors as a param, e.g., `rgba(#000, .5)`).
+* Use hex color codes `#000` unless using `rgba()` in raw CSS (the SCSS `rgba()` function is overloaded to accept hex colors, as in `rgba(#000, .5)`).
 * Use `//` for comment blocks (instead of `/* */`).
 * Avoid specifying units for zero values, e.g., `margin: 0;` instead of `margin: 0px;`.
 * Strive to limit use of shorthand declarations to instances where you must explicitly set all the available values.

--- a/docs/pages/index.js
+++ b/docs/pages/index.js
@@ -1,2 +1,2 @@
-import {redirect} from '../src/utils'
+import redirect from '../src/redirect'
 export default redirect('/css')

--- a/docs/src/CodeExample.js
+++ b/docs/src/CodeExample.js
@@ -1,8 +1,9 @@
 import React from 'react'
+import HTMLtoJSX from 'html-2-jsx'
+import {Absolute, BorderBox, Box, StyledOcticon as Octicon, Relative, Text, theme} from '@primer/components'
 import {LiveEditor, LiveError, LivePreview, LiveProvider} from 'react-live'
 import {createGlobalStyle} from 'styled-components'
 import {getIconByName} from '@githubprimer/octicons-react'
-import {Absolute, BorderBox, Box, StyledOcticon as Octicon, Relative, Text, theme} from '@primer/components'
 import ClipboardCopy from './ClipboardCopy'
 import Frame from './Frame'
 import {CommonStyles, CommonScripts} from './utils'
@@ -35,7 +36,7 @@ const converter = new HTMLtoJSX({
 const defaultTransform = code => `<React.Fragment>${code}</React.Fragment>`
 
 const languageTransforms = {
-  erb: erb => sanitizeERB(languageTransforms.html(erb)),
+  // erb: erb => sanitizeERB(languageTransforms.html(erb)),
   html: html => defaultTransform(converter.convert(html)),
   jsx: defaultTransform
 }

--- a/docs/src/CodeExample.js
+++ b/docs/src/CodeExample.js
@@ -8,8 +8,6 @@ import ClipboardCopy from './ClipboardCopy'
 import Frame from './Frame'
 import {CommonStyles, CommonScripts} from './utils'
 
-import 'prism-github'
-
 // XXX undo .markdown-body .rule (:facepalm:)
 const RuleOverrideStyles = createGlobalStyle`
   .markdown-body .rule.token {

--- a/docs/src/CodeExample.js
+++ b/docs/src/CodeExample.js
@@ -10,22 +10,6 @@ import {CommonStyles, CommonScripts} from './utils'
 
 import 'prism-github/prism-github.scss'
 
-// XXX undo .markdown-body .rule (:facepalm:)
-const RuleOverrideStyles = createGlobalStyle`
-  .markdown-body .rule.token {
-    height: auto;
-    margin: 0;
-    overflow: visible;
-    border-bottom: none;
-  }
-
-  .markdown-body .rule.token::before,
-  .markdown-body .rule.token::after {
-    display: none;
-  }
-}
-`
-
 const LANG_PATTERN = /\blanguage-\.?(jsx?|html)\b/
 
 const converter = new HTMLtoJSX({
@@ -45,44 +29,50 @@ export default function CodeExample(props) {
   const {children, dangerouslySetInnerHTML, dead, source, ...rest} = props
   const lang = getLanguage(props.className)
   if (lang && !dead) {
-    rest.code = source
-    rest.scope = {Octicon, getIconByName}
-    rest.transformCode = getTransformForLanguage(lang)
+    const liveProps = {
+      code: source,
+      scope: {Octicon, getIconByName},
+      transformCode: getTransformForLanguage(lang),
+      mountStylesheet: false
+    }
     return (
-      <LiveProvider mountStylesheet={false} {...rest}>
-        <BorderBox bg="gray.1" my={4}>
-          <Frame head={<CommonStyles />}>
-            <LivePreview />
-            <CommonScripts />
-          </Frame>
-          <Relative p={3}>
-            <Text
-              as={LiveEditor}
-              fontFamily="mono"
-              bg="transparent"
-              p="0 !important"
-              m="0 !important"
-            />
-            <Absolute right={theme.space[3]} top={theme.space[3]}>
+      <LiveProvider {...liveProps}>
+        <BorderBox {...rest}>
+          <BorderBox bg="white" p={3} border={0} borderBottom={1} borderRadius={0}>
+            <Frame>
+              <LivePreview />
+            </Frame>
+          </BorderBox>
+          <Box is={Relative} bg="gray.1" p={3}>
+            <LiveEditor style={{margin: 0, padding: 0}} />
+            <Absolute right={0} top={0} m={3}>
               <ClipboardCopy value={source} />
             </Absolute>
-            <RuleOverrideStyles />
-          </Relative>
-          <Text
-            as={LiveError}
-            fontFamily="mono"
-            css={{
-              overflow: 'auto',
-              whiteSpace: 'pre'
-            }}
-          />
+            <Text
+              as={LiveError}
+              fontFamily="mono"
+              css={{
+                overflow: 'auto',
+                whiteSpace: 'pre'
+              }}
+            />
+          </Box>
         </BorderBox>
       </LiveProvider>
     )
   } else {
-    Object.assign(rest, {children, dangerouslySetInnerHTML})
-    return <pre data-source={source} {...rest} />
+    const rest = {
+      children,
+      dangerouslySetInnerHTML
+    }
+    return (
+      <BorderBox data-source={source} is="pre" {...rest} />
+    )
   }
+}
+
+CodeExample.defaultProps = {
+  my: 4
 }
 
 

--- a/docs/src/CodeExample.js
+++ b/docs/src/CodeExample.js
@@ -1,9 +1,29 @@
 import React from 'react'
 import {LiveEditor, LiveError, LivePreview, LiveProvider} from 'react-live'
+import {createGlobalStyle} from 'styled-components'
 import {getIconByName} from '@githubprimer/octicons-react'
 import {Absolute, BorderBox, Box, StyledOcticon as Octicon, Relative, Text, theme} from '@primer/components'
 import ClipboardCopy from './ClipboardCopy'
-import HTMLtoJSX from 'html-2-jsx'
+import Frame from './Frame'
+import {CommonStyles, CommonScripts} from './utils'
+
+import 'prism-github'
+
+// XXX undo .markdown-body .rule (:facepalm:)
+const RuleOverrideStyles = createGlobalStyle`
+  .markdown-body .rule.token {
+    height: auto;
+    margin: 0;
+    overflow: visible;
+    border-bottom: none;
+  }
+
+  .markdown-body .rule.token::before,
+  .markdown-body .rule.token::after {
+    display: none;
+  }
+}
+`
 
 const LANG_PATTERN = /\blanguage-\.?(jsx?|html)\b/
 
@@ -30,14 +50,14 @@ export default function CodeExample(props) {
     return (
       <LiveProvider mountStylesheet={false} {...rest}>
         <BorderBox bg="gray.1" my={4}>
-          <Box bg="white" p={3} className="clearfix">
+          <Frame head={<CommonStyles />}>
             <LivePreview />
-          </Box>
+            <CommonScripts />
+          </Frame>
           <Relative p={3}>
             <Text
-              is={LiveEditor}
+              as={LiveEditor}
               fontFamily="mono"
-              lineHeight="normal"
               bg="transparent"
               p="0 !important"
               m="0 !important"
@@ -45,9 +65,10 @@ export default function CodeExample(props) {
             <Absolute right={theme.space[3]} top={theme.space[3]}>
               <ClipboardCopy value={source} />
             </Absolute>
+            <RuleOverrideStyles />
           </Relative>
           <Text
-            is={LiveError}
+            as={LiveError}
             fontFamily="mono"
             css={{
               overflow: 'auto',
@@ -62,6 +83,7 @@ export default function CodeExample(props) {
     return <pre data-source={source} {...rest} />
   }
 }
+
 
 function getLanguage(className) {
   const match = className && className.match(LANG_PATTERN)

--- a/docs/src/CodeExample.js
+++ b/docs/src/CodeExample.js
@@ -65,16 +65,13 @@ export default function CodeExample(props) {
       children,
       dangerouslySetInnerHTML
     }
-    return (
-      <BorderBox data-source={source} is="pre" {...rest} />
-    )
+    return <BorderBox data-source={source} is="pre" {...rest} />
   }
 }
 
 CodeExample.defaultProps = {
   my: 4
 }
-
 
 function getLanguage(className) {
   const match = className && className.match(LANG_PATTERN)

--- a/docs/src/CodeExample.js
+++ b/docs/src/CodeExample.js
@@ -1,12 +1,10 @@
 import React from 'react'
 import HTMLtoJSX from 'html-2-jsx'
-import {Absolute, BorderBox, Box, StyledOcticon as Octicon, Relative, Text, theme} from '@primer/components'
+import {Absolute, BorderBox, Box, StyledOcticon as Octicon, Relative, Text} from '@primer/components'
 import {LiveEditor, LiveError, LivePreview, LiveProvider} from 'react-live'
-import {createGlobalStyle} from 'styled-components'
 import {getIconByName} from '@githubprimer/octicons-react'
 import ClipboardCopy from './ClipboardCopy'
 import Frame from './Frame'
-import {CommonStyles, CommonScripts} from './utils'
 
 import 'prism-github/prism-github.scss'
 
@@ -20,7 +18,6 @@ const converter = new HTMLtoJSX({
 const defaultTransform = code => `<React.Fragment>${code}</React.Fragment>`
 
 const languageTransforms = {
-  // erb: erb => sanitizeERB(languageTransforms.html(erb)),
   html: html => defaultTransform(converter.convert(html)),
   jsx: defaultTransform
 }
@@ -65,6 +62,7 @@ export default function CodeExample(props) {
       children,
       dangerouslySetInnerHTML
     }
+    // eslint-disable-next-line react/no-danger-with-children
     return <BorderBox data-source={source} is="pre" {...rest} />
   }
 }
@@ -80,34 +78,4 @@ function getLanguage(className) {
 
 function getTransformForLanguage(lang) {
   return lang in languageTransforms ? languageTransforms[lang] : null
-}
-
-function sanitizeERB(html) {
-  return html
-    .replace(/&lt;%= octicon\("([-\w]+)"([^%]+)\)\s*%&gt;/g, erbOcticon)
-    .replace(/&lt;%([^%]+)%gt;/g, '{/* ERB: `$1` */}')
-}
-
-const RUBY_ARG_PATTERNS = [/^:(\w+) ?=&gt; ?(.+)$/, /^(\w+): ?(.+)$/]
-
-function erbOcticon(substr, name, argString) {
-  let args = ''
-  if (argString) {
-    args = argString
-      .split(/,\s*/)
-      .slice(1)
-      .map(arg => {
-        for (const pattern of RUBY_ARG_PATTERNS) {
-          const match = arg.match(pattern)
-          if (match) {
-            const attr = match[1]
-            const value = match[2].charAt(0) === '"' ? match[2] : `{${match[2]}}`
-            return `${attr}=${value}`
-          }
-        }
-        return ''
-      })
-      .join(' ')
-  }
-  return `<Octicon icon={getIconByName("${name}")} ${args} />`
 }

--- a/docs/src/CodeExample.js
+++ b/docs/src/CodeExample.js
@@ -8,6 +8,8 @@ import ClipboardCopy from './ClipboardCopy'
 import Frame from './Frame'
 import {CommonStyles, CommonScripts} from './utils'
 
+import 'prism-github/prism-github.scss'
+
 // XXX undo .markdown-body .rule (:facepalm:)
 const RuleOverrideStyles = createGlobalStyle`
   .markdown-body .rule.token {

--- a/docs/src/Frame.js
+++ b/docs/src/Frame.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import {BorderBox} from '@primer/components'
+
+export default class Frame extends React.Component {
+  componentDidMount() {
+    this.doc = this.node.contentDocument
+    this.forceUpdate()
+  }
+
+  render() {
+    const {children, head: _head, ...rest} = this.props
+    const head = this.doc ? ReactDOM.createPortal(_head, this.doc.head) : null
+    const body = this.doc ? ReactDOM.createPortal(children, this.doc.body) : null
+    return (
+      <BorderBox as="iframe" {...rest} ref={node => (this.node = node)}>
+        {head}
+        {body}
+      </BorderBox>
+    )
+  }
+}
+
+Frame.defaultProps = {
+  bg: 'white',
+  border: 0,
+  p: 3,
+  width: '100%'
+}

--- a/docs/src/Frame.js
+++ b/docs/src/Frame.js
@@ -1,29 +1,39 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import PropTypes from 'prop-types'
+import Document, {Head} from 'next/document'
 import {BorderBox} from '@primer/components'
+import {assetPrefix} from './utils'
 
 export default class Frame extends React.Component {
+  static defaultProps = {
+    bg: 'white',
+    border: 0,
+    p: 3,
+    width: '100%'
+  }
+
   componentDidMount() {
     this.doc = this.node.contentDocument
     this.forceUpdate()
   }
 
+  getCssLinks() {
+    const context = JSON.parse(document.body.dataset.context || '{}')
+    const {files = []} = context
+    return files.filter(file => file.endsWith('.css'))
+      .map(file => <link rel="stylesheet" href={`${assetPrefix}/_next/${file}`} />)
+  }
+
   render() {
-    const {children, head: _head, ...rest} = this.props
-    const head = this.doc ? ReactDOM.createPortal(_head, this.doc.head) : null
-    const body = this.doc ? ReactDOM.createPortal(children, this.doc.body) : null
+    const {children, ...rest} = this.props
     return (
       <BorderBox as="iframe" {...rest} ref={node => (this.node = node)}>
-        {head}
-        {body}
+        {this.doc ? [
+          ReactDOM.createPortal(this.getCssLinks(), this.doc.head),
+          ReactDOM.createPortal(children, this.doc.body)
+        ] : null}
       </BorderBox>
     )
   }
-}
-
-Frame.defaultProps = {
-  bg: 'white',
-  border: 0,
-  p: 3,
-  width: '100%'
 }

--- a/docs/src/Frame.js
+++ b/docs/src/Frame.js
@@ -5,34 +5,53 @@ import Document, {Head} from 'next/document'
 import {BorderBox} from '@primer/components'
 import {assetPrefix} from './utils'
 
+const DEFAULT_IFRAME_HEIGHT = 150
+
 export default class Frame extends React.Component {
   static defaultProps = {
-    bg: 'white',
     border: 0,
-    p: 3,
+    borderRadius: 0,
+    minHeight: 0,
     width: '100%'
+  }
+
+  constructor(props) {
+    super(props)
+    this.state = {files: [], height: props.height}
   }
 
   componentDidMount() {
     this.doc = this.node.contentDocument
-    this.forceUpdate()
+    const files = JSON.parse(document.body.dataset.files || '[]')
+    this.setState({files})
+    this.node.addEventListener('load', () => this.setState({loaded: true}))
   }
 
   getCssLinks() {
-    const context = JSON.parse(document.body.dataset.context || '{}')
-    const {files = []} = context
-    return files.filter(file => file.endsWith('.css'))
-      .map(file => <link rel="stylesheet" href={`${assetPrefix}/_next/${file}`} />)
+    const {files} = this.state
+    return files
+      ? files
+          .filter(file => file.endsWith('.css'))
+          .map(file => <link rel="stylesheet" href={`${assetPrefix}/_next/${file}`} key={file} />)
+      : null
+  }
+
+  getHeight() {
+    if (!this.node) return null
+    this.node.style.height = 'max-content'
+    const {body} = this.node.contentDocument
+    return body.offsetHeight > DEFAULT_IFRAME_HEIGHT ? body.offsetHeight : body.scrollHeight
   }
 
   render() {
     const {children, ...rest} = this.props
+    const height = this.getHeight()
+    const style = height ? {height} : null
     return (
-      <BorderBox as="iframe" {...rest} ref={node => (this.node = node)}>
-        {this.doc ? [
-          ReactDOM.createPortal(this.getCssLinks(), this.doc.head),
-          ReactDOM.createPortal(children, this.doc.body)
-        ] : null}
+      <BorderBox as="iframe" style={style} {...rest} ref={node => (this.node = node)}>
+        {this.doc
+          ? [ReactDOM.createPortal(this.getCssLinks(), this.doc.head), ReactDOM.createPortal(children, this.doc.body)]
+          : null}
       </BorderBox>
     )
   }

--- a/docs/src/Frame.js
+++ b/docs/src/Frame.js
@@ -1,7 +1,5 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import PropTypes from 'prop-types'
-import Document, {Head} from 'next/document'
 import {BorderBox} from '@primer/components'
 import {assetPrefix} from './utils'
 
@@ -23,6 +21,7 @@ export default class Frame extends React.Component {
   componentDidMount() {
     this.doc = this.node.contentDocument
     const files = JSON.parse(document.body.dataset.files || '[]')
+    // eslint-disable-next-line react/no-did-mount-set-state
     this.setState({files})
     this.node.addEventListener('load', () => this.setState({loaded: true}))
   }

--- a/docs/src/Header.js
+++ b/docs/src/Header.js
@@ -29,7 +29,9 @@ const Header = props => (
             <NavLink href="/css/getting-started" />
             <NavLink href="/css/principles" />
             <NavLink href="/css/tools" />
-            <NavLink as={Link} href="https://github.com/primer/primer/releases">Releases</NavLink>
+            <NavLink as={Link} href="https://github.com/primer/primer/releases">
+              Releases
+            </NavLink>
           </HeaderText>
         </Box>
         <Box display={['block', 'block', 'none']}>

--- a/docs/src/Header.js
+++ b/docs/src/Header.js
@@ -5,7 +5,6 @@ import {Text, Flex, Sticky, BorderBox, Box} from '@primer/components'
 import BoxShadow from './BoxShadow'
 import Link from './Link'
 import NodeLink from './NodeLink'
-import {repository} from 'primer/package.json'
 
 const NavLink = withRouter(({is: Tag = NodeLink, href, router, ...rest}) => (
   <Tag href={href} color="white" px={4} fontWeight={router.pathname === href ? 'bold' : null} {...rest} />

--- a/docs/src/PackageHeader.js
+++ b/docs/src/PackageHeader.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {Comment, Info, FileCode, Alert, PrimitiveDot} from '@githubprimer/octicons-react'
-import {BorderBox, Box, Flex, Link, StyledOcticon as Octicon, Text} from '@primer/components'
+import {Comment, Info, FileCode, Alert} from '@githubprimer/octicons-react'
+import {Box, Flex, Link, StyledOcticon as Octicon, Text} from '@primer/components'
 import StatusLabel from './StatusLabel'
 
 export default function PackageHeader(props) {

--- a/docs/src/SideNav.js
+++ b/docs/src/SideNav.js
@@ -75,12 +75,7 @@ function NavList({path}) {
  */
 const SectionLink = withRouter(({href, router, ...rest}) => (
   <Box {...rest}>
-    <NodeLink
-      href={href}
-      color="gray.9"
-      fontSize={2}
-      fontWeight={router.pathname.startsWith(href) ? 'bold' : null}
-    />
+    <NodeLink href={href} color="gray.9" fontSize={2} fontWeight={router.pathname.startsWith(href) ? 'bold' : null} />
   </Box>
 ))
 

--- a/docs/src/StatusLabel.js
+++ b/docs/src/StatusLabel.js
@@ -19,7 +19,9 @@ export default function StatusLabel({status, children, ...rest}) {
   return (
     <StyledLabel px={2} py={1} {...rest}>
       <Octicon icon={PrimitiveDot} color={getStatusColor(status)} mr={2} />
-      <Text color='black' fontSize={1}>{children || status}</Text>
+      <Text color="black" fontSize={1}>
+        {children || status}
+      </Text>
     </StyledLabel>
   )
 }

--- a/docs/src/StatusLabel.js
+++ b/docs/src/StatusLabel.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import styled from 'styled-components'
 import {BorderBox, StyledOcticon as Octicon, Text} from '@primer/components'
 import {PrimitiveDot} from '@githubprimer/octicons-react'

--- a/docs/src/landing/index.js
+++ b/docs/src/landing/index.js
@@ -140,15 +140,17 @@ export function MetaPackageBox({children, data = {}, title, ...rest}) {
   const deps = data.dependencies || []
   return (
     <Flex.Item as={BorderBox} bg="white" maxWidth={220} {...rest}>
-      <Heading fontSize={2} as={BorderBox} bg="gray.1" border={0} borderBottom={1} px={3} py={2}>
-        <Link href={packageSourceURL(data.name)} color="inherit">
-          {title}
-        </Link>{' '}
-        <Link href={packageURL(data.name)}>{data.version}</Link>
-      </Heading>
-      <Text as="div" fontSize={1} p={3}>
+      <BorderBox bg="gray.1" border={0} borderBottom={1} borderRadius={0} px={3} py={2}>
+        <Heading as="div" fontSize={2}>
+          <Link href={packageSourceURL(data.name)} color="inherit">
+            {title}
+          </Link>{' '}
+          <Link href={packageURL(data.name)}>{data.version}</Link>
+        </Heading>
+      </BorderBox>
+      <Text is="div" fontSize={1} p={3}>
         {children}
-        <Text fontWeight="bold" as="div" mt={4} mb={2}>
+        <Text is="div" fontWeight="bold" mt={4} mb={2}>
           {deps.length} packages:
         </Text>
         <ul className="list-style-none pl-0">

--- a/docs/src/markdown.js
+++ b/docs/src/markdown.js
@@ -12,6 +12,8 @@ export default function getComponents(page = {}) {
     h1: H1,
     // render links with our component
     a: Link,
+    // render code blocks with our wrapper around mdx-live
+    code: CodeExample,
     // render the outline for <p> tags with exactly the text "{:toc}"
     p: ({children, ...rest}) => {
       if (children === '{:toc}') {
@@ -20,8 +22,7 @@ export default function getComponents(page = {}) {
         return <p {...rest}>{children}</p>
       }
     },
-    // render code blocks with our wrapper around mdx-live
-    code: CodeExample,
+    // "unwrap" <pre> elements around <code> blocks
     pre: props => props.children
   }
 }

--- a/docs/src/redirect.js
+++ b/docs/src/redirect.js
@@ -28,4 +28,3 @@ export default function redirect(uri, status = 303) {
     }
   }
 }
-

--- a/docs/src/redirect.js
+++ b/docs/src/redirect.js
@@ -1,0 +1,31 @@
+import Router from 'next/router'
+
+/**
+ * Export this as your default from a page, and it'll redirect both server-
+ * and client-side:
+ *
+ * ```js
+ * import {redirect} from '../src/utils'
+ * export default redirect('/some/path')
+ * ```
+ */
+export default function redirect(uri, status = 303) {
+  // XXX this doesn't need to extend React.Component because
+  // it doesn't "do" anything React-y
+  return class {
+    static getInitialProps({res}) {
+      // the "context" object passed to getInitialProps() will
+      // have a "res" (response) object if we're server-side
+      if (res) {
+        res.writeHead(status, {Location: uri})
+        res.end()
+      }
+    }
+
+    render() {
+      Router.replace(uri)
+      return null
+    }
+  }
+}
+

--- a/docs/src/utils.js
+++ b/docs/src/utils.js
@@ -2,12 +2,6 @@ import Router from 'next/router'
 import getConfig from 'next/config'
 import TreeModel from 'tree-model'
 
-export const DocumentContext = React.createContext({
-  _documentProps: {
-    files: []
-  }
-})
-
 export const CommonStyles = () => {
   const sheets = [getAssetPath('github/styleguide.css')]
   return sheets.map(href => <link href={href} rel="stylesheet" />)

--- a/docs/src/utils.js
+++ b/docs/src/utils.js
@@ -1,10 +1,10 @@
-import Router from 'next/router'
+import React from 'react'
 import getConfig from 'next/config'
 import TreeModel from 'tree-model'
 
 export const CommonStyles = () => {
   const sheets = [getAssetPath('github/styleguide.css')]
-  return sheets.map(href => <link href={href} rel="stylesheet" />)
+  return sheets.map(href => <link href={href} rel="stylesheet" key={href} />)
 }
 
 export const CommonScripts = () => <script src={getAssetPath('github/styleguide.js')} />
@@ -42,35 +42,6 @@ rootPage.walk(node => {
     console.warn('no file for page node:', node.path)
   }
 })
-
-/**
- * Export this as your default from a page, and it'll redirect both server-
- * and client-side:
- *
- * ```js
- * import {redirect} from '../src/utils'
- * export default redirect('/some/path')
- * ```
- */
-export function redirect(uri, status = 303) {
-  // XXX this doesn't need to extend React.Component because
-  // it doesn't "do" anything React-y
-  return class {
-    static getInitialProps({res}) {
-      // the "context" object passed to getInitialProps() will
-      // have a "res" (response) object if we're server-side
-      if (res) {
-        res.writeHead(status, {Location: uri})
-        res.end()
-      }
-    }
-
-    render() {
-      Router.replace(uri)
-      return null
-    }
-  }
-}
 
 function nest(map) {
   const nodeMap = {}

--- a/docs/src/utils.js
+++ b/docs/src/utils.js
@@ -4,7 +4,6 @@ import TreeModel from 'tree-model'
 
 export const CommonStyles = () => {
   const sheets = [
-    config.production ? getAssetPath('primer.css') : assetPrefix + '/_next/static/css/styles.chunk.css',
     getAssetPath('github/styleguide.css')
   ]
   return sheets.map(href => <link href={href} rel="stylesheet" />)

--- a/docs/src/utils.js
+++ b/docs/src/utils.js
@@ -2,16 +2,18 @@ import Router from 'next/router'
 import getConfig from 'next/config'
 import TreeModel from 'tree-model'
 
+export const DocumentContext = React.createContext({
+  _documentProps: {
+    files: []
+  }
+})
+
 export const CommonStyles = () => {
-  const sheets = [
-    getAssetPath('github/styleguide.css')
-  ]
+  const sheets = [getAssetPath('github/styleguide.css')]
   return sheets.map(href => <link href={href} rel="stylesheet" />)
 }
 
-export const CommonScripts = () => (
-  <script src={getAssetPath('github/styleguide.js')} />
-)
+export const CommonScripts = () => <script src={getAssetPath('github/styleguide.js')} />
 
 const INDEX_PATTERN = /\/index(\.[a-z]+)?$/
 

--- a/docs/src/utils.js
+++ b/docs/src/utils.js
@@ -2,12 +2,13 @@ import Router from 'next/router'
 import getConfig from 'next/config'
 import TreeModel from 'tree-model'
 
-export const CommonStyles = () => (
-  <>
-    <link rel="stylesheet" href={assetPrefix + '/_next/static/css/styles.chunk.css'} />
-    <link rel="stylesheet" href={getAssetPath('github/styleguide.css')} />
-  </>
-)
+export const CommonStyles = () => {
+  const sheets = [
+    config.production ? getAssetPath('primer.css') : assetPrefix + '/_next/static/css/styles.chunk.css',
+    getAssetPath('github/styleguide.css')
+  ]
+  return sheets.map(href => <link href={href} rel="stylesheet" />)
+}
 
 export const CommonScripts = () => (
   <script src={getAssetPath('github/styleguide.js')} />

--- a/docs/src/utils.js
+++ b/docs/src/utils.js
@@ -2,6 +2,17 @@ import Router from 'next/router'
 import getConfig from 'next/config'
 import TreeModel from 'tree-model'
 
+export const CommonStyles = () => (
+  <>
+    <link rel="stylesheet" href={assetPrefix + '/_next/static/css/styles.chunk.css'} />
+    <link rel="stylesheet" href={getAssetPath('github/styleguide.css')} />
+  </>
+)
+
+export const CommonScripts = () => (
+  <script src={getAssetPath('github/styleguide.js')} />
+)
+
 const INDEX_PATTERN = /\/index(\.[a-z]+)?$/
 
 export const config = getConfig().publicRuntimeConfig || {}


### PR DESCRIPTION
### [:eyes: Preview](https://primer-css-sandboxed-examples.now.sh/css)
This wraps all of our rendered code examples in `<iframe>` elements with the magic of [React portals](https://reactjs.org/docs/portals.html)! The trickiest part (by far) was getting the stylesheets into the frames, and required some refactoring of our Next config and a hack to pass an SSR-only file listing down to client-rendered components.

In this PR I'm introducing two new components that both the document template and our sandboxex code examples can use: `<CommonStyles />` and `<CommonScripts />`. The idea is that both of these will render the requisite `<link>` and `<script>` tags for both the Primer CSS build and any style guide-specific CSS and JS bundles that we need from dot-com (for components that haven't yet made it into Primer CSS). These live in the ever-expanding `src/utils.js` — which could probably be reorganized because it really deals more with "pages" and "assets".