### PR TITLE
Add $marketing-font-path

### DIFF
--- a/modules/primer-marketing-support/lib/variables.scss
+++ b/modules/primer-marketing-support/lib/variables.scss
@@ -1,16 +1,18 @@
+$marketing-font-path: "/primer-marketing-support/fonts/" !default;
+
 // Type
 @font-face {
   font-family: InterUI;
   font-style: normal;
   font-weight: $font-weight-normal;
-  src: local("InterUI"), local("InterUI-Regular"), url("/primer-marketing-support/fonts/Inter-UI-Regular.woff") format("woff");
+  src: local("InterUI"), local("InterUI-Regular"), url("#{$marketing-font-path}Inter-UI-Regular.woff") format("woff");
 }
 
 @font-face {
   font-family: InterUI;
   font-style: normal;
   font-weight: $font-weight-semibold;
-  src: local("InterUI Medium"), local("InterUI-Medium"), url("/primer-marketing-support/fonts/Inter-UI-Medium.woff") format("woff");
+  src: local("InterUI Medium"), local("InterUI-Medium"), url("#{$marketing-font-path}Inter-UI-Medium.woff") format("woff");
 }
 
 $font-mktg: InterUI, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;


### PR DESCRIPTION
This adds a `$marketing-font-path` variable that allows sites to specify where the Inter UI `.woff` files are located. The default remains unchanged (`/primer-marketing-support/font/`), but you can change it by setting the variable before the relevant Primer imports:

```scss
$marketing-font-path: "/assets/fonts/";
@import "primer-marketing/index.scss";
```