### PR TITLE
Generate selector diff report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ script:
   - npm test
   - script/check-versions
 
+after_script:
+  - echo "generating selector diff report..."
+  - script/selector-diff-report
+
 before_deploy:
   # this will short-circuit the publish step if it fails to interpolate $NPM_API_KEY
   - npm config set "//registry.npmjs.org/:_authToken=\${NPM_API_KEY}"

--- a/script/selector-diff-report
+++ b/script/selector-diff-report
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+module=${1:-primer}
+version=${2:-latest}
+
+function log() {
+    echo "$@" 1>&2
+}
+
+log "Pulling the latest ${module}/build/data.json ..."
+curl -sL "https://unpkg.com/${module}@${version}/build/data.json" > before.json
+
+log "Building ${module}/build/data.json locally..."
+pushd modules/${module} > /dev/null
+npm run build
+popd > /dev/null
+cp modules/${module}/build/data.json after.json
+
+function list_selectors() {
+    jq -r .cssstats.selectors.values[] $1 | sort
+}
+
+list_selectors before.json > before.txt
+list_selectors after.json > after.txt
+
+diff before.txt after.txt && log "(no diff!)"
+rm {before,after}.{json,txt}


### PR DESCRIPTION
This adds a script, `script/selector-diff-report`, which:

1. Downloads the `build/data.json` from the latest published version of `primer`
1. Builds `build/data.json` in the local version of `primer`
1. Diffs the `.cssstats.selectors.values` array (sorted) of the before and after JSON files and outputs the diff

This script should run on Travis after `script/check-versions`, so we should see something useful in the build log here because this branches off #498. 🤞 